### PR TITLE
Update creation of dataset document

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -52,7 +52,7 @@ func routes(host, secretKey string, router *mux.Router, dataStore store.DataStor
 	router.Path("/healthcheck").Methods("GET").HandlerFunc(api.healthCheck)
 
 	api.router.HandleFunc("/datasets", api.getDatasets).Methods("GET")
-	api.router.HandleFunc("/datasets", api.privateAuth.Check(api.addDataset)).Methods("POST")
+	api.router.HandleFunc("/datasets/{id}", api.privateAuth.Check(api.addDataset)).Methods("POST")
 	api.router.HandleFunc("/datasets/{id}", api.getDataset).Methods("GET")
 	api.router.HandleFunc("/datasets/{id}", api.privateAuth.Check(api.putDataset)).Methods("PUT")
 	api.router.HandleFunc("/datasets/{id}/editions", api.getEditions).Methods("GET")

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -216,6 +216,9 @@ func (api *DatasetAPI) getVersion(w http.ResponseWriter, r *http.Request) {
 }
 
 func (api *DatasetAPI) addDataset(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	datasetID := vars["id"]
+
 	dataset, err := models.CreateDataset(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -223,7 +226,7 @@ func (api *DatasetAPI) addDataset(w http.ResponseWriter, r *http.Request) {
 	}
 	defer r.Body.Close()
 
-	datasetID := dataset.ID
+	dataset.ID = datasetID
 	dataset.Links.Self.HRef = fmt.Sprintf("%s/datasets/%s", api.host, datasetID)
 	dataset.Links.Editions.HRef = fmt.Sprintf("%s/datasets/%s/editions", api.host, datasetID)
 	dataset.LastUpdated = time.Now()

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -423,7 +423,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 	Convey("", t, func() {
 		var b string
 		b = datasetPayload
-		r := httptest.NewRequest("POST", "http://localhost:22000/datasets", bytes.NewBufferString(b))
+		r := httptest.NewRequest("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 		r.Header.Add("internal-token", secretKey)
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -445,7 +445,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 	Convey("When the request contain malformed json a bad request status is returned", t, func() {
 		var b string
 		b = "{"
-		r := httptest.NewRequest("POST", "http://localhost:22000/datasets", bytes.NewBufferString(b))
+		r := httptest.NewRequest("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 		r.Header.Add("internal-token", secretKey)
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -463,7 +463,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 	Convey("When the api cannot connect to datastore return an internal server error", t, func() {
 		var b string
 		b = datasetPayload
-		r := httptest.NewRequest("POST", "http://localhost:22000/datasets", bytes.NewBufferString(b))
+		r := httptest.NewRequest("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 		r.Header.Add("internal-token", secretKey)
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -481,7 +481,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 	Convey("When the request does not contain a valid internal token return status unauthorised", t, func() {
 		var b string
 		b = datasetPayload
-		r := httptest.NewRequest("POST", "http://localhost:22000/datasets", bytes.NewBufferString(b))
+		r := httptest.NewRequest("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			UpsertDatasetFunc: func(string, *models.DatasetUpdate) error {

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.8.3
+    tag: 1.9.0
 
 inputs:
   - name: dp-dataset-api

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.8.3
+    tag: 1.9.0
 
 inputs:
   - name: dp-dataset-api

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -159,8 +159,6 @@ func CreateDataset(reader io.Reader) (*Dataset, error) {
 	}
 
 	var dataset Dataset
-	// Create unique id
-	dataset.ID = uuid.NewV4().String()
 
 	err = json.Unmarshal(bytes, &dataset)
 	if err != nil {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -150,6 +150,24 @@ paths:
         500:
           description: "Failed to process the request due to an internal error"
   /datasets:
+    get:
+      tags:
+      - "Public"
+      summary: "Get a list of datasets"
+      description: "Returns a list of all datasets provided by the ONS that can be filtered using the filter API"
+      parameters:
+      - $ref: '#/parameters/limit'
+      - $ref: '#/parameters/offset'
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "A json list containing datasets which have been published"
+          schema:
+            $ref: '#/definitions/Datasets'
+        500:
+          $ref: '#/responses/InternalError'
+  /datasets/{id}:
     post:
       tags:
       - "Private user"
@@ -172,24 +190,6 @@ paths:
           description: "Forbidden to overwrite dataset, already published"
         500:
           $ref: '#/responses/InternalError'
-    get:
-      tags:
-      - "Public"
-      summary: "Get a list of datasets"
-      description: "Returns a list of all datasets provided by the ONS that can be filtered using the filter API"
-      parameters:
-      - $ref: '#/parameters/limit'
-      - $ref: '#/parameters/offset'
-      produces:
-      - "application/json"
-      responses:
-        200:
-          description: "A json list containing datasets which have been published"
-          schema:
-            $ref: '#/definitions/Datasets'
-        500:
-          $ref: '#/responses/InternalError'
-  /datasets/{id}:
     get:
       tags:
       - "Public"


### PR DESCRIPTION
### What

POST request to /datasets is now handled by a POST request to
/datasets/<id>. Removed creation of unique id in model and updated unit
tests.

Also updated specs

### How to review

Check endpoint works (POST /datasets/<id>) and mongo stores document with the same unique identifier passed in request path as the `_id` stored in mongo. Make sure tests still pass.

### Who can review

Team A or B
