### PR TITLE
Update service to gracefully shutdown

### DIFF
--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -44,7 +44,7 @@ func TestGetDatasetsReturnsOK(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetDatasetsCalls()), ShouldEqual, 1)
@@ -63,7 +63,7 @@ func TestGetDatasetsReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(len(mockedDataStore.GetDatasetsCalls()), ShouldEqual, 1)
@@ -82,7 +82,7 @@ func TestGetDatasetReturnsOK(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -99,7 +99,7 @@ func TestGetDatasetReturnsOK(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -118,7 +118,7 @@ func TestGetDatasetReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -134,7 +134,7 @@ func TestGetDatasetReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -150,7 +150,7 @@ func TestGetDatasetReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -169,7 +169,7 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 1)
@@ -188,7 +188,7 @@ func TestGetEditionsReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 1)
@@ -205,7 +205,7 @@ func TestGetEditionsReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 1)
@@ -221,7 +221,7 @@ func TestGetEditionsReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 1)
@@ -240,7 +240,7 @@ func TestGetEditionReturnsOK(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
@@ -259,7 +259,7 @@ func TestGetEditionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
@@ -276,7 +276,7 @@ func TestGetEditionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
@@ -292,7 +292,7 @@ func TestGetEditionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
@@ -311,7 +311,7 @@ func TestGetVersionsReturnsOK(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetVersionsCalls()), ShouldEqual, 1)
@@ -330,7 +330,7 @@ func TestGetVersionsReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(len(mockedDataStore.GetVersionsCalls()), ShouldEqual, 1)
@@ -347,7 +347,7 @@ func TestGetVersionsReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(len(mockedDataStore.GetVersionsCalls()), ShouldEqual, 1)
@@ -363,7 +363,7 @@ func TestGetVersionsReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(len(mockedDataStore.GetVersionsCalls()), ShouldEqual, 1)
@@ -382,7 +382,7 @@ func TestGetVersionReturnsOK(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
@@ -401,7 +401,7 @@ func TestGetVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
@@ -418,7 +418,7 @@ func TestGetVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
@@ -434,7 +434,7 @@ func TestGetVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
@@ -457,7 +457,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 		}
 		mockedDataStore.UpsertDataset("123", &models.DatasetUpdate{})
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 2)
@@ -479,7 +479,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
@@ -498,7 +498,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 1)
@@ -516,7 +516,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusUnauthorized)
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
@@ -548,7 +548,7 @@ func TestPostEditionReturnsCreated(t *testing.T) {
 		}
 		mockedDataStore.UpsertEdition("2017", editionDoc)
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 2)
@@ -575,7 +575,7 @@ func TestPostEditionReturnsError(t *testing.T) {
 		}
 		mockedDataStore.GetEdition("123", "2017", "created")
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 2)
@@ -598,7 +598,7 @@ func TestPostEditionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
@@ -620,7 +620,7 @@ func TestPostEditionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusUnauthorized)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 0)
@@ -643,7 +643,7 @@ func TestPostEditionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
@@ -662,7 +662,7 @@ func TestPostVersionReturnsCreated(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := setUp("created")
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 2)
@@ -683,7 +683,7 @@ func TestPostVersionReturnsCreated(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := setUp(associatedState)
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 2)
@@ -705,7 +705,7 @@ func TestPostVersionReturnsCreated(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := setUp(publishedState)
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 2)
@@ -733,7 +733,7 @@ func TestPostVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(len(mockedDataStore.UpsertVersionCalls()), ShouldEqual, 0)
@@ -753,7 +753,7 @@ func TestPostVersionReturnsError(t *testing.T) {
 		}
 		mockedDataStore.GetEdition("123", "2017", "created")
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 2)
@@ -787,7 +787,7 @@ func TestPostVersionReturnsError(t *testing.T) {
 		}
 		mockedDataStore.UpsertVersion("1", versionDoc)
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 2)
@@ -807,7 +807,7 @@ func TestPostVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusUnauthorized)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 0)
@@ -826,7 +826,7 @@ func TestPostVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 0)
@@ -853,7 +853,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		}
 		mockedDataStore.UpdateDataset("123", dataset)
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 2)
@@ -875,7 +875,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(len(mockedDataStore.UpsertVersionCalls()), ShouldEqual, 0)
@@ -899,7 +899,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		}
 		mockedDataStore.UpdateDataset("123", dataset)
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 2)
@@ -923,7 +923,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		}
 		mockedDataStore.UpdateDataset("123", dataset)
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 2)
@@ -941,7 +941,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusUnauthorized)
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 0)
@@ -990,7 +990,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		mockedDataStore.GetVersion("123", "2017", "1", "")
 		mockedDataStore.UpdateVersion("a1b2c3", &models.Version{})
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
@@ -1024,7 +1024,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		mockedDataStore.UpdateVersion("a1b2c3", &models.Version{})
 		mockedDataStore.UpdateDatasetWithAssociation("123", "associated", &models.Version{})
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
@@ -1090,7 +1090,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		mockedDataStore.GetDataset("123")
 		mockedDataStore.UpsertDataset("123", &models.DatasetUpdate{})
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
@@ -1117,7 +1117,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 0)
@@ -1139,7 +1139,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
@@ -1162,7 +1162,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
@@ -1181,7 +1181,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusUnauthorized)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 0)
@@ -1205,7 +1205,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
@@ -1228,7 +1228,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)

--- a/api/healthcheck.go
+++ b/api/healthcheck.go
@@ -1,8 +1,13 @@
 package api
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/ONSdigital/go-ns/log"
+)
 
 // HealthCheck returns the health of the application.
-func healthCheck(w http.ResponseWriter, r *http.Request) {
+func (api *DatasetAPI) healthCheck(w http.ResponseWriter, r *http.Request) {
+	log.Debug("Healthcheck endpoint.", nil)
 	w.WriteHeader(http.StatusOK)
 }

--- a/api/healthcheck_test.go
+++ b/api/healthcheck_test.go
@@ -20,7 +20,7 @@ func TestHealthCheckReturnsOK(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{}
 
-		api := CreateDatasetAPI(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
+		api := routes(host, secretKey, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})

--- a/config/config.go
+++ b/config/config.go
@@ -1,20 +1,25 @@
 package config
 
-import "github.com/ian-kent/gofigure"
+import (
+	"time"
+
+	"github.com/kelseyhightower/envconfig"
+)
 
 // Configuration structure which hold information for configuring the import API
 type Configuration struct {
-	BindAddr      string `env:"BIND_ADDR" flag:"bind-addr" flagDesc:"The port to bind to"`
-	DatasetAPIURL string `env:"DATASET_API_URL" flag:"dataset-api-url" flagDesc:"The host and port this API is run on"`
-	SecretKey     string `env:"SECRET_KEY" flag:"secret-key" flagDesc:"A secret key used authentication"`
-	MongoConfig   MongoConfig
+	BindAddr        string        `envconfig:"BIND_ADDR"`
+	DatasetAPIURL   string        `envconfig:"DATASET_API_URL"`
+	SecretKey       string        `envconfig:"SECRET_KEY"`
+	ShutdownTimeout time.Duration `envconfig:"SHUTDOWN_TIMEOUT"`
+	MongoConfig     MongoConfig
 }
 
 // MongoConfig contains the config required to connect to MongoDB.
 type MongoConfig struct {
-	BindAddr   string `env:"MONGODB_BIND_ADDR" flag:"mongodb-bind-addr" flagDesc:"MongoDB bind address"`
-	Collection string `env:"MONGODB_DATABASE" flag:"mongodb-database" flagDesc:"MongoDB database"`
-	Database   string `env:"MONGODB_COLLECTION" flag:"mongodb-collection" flagDesc:"MongoDB collection"`
+	BindAddr   string `envconfig:"MONGODB_BIND_ADDR"`
+	Collection string `envconfig:"MONGODB_DATABASE"`
+	Database   string `envconfig:"MONGODB_COLLECTION"`
 }
 
 var cfg *Configuration
@@ -25,10 +30,13 @@ func Get() (*Configuration, error) {
 		return cfg, nil
 	}
 
+	defaultTimeout := time.Duration(5 * time.Second)
+
 	cfg = &Configuration{
-		BindAddr:      ":22000",
-		DatasetAPIURL: "http://localhost:22000",
-		SecretKey:     "FD0108EA-825D-411C-9B1D-41EF7727F465",
+		BindAddr:        ":22000",
+		DatasetAPIURL:   "http://localhost:22000",
+		SecretKey:       "FD0108EA-825D-411C-9B1D-41EF7727F465",
+		ShutdownTimeout: defaultTimeout,
 		MongoConfig: MongoConfig{
 			BindAddr:   "localhost:27017",
 			Collection: "datasets",
@@ -36,6 +44,5 @@ func Get() (*Configuration, error) {
 		},
 	}
 
-	return cfg, gofigure.Gofigure(cfg)
-
+	return cfg, envconfig.Process("", cfg)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -30,13 +30,11 @@ func Get() (*Configuration, error) {
 		return cfg, nil
 	}
 
-	defaultTimeout := time.Duration(5 * time.Second)
-
 	cfg = &Configuration{
 		BindAddr:        ":22000",
 		DatasetAPIURL:   "http://localhost:22000",
 		SecretKey:       "FD0108EA-825D-411C-9B1D-41EF7727F465",
-		ShutdownTimeout: defaultTimeout,
+		ShutdownTimeout: 5 * time.Second,
 		MongoConfig: MongoConfig{
 			BindAddr:   "localhost:27017",
 			Collection: "datasets",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,7 +21,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.BindAddr, ShouldEqual, ":22000")
 				So(cfg.DatasetAPIURL, ShouldEqual, "http://localhost:22000")
 				So(cfg.SecretKey, ShouldEqual, "FD0108EA-825D-411C-9B1D-41EF7727F465")
-				So(cfg.ShutdownTimeout, ShouldEqual, time.Duration(5*time.Second))
+				So(cfg.ShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.MongoConfig.BindAddr, ShouldEqual, "localhost:27017")
 				So(cfg.MongoConfig.Collection, ShouldEqual, "datasets")
 				So(cfg.MongoConfig.Database, ShouldEqual, "datasets")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -20,6 +21,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.BindAddr, ShouldEqual, ":22000")
 				So(cfg.DatasetAPIURL, ShouldEqual, "http://localhost:22000")
 				So(cfg.SecretKey, ShouldEqual, "FD0108EA-825D-411C-9B1D-41EF7727F465")
+				So(cfg.ShutdownTimeout, ShouldEqual, time.Duration(5*time.Second))
 				So(cfg.MongoConfig.BindAddr, ShouldEqual, "localhost:27017")
 				So(cfg.MongoConfig.Collection, ShouldEqual, "datasets")
 				So(cfg.MongoConfig.Database, ShouldEqual, "datasets")

--- a/main.go
+++ b/main.go
@@ -1,20 +1,24 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/ONSdigital/dp-dataset-api/api"
 	"github.com/ONSdigital/dp-dataset-api/config"
 	"github.com/ONSdigital/dp-dataset-api/mongo"
 	"github.com/ONSdigital/dp-dataset-api/store"
 	"github.com/ONSdigital/go-ns/log"
-	"github.com/ONSdigital/go-ns/server"
-	"github.com/gorilla/mux"
-	_ "github.com/lib/pq"
 )
 
 func main() {
 	log.Namespace = "dp-dataset-api"
+
+	signals := make(chan os.Signal)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 
 	cfg, err := config.Get()
 	if err != nil {
@@ -33,17 +37,34 @@ func main() {
 		os.Exit(1)
 	}
 
-	router := mux.NewRouter()
-
-	s := server.New(cfg.BindAddr, router)
-
 	log.Debug("listening...", log.Data{
 		"bind_address": cfg.BindAddr,
 	})
 
-	_ = api.CreateDatasetAPI(cfg.DatasetAPIURL, cfg.SecretKey, router, store.DataStore{Backend: mongo})
+	apiErrors := make(chan error)
 
-	if err = s.ListenAndServe(); err != nil {
-		log.Error(err, nil)
+	api.CreateDatasetAPI(cfg.DatasetAPIURL, cfg.BindAddr, cfg.SecretKey, store.DataStore{Backend: mongo}, apiErrors)
+
+	// Gracefully shutdown the application closing any open resources.
+	gracefulShutdown := func() {
+		log.Info(fmt.Sprintf("Shutdown with timeout: %s", cfg.ShutdownTimeout), nil)
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
+		defer cancel()
+
+		api.Close(ctx)
+
+		log.Info("Shutdown complete", nil)
+		os.Exit(1)
+	}
+
+	for {
+		select {
+		case err := <-apiErrors:
+			log.ErrorC("api error received", err, nil)
+			gracefulShutdown()
+		case <-signals:
+			log.Debug("os signal received", nil)
+			gracefulShutdown()
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -52,6 +52,11 @@ func main() {
 
 		api.Close(ctx)
 
+		// mongo.Close() may use all remaining time in the context - do this last!
+		if err = mongo.Close(ctx); err != nil {
+			log.Error(err, nil)
+		}
+
 		log.Info("Shutdown complete", nil)
 
 		cancel()

--- a/vendor/github.com/ONSdigital/go-ns/server/server.go
+++ b/vendor/github.com/ONSdigital/go-ns/server/server.go
@@ -6,36 +6,40 @@ import (
 	"os/signal"
 	"time"
 
+	"context"
 	"github.com/ONSdigital/go-ns/handlers/requestID"
-	"github.com/ONSdigital/go-ns/handlers/timeout"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/justinas/alice"
 )
+
+const RequestIDHandlerKey string = "RequestID"
+const LogHandlerKey string = "Log"
 
 // Server is a http.Server with sensible defaults, which supports
 // configurable middleware and timeouts, and shuts down cleanly
 // on SIGINT/SIGTERM
 type Server struct {
 	http.Server
-	Middleware      map[string]alice.Constructor
-	MiddlewareOrder []string
-	Alice           *alice.Chain
-	CertFile        string
-	KeyFile         string
+	Middleware             map[string]alice.Constructor
+	MiddlewareOrder        []string
+	Alice                  *alice.Chain
+	CertFile               string
+	KeyFile                string
+	DefaultShutdownTimeout time.Duration
+	HandleOSSignals        bool
 }
 
 // New creates a new server
 func New(bindAddr string, router http.Handler) *Server {
 	middleware := map[string]alice.Constructor{
-		"RequestID": requestID.Handler(16),
-		"Log":       log.Handler,
-		"Timeout":   timeout.Handler(10 * time.Second),
+		RequestIDHandlerKey: requestID.Handler(16),
+		LogHandlerKey:       log.Handler,
 	}
 
 	return &Server{
 		Alice:           nil,
 		Middleware:      middleware,
-		MiddlewareOrder: []string{"RequestID", "Log", "Timeout"},
+		MiddlewareOrder: []string{RequestIDHandlerKey, LogHandlerKey},
 		Server: http.Server{
 			Handler:           router,
 			Addr:              bindAddr,
@@ -45,6 +49,8 @@ func New(bindAddr string, router http.Handler) *Server {
 			IdleTimeout:       0,
 			MaxHeaderBytes:    0,
 		},
+		HandleOSSignals:        true,
+		DefaultShutdownTimeout: 10 * time.Second,
 	}
 }
 
@@ -69,14 +75,60 @@ func (s *Server) prep() {
 //
 // Specifying one of CertFile/KeyFile without the other will panic.
 func (s *Server) ListenAndServe() error {
+	if s.HandleOSSignals {
+		return s.listenAndServeHandleOSSignals()
+	}
+
+	return s.listenAndServe()
+}
+
+// ListenAndServeTLS sets KeyFile and CertFile, then calls ListenAndServe
+func (s *Server) ListenAndServeTLS(certFile, keyFile string) error {
+	if len(certFile) == 0 || len(keyFile) == 0 {
+		panic("either CertFile/KeyFile must be blank, or both provided")
+	}
+	s.KeyFile = keyFile
+	s.CertFile = certFile
+	return s.ListenAndServe()
+}
+
+// Shutdown will gracefully shutdown the server, using a default shutdown
+// timeout if a context is not provided.
+func (s *Server) Shutdown(ctx context.Context) error {
+
+	if ctx == nil {
+		ctx, _ = context.WithTimeout(context.Background(), s.DefaultShutdownTimeout)
+	}
+
+	return s.Server.Shutdown(ctx)
+}
+
+func (s *Server) listenAndServe() error {
+
 	s.prep()
+	if len(s.CertFile) > 0 || len(s.KeyFile) > 0 {
+		return s.Server.ListenAndServeTLS(s.CertFile, s.KeyFile)
+	}
+
+	return s.Server.ListenAndServe()
+}
+
+func (s *Server) listenAndServeHandleOSSignals() error {
+
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, os.Kill)
 
+	s.listenAndServeAsync()
+
+	<-stop
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	return s.Shutdown(ctx)
+}
+
+func (s *Server) listenAndServeAsync() {
+
+	s.prep()
 	if len(s.CertFile) > 0 || len(s.KeyFile) > 0 {
-		if len(s.CertFile) == 0 || len(s.KeyFile) == 0 {
-			panic("either CertFile/KeyFile must be blank, or both provided")
-		}
 		go func() {
 			if err := s.Server.ListenAndServeTLS(s.CertFile, s.KeyFile); err != nil {
 				log.Error(err, nil)
@@ -91,14 +143,4 @@ func (s *Server) ListenAndServe() error {
 			}
 		}()
 	}
-
-	<-stop
-	return s.Shutdown(nil)
-}
-
-// ListenAndServeTLS sets KeyFile and CertFile, then calls ListenAndServe
-func (s *Server) ListenAndServeTLS(certFile, keyFile string) error {
-	s.KeyFile = keyFile
-	s.CertFile = certFile
-	return s.ListenAndServe()
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -5,8 +5,8 @@
 		{
 			"checksumSHA1": "J9OiPnhPHFPhQ+R+dq6LFj+dTxE=",
 			"path": "github.com/ONSdigital/go-ns/handlers/requestID",
-			"revision": "c493b1568574c9720d7805f23ce6271ac445dc57",
-			"revisionTime": "2017-07-28T08:24:17Z"
+			"revision": "5c4e318aa10e56921c4e39fd5735c95868281d33",
+			"revisionTime": "2017-09-07T12:17:38Z"
 		},
 		{
 			"checksumSHA1": "HgL/HLG5D1WNPb1lrb/hpywtm9o=",
@@ -17,14 +17,14 @@
 		{
 			"checksumSHA1": "AjbjbhFVAOP/1NU5HL+uy+X/yJo=",
 			"path": "github.com/ONSdigital/go-ns/log",
-			"revision": "c493b1568574c9720d7805f23ce6271ac445dc57",
-			"revisionTime": "2017-07-28T08:24:17Z"
+			"revision": "5c4e318aa10e56921c4e39fd5735c95868281d33",
+			"revisionTime": "2017-09-07T12:17:38Z"
 		},
 		{
-			"checksumSHA1": "iz7DRbcFPAK2UUXpmFs2byjTwm0=",
+			"checksumSHA1": "Wc0l6IlAATaN3qFb2ECwcjcHH4I=",
 			"path": "github.com/ONSdigital/go-ns/server",
-			"revision": "c493b1568574c9720d7805f23ce6271ac445dc57",
-			"revisionTime": "2017-07-28T08:24:17Z"
+			"revision": "5c4e318aa10e56921c4e39fd5735c95868281d33",
+			"revisionTime": "2017-09-07T12:17:38Z"
 		},
 		{
 			"checksumSHA1": "hIbmXmNbwyP44fi1hh6zJrMcYws=",
@@ -60,8 +60,8 @@
 			"checksumSHA1": "OBvAHqWjdI4NQVAqTkcQAdTuCFY=",
 			"origin": "github.com/ONSdigital/go-ns/vendor/github.com/justinas/alice",
 			"path": "github.com/justinas/alice",
-			"revision": "c493b1568574c9720d7805f23ce6271ac445dc57",
-			"revisionTime": "2017-07-28T08:24:17Z"
+			"revision": "5c4e318aa10e56921c4e39fd5735c95868281d33",
+			"revisionTime": "2017-09-07T12:17:38Z"
 		},
 		{
 			"checksumSHA1": "Wh2YCiWY/VIAEEQGLS7sMB9isXk=",
@@ -79,8 +79,8 @@
 			"checksumSHA1": "hBgLmZ/4mCxmnH88mqFKBkpJFUY=",
 			"origin": "github.com/ONSdigital/go-ns/vendor/github.com/mgutz/ansi",
 			"path": "github.com/mgutz/ansi",
-			"revision": "c493b1568574c9720d7805f23ce6271ac445dc57",
-			"revisionTime": "2017-07-28T08:24:17Z"
+			"revision": "5c4e318aa10e56921c4e39fd5735c95868281d33",
+			"revisionTime": "2017-09-07T12:17:38Z"
 		},
 		{
 			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",


### PR DESCRIPTION
### What

Service gracefully shuts down when a terminal or interrupt signal is called or a critical error is returned from http server. Once the graceful shutdown is called any incoming requests are blocked but current processes are able to complete within the (configurable) SHUTDOWN_TIMEOUT .

### How to review

Make sure service shuts down gracefully as described above and connections to mongo db are released.

To check this works requires adding in time.Sleep() in the endpoint you are calling and manually sending a signal to interrupt or terminate service. Make sure processes finish as long as they complete within the default time (5 seconds), once all processes complete, shutdown straight away (do not hang around waiting for the 5 seconds to complete) . Check new requests fail once service starts to shutdown and if any processes that take longer than the SHUTDOWN_TIMEOUT to complete, then they end up not completing and shutdown of service occurs.

### Who can review

Team B