### PR TITLE
Allow comma separated state filter values for instances endpoint

### DIFF
--- a/instance/instance.go
+++ b/instance/instance.go
@@ -35,9 +35,7 @@ const (
 func (s *Store) GetList(w http.ResponseWriter, r *http.Request) {
 	stateFilterQuery := r.URL.Query().Get("state")
 	var stateFilterList []string
-	if stateFilterQuery == "" {
-		stateFilterList = nil
-	} else {
+	if stateFilterQuery != "" {
 		stateFilterList = strings.Split(stateFilterQuery, ",")
 	}
 

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/models"
@@ -32,9 +33,15 @@ const (
 
 //GetList a list of all instances
 func (s *Store) GetList(w http.ResponseWriter, r *http.Request) {
-	stateFilter := r.URL.Query().Get("state")
+	stateFilterQuery := r.URL.Query().Get("state")
+	var stateFilterList []string
+	if stateFilterQuery == "" {
+		stateFilterList = nil
+	} else {
+		stateFilterList = strings.Split(stateFilterQuery, ",")
+	}
 
-	results, err := s.GetInstances(stateFilter)
+	results, err := s.GetInstances(stateFilterList)
 	if err != nil {
 		log.Error(err, nil)
 		handleErrorType(err, w)
@@ -48,7 +55,7 @@ func (s *Store) GetList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeBody(w, bytes)
-	log.Debug("get all instances", log.Data{"query": stateFilter})
+	log.Debug("get all instances", log.Data{"query": stateFilterQuery})
 }
 
 //Get a single instance by id

--- a/instance/instance_external_test.go
+++ b/instance/instance_external_test.go
@@ -47,6 +47,45 @@ func TestGetInstancesReturnsOK(t *testing.T) {
 	})
 }
 
+func TestGetInstancesFiltersOnState(t *testing.T) {
+	t.Parallel()
+	Convey("Get instances filtered by a single state value returns only instances with that value", t, func() {
+		r := createRequestWithToken("GET", "http://localhost:21800/instances?state=completed", nil)
+		w := httptest.NewRecorder()
+		var result []string
+
+		mockedDataStore := &storetest.StorerMock{
+			GetInstancesFunc: func(filterString []string) (*models.InstanceResults, error) {
+				result = filterString
+				return &models.InstanceResults{}, nil
+			},
+		}
+
+		instance := &instance.Store{"http://lochost://8080", mockedDataStore}
+		instance.GetList(w, r)
+
+		So(result, ShouldResemble, []string{"completed"})
+	})
+
+	Convey("Get instances filtered by multiple state values returns only instances with those values", t, func() {
+		r := createRequestWithToken("GET", "http://localhost:21800/instances?state=completed,edition-confirmed", nil)
+		w := httptest.NewRecorder()
+		var result []string
+
+		mockedDataStore := &storetest.StorerMock{
+			GetInstancesFunc: func(filterString []string) (*models.InstanceResults, error) {
+				result = filterString
+				return &models.InstanceResults{}, nil
+			},
+		}
+
+		instance := &instance.Store{"http://lochost://8080", mockedDataStore}
+		instance.GetList(w, r)
+
+		So(result, ShouldResemble, []string{"completed", "edition-confirmed"})
+	})
+}
+
 func TestGetInstancesReturnsInternalError(t *testing.T) {
 	t.Parallel()
 	Convey("Get instances returns an internal error", t, func() {

--- a/instance/instance_external_test.go
+++ b/instance/instance_external_test.go
@@ -34,7 +34,7 @@ func TestGetInstancesReturnsOK(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		mockedDataStore := &storetest.StorerMock{
-			GetInstancesFunc: func(string) (*models.InstanceResults, error) {
+			GetInstancesFunc: func([]string) (*models.InstanceResults, error) {
 				return &models.InstanceResults{}, nil
 			},
 		}
@@ -54,7 +54,7 @@ func TestGetInstancesReturnsInternalError(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		mockedDataStore := &storetest.StorerMock{
-			GetInstancesFunc: func(string) (*models.InstanceResults, error) {
+			GetInstancesFunc: func([]string) (*models.InstanceResults, error) {
 				return nil, internalError
 			},
 		}

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store"
-	"github.com/ONSdigital/go-ns/log"
 
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"gopkg.in/mgo.v2"
@@ -300,7 +299,6 @@ func (m *Mongo) UpdateDataset(id string, dataset *models.Dataset) (err error) {
 	defer s.Close()
 
 	updates := createDatasetUpdateQuery(dataset)
-	log.Debug("Stuff", log.Data{"id": id, "updates": updates})
 	err = s.DB(m.Database).C("datasets").UpdateId(id, bson.M{"$set": updates, "$setOnInsert": bson.M{"next.last_updated": time.Now()}})
 	return
 }

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store"
+	"github.com/ONSdigital/go-ns/log"
 
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"gopkg.in/mgo.v2"
@@ -299,7 +300,7 @@ func (m *Mongo) UpdateDataset(id string, dataset *models.Dataset) (err error) {
 	defer s.Close()
 
 	updates := createDatasetUpdateQuery(dataset)
-
+	log.Debug("Stuff", log.Data{"id": id, "updates": updates})
 	err = s.DB(m.Database).C("datasets").UpdateId(id, bson.M{"$set": updates, "$setOnInsert": bson.M{"next.last_updated": time.Now()}})
 	return
 }

--- a/mongo/instance_store.go
+++ b/mongo/instance_store.go
@@ -13,16 +13,16 @@ import (
 const INSTANCE_COLLECTION = "instances"
 
 // GetInstances from a mongo collection
-func (m *Mongo) GetInstances(filter string) (*models.InstanceResults, error) {
+func (m *Mongo) GetInstances(filters []string) (*models.InstanceResults, error) {
 	s := m.Session.Copy()
 	defer s.Close()
 
-	query := bson.M{}
-	if filter != "" {
-		query["state"] = filter
+	var stateFilter bson.M
+	if len(filters) > 0 {
+		stateFilter = bson.M{"state": bson.M{"$in": filters}}
 	}
 
-	iter := s.DB(m.Database).C(INSTANCE_COLLECTION).Find(query).Iter()
+	iter := s.DB(m.Database).C(INSTANCE_COLLECTION).Find(stateFilter).Iter()
 	defer iter.Close()
 
 	results := []models.Instance{}

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -21,7 +21,7 @@ type Storer interface {
 	GetDimensionOptions(datasetID, editionID, versionID, dimension string) (*models.DimensionOptionResults, error)
 	GetEdition(id, editionID, state string) (*models.Edition, error)
 	GetEditions(id, state string) (*models.EditionResults, error)
-	GetInstances(filter string) (*models.InstanceResults, error)
+	GetInstances(filters []string) (*models.InstanceResults, error)
 	GetInstance(id string) (*models.Instance, error)
 	GetNextVersion(datasetID, editionID string) (int, error)
 	GetUniqueDimensionValues(id, dimension string) (*models.DimensionValues, error)

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -4,8 +4,9 @@
 package storetest
 
 import (
-	"github.com/ONSdigital/dp-dataset-api/models"
 	"sync"
+
+	"github.com/ONSdigital/dp-dataset-api/models"
 )
 
 var (
@@ -174,7 +175,7 @@ type StorerMock struct {
 	GetInstanceFunc func(id string) (*models.Instance, error)
 
 	// GetInstancesFunc mocks the GetInstances method.
-	GetInstancesFunc func(filter string) (*models.InstanceResults, error)
+	GetInstancesFunc func(filter []string) (*models.InstanceResults, error)
 
 	// GetNextVersionFunc mocks the GetNextVersion method.
 	GetNextVersionFunc func(datasetID string, editionID string) (int, error)
@@ -303,7 +304,7 @@ type StorerMock struct {
 		// GetInstances holds details about calls to the GetInstances method.
 		GetInstances []struct {
 			// Filter is the filter argument value.
-			Filter string
+			Filter []string
 		}
 		// GetNextVersion holds details about calls to the GetNextVersion method.
 		GetNextVersion []struct {
@@ -804,29 +805,29 @@ func (mock *StorerMock) GetInstanceCalls() []struct {
 }
 
 // GetInstances calls GetInstancesFunc.
-func (mock *StorerMock) GetInstances(filter string) (*models.InstanceResults, error) {
+func (mock *StorerMock) GetInstances(filters []string) (*models.InstanceResults, error) {
 	if mock.GetInstancesFunc == nil {
 		panic("moq: StorerMock.GetInstancesFunc is nil but Storer.GetInstances was just called")
 	}
 	callInfo := struct {
-		Filter string
+		Filter []string
 	}{
-		Filter: filter,
+		Filter: filters,
 	}
 	lockStorerMockGetInstances.Lock()
 	mock.calls.GetInstances = append(mock.calls.GetInstances, callInfo)
 	lockStorerMockGetInstances.Unlock()
-	return mock.GetInstancesFunc(filter)
+	return mock.GetInstancesFunc(filters)
 }
 
 // GetInstancesCalls gets all the calls that were made to GetInstances.
 // Check the length with:
 //     len(mockedStorer.GetInstancesCalls())
 func (mock *StorerMock) GetInstancesCalls() []struct {
-	Filter string
+	Filter []string
 } {
 	var calls []struct {
-		Filter string
+		Filter []string
 	}
 	lockStorerMockGetInstances.RLock()
 	calls = mock.calls.GetInstances

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -101,7 +101,7 @@ parameters:
     type: string
   state:
     name: "state"
-    description: "Query data based of there state"
+    description: "A comma separated list of state values to filter on (e.g. ‘completed,edition-confirmed’)"
     in: query
     type: string
   option:


### PR DESCRIPTION
### What

Extend the `/instances` endpoint to use comma separated values to filter the state property. For example:
`/instances?state=completed,edition-confirmed`

### How to review

A code check would be much appreciated. From a functionality perspective you should be able to go to `/instances` and add a state query with any valid comma separated values.

### Who can review

Anyone but me
