### PR TITLE
Remove mongo session global var in favor of mongo receiver struct

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -64,6 +64,7 @@ func routes(host, secretKey string, router *mux.Router, dataStore store.DataStor
 	api.router.HandleFunc("/datasets/{id}/editions/{edition}/versions/{version}", api.addVersion).Methods("POST")
 	api.router.HandleFunc("/datasets/{id}/editions/{edition}/versions/{version}", api.privateAuth.Check(api.putVersion)).Methods("PUT")
 	api.router.HandleFunc("/datasets/{id}/editions/{edition}/versions/{version}/dimensions", api.getDimensions).Methods("GET")
+	api.router.HandleFunc("/datasets/{id}/editions/{edition}/versions/{version}/dimensions/{dimension}/options", api.getDimensionOptions).Methods("GET")
 
 	instance := instance.Store{api.dataStore.Backend}
 	api.router.HandleFunc("/instances", instance.GetList).Methods("GET")
@@ -78,7 +79,6 @@ func routes(host, secretKey string, router *mux.Router, dataStore store.DataStor
 	api.router.HandleFunc("/instances/{id}/dimensions", api.privateAuth.Check(dimension.Add)).Methods("POST")
 	api.router.HandleFunc("/instances/{id}/dimensions/{dimension}/options", dimension.GetUnique).Methods("GET")
 	api.router.HandleFunc("/instances/{id}/dimensions/{dimension}/options/{value}/node_id/{node_id}", api.privateAuth.Check(dimension.AddNodeID)).Methods("PUT")
-	api.router.HandleFunc("/datasets/{id}/editions/{edition}/versions/{version}/dimensions/{dimension}/options", api.getDimensionOptions).Methods("GET")
 	return &api
 }
 

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -11,21 +11,18 @@ import (
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-
 )
 
 var _ store.Storer = &Mongo{}
-var session *mgo.Session
 
 // Mongo represents a simplistic MongoDB configuration.
 type Mongo struct {
 	CodeListURL string
-	Collection string
-	Database   string
+	Collection  string
+	Database    string
 	DatasetURL  string
-	Session    *mgo.Session
-	URI        string
-
+	Session     *mgo.Session
+	URI         string
 }
 
 // Init creates a new mgo.Session with a strong consistency and a write mode of "majortiy".

--- a/mongo/dimension_store.go
+++ b/mongo/dimension_store.go
@@ -2,20 +2,23 @@ package mongo
 
 import (
 	"fmt"
+	"time"
+
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"gopkg.in/mgo.v2/bson"
-	"time"
 )
 
 const DIMENSION_OPTIONS = "dimension.options"
 
 // GetDimensionNodesFromInstance which are stored in a mongodb collection
 func (m *Mongo) GetDimensionNodesFromInstance(id string) (*models.DimensionNodeResults, error) {
-	s := session.Copy()
+	s := m.Session.Copy()
 	defer s.Close()
+
 	var dimensions []models.DimensionOption
 	iter := s.DB(m.Database).C(DIMENSION_OPTIONS).Find(bson.M{"instance_id": id}).Select(bson.M{"id": 0, "last_updated": 0, "instance_id": 0}).Iter()
+
 	err := iter.All(&dimensions)
 	if err != nil {
 		return nil, err
@@ -26,8 +29,9 @@ func (m *Mongo) GetDimensionNodesFromInstance(id string) (*models.DimensionNodeR
 
 // GetUniqueDimensionValues which are stored in mongodb collection
 func (m *Mongo) GetUniqueDimensionValues(id, dimension string) (*models.DimensionValues, error) {
-	s := session.Copy()
+	s := m.Session.Copy()
 	defer s.Close()
+
 	var values []string
 	err := s.DB(m.Database).C(DIMENSION_OPTIONS).Find(bson.M{"instance_id": id, "name": dimension}).Distinct("value", &values)
 	if err != nil {
@@ -37,13 +41,15 @@ func (m *Mongo) GetUniqueDimensionValues(id, dimension string) (*models.Dimensio
 	if len(values) == 0 {
 		return nil, errs.DimensionNodeNotFound
 	}
+
 	return &models.DimensionValues{Name: dimension, Values: values}, nil
 }
 
 // AddDimensionToInstance to the dimension collection
 func (m *Mongo) AddDimensionToInstance(opt *models.CachedDimensionOption) error {
-	s := session.Copy()
+	s := m.Session.Copy()
 	defer s.Close()
+
 	option := models.DimensionOption{InstanceID: opt.InstanceID, Option: opt.Option, Name: opt.Name}
 	option.Links.CodeList = models.LinkObject{ID: opt.CodeList, HRef: fmt.Sprintf("%s/code-lists/%s", m.CodeListURL, opt.CodeList)}
 	option.Links.Code = models.LinkObject{ID: opt.Code, HRef: fmt.Sprintf("%s/code-lists/%s/codes/%s", m.CodeListURL, opt.CodeList, opt.Code)}
@@ -54,17 +60,20 @@ func (m *Mongo) AddDimensionToInstance(opt *models.CachedDimensionOption) error 
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // GetDimensions returns a list of all dimensions from a dataset
 func (m *Mongo) GetDimensions(datasetID, editionID, versionID string) (*models.DatasetDimensionResults, error) {
-	s := session.Copy()
+	s := m.Session.Copy()
 	defer s.Close()
+
 	version, err := m.GetVersion(datasetID, editionID, versionID, "published")
 	if err != nil {
 		return nil, err
 	}
+
 	var results []models.Dimension
 	// To get all unique values an aggregation is needed, as using distinct() will only return the distinct values and
 	// not the documents.
@@ -77,6 +86,7 @@ func (m *Mongo) GetDimensions(datasetID, editionID, versionID string) (*models.D
 	if err != nil {
 		return nil, err
 	}
+
 	for _, dim := range res {
 		opt := convertBSonToDimension(dim["doc"])
 		dimension := models.Dimension{Name: opt.Name}
@@ -84,26 +94,31 @@ func (m *Mongo) GetDimensions(datasetID, editionID, versionID string) (*models.D
 		dimension.Links.Options = models.LinkObject{ID: opt.Name, HRef: fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s/dimensions/%s/options",
 			m.DatasetURL, version.Links.Dataset.ID, version.Edition, versionID, opt.Name)}
 		dimension.Links.Version = version.Links.Self
+
 		results = append(results, dimension)
 	}
+
 	return &models.DatasetDimensionResults{Items: results}, nil
 }
 
 // GetDimensionOptions returns all dimension options for a dimensions within a dataset.
 func (m *Mongo) GetDimensionOptions(datasetID, editionID, versionID, dimension string) (*models.DimensionOptionResults, error) {
-	s := session.Copy()
+	s := m.Session.Copy()
 	defer s.Close()
+
 	version, err := m.GetVersion(datasetID, editionID, versionID, "published")
 	if err != nil {
 		return nil, err
 	}
+
 	var values []models.PublicDimensionOption
 	iter := s.DB(m.Database).C(DIMENSION_OPTIONS).Find(bson.M{"instance_id": version.InstanceID, "name": dimension}).Iter()
 	err = iter.All(&values)
 	if err != nil {
 		return nil, err
 	}
-	for i :=0; i < len(values); i++ {
+
+	for i := 0; i < len(values); i++ {
 		values[i].Links.Version = version.Links.Self
 	}
 
@@ -116,6 +131,7 @@ func convertBSonToDimension(data interface{}) *models.DimensionOption {
 	if err != nil {
 
 	}
+
 	bson.Unmarshal(bytes, &dim)
 
 	return &dim

--- a/mongo/instance_store.go
+++ b/mongo/instance_store.go
@@ -16,10 +16,12 @@ const INSTANCE_COLLECTION = "instances"
 func (m *Mongo) GetInstances(filter string) (*models.InstanceResults, error) {
 	s := m.Session.Copy()
 	defer s.Close()
+
 	query := bson.M{}
 	if filter != "" {
 		query["state"] = filter
 	}
+
 	iter := s.DB(m.Database).C(INSTANCE_COLLECTION).Find(query).Iter()
 	defer iter.Close()
 
@@ -38,6 +40,7 @@ func (m *Mongo) GetInstances(filter string) (*models.InstanceResults, error) {
 func (m *Mongo) GetInstance(ID string) (*models.Instance, error) {
 	s := m.Session.Copy()
 	defer s.Close()
+
 	var instance models.Instance
 	err := s.DB(m.Database).C(INSTANCE_COLLECTION).Find(bson.M{"id": ID}).One(&instance)
 
@@ -75,6 +78,7 @@ func (m *Mongo) UpdateInstance(id string, instance *models.Instance) error {
 	if err != nil {
 		return err
 	}
+
 	if info.Updated == 0 {
 		return errs.InstanceNotFound
 	}
@@ -92,6 +96,7 @@ func (m *Mongo) AddEventToInstance(instanceId string, event *models.Event) error
 	if err != nil {
 		return err
 	}
+
 	if info.Updated == 0 {
 		return errs.InstanceNotFound
 	}
@@ -101,16 +106,19 @@ func (m *Mongo) AddEventToInstance(instanceId string, event *models.Event) error
 
 // UpdateDimensionNodeID to cache the id for other import processes
 func (m *Mongo) UpdateDimensionNodeID(dimension *models.DimensionOption) error {
-	s := session.Copy()
+	s := m.Session.Copy()
 	defer s.Close()
+
 	err := s.DB(m.Database).C(DIMENSION_OPTIONS).Update(bson.M{"instance_id": dimension.InstanceID, "name": dimension.Name,
-		"value":                                                              dimension.Option}, bson.M{"$set": bson.M{"node_id": &dimension.NodeID, "last_updated": time.Now().UTC()}})
+		"value": dimension.Option}, bson.M{"$set": bson.M{"node_id": &dimension.NodeID, "last_updated": time.Now().UTC()}})
 	if err == mgo.ErrNotFound {
 		return errs.InstanceNotFound
 	}
+
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -118,6 +126,7 @@ func (m *Mongo) UpdateDimensionNodeID(dimension *models.DimensionOption) error {
 func (m *Mongo) UpdateObservationInserted(id string, observationInserted int64) error {
 	s := m.Session.Copy()
 	defer s.Close()
+
 	err := s.DB(m.Database).C(INSTANCE_COLLECTION).Update(bson.M{"id": id},
 		bson.M{"$inc": bson.M{"total_inserted_observations": observationInserted}, "$set": bson.M{"last_updated": time.Now().UTC()}})
 
@@ -128,6 +137,6 @@ func (m *Mongo) UpdateObservationInserted(id string, observationInserted int64) 
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
-


### PR DESCRIPTION
### What

Removed the package var for mongo session as the Init function creates the session off a Mongo struct, having this inconsistency was causing panics

### How to review

Ensure mongo continues to work as expected

### Who can review

@Matt-Guest or @nshumoogum - sanity check that removing this doesnt break stuff you've done/there wasn't a reason for this var that I'm unaware of