### PR TITLE
Add 'submitted' to map of valid state values

### DIFF
--- a/models/instance.go
+++ b/models/instance.go
@@ -65,6 +65,7 @@ func (e *Event) Validate() error {
 
 var validStates = map[string]int{
 	"created":           1,
+	"submitted":         1,
 	"completed":         1,
 	"edition-confirmed": 1,
 	"associated":        1,

--- a/models/instance_test.go
+++ b/models/instance_test.go
@@ -16,6 +16,12 @@ func TestValidateStateFilter(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 
+		Convey("when the filter list contains a state of `submitted`", func() {
+
+			err := ValidateStateFilter([]string{"submitted"})
+			So(err, ShouldBeNil)
+		})
+
 		Convey("when the filter list contains a state of `completed`", func() {
 
 			err := ValidateStateFilter([]string{"completed"})


### PR DESCRIPTION
### What

Add 'submitted' to map of valid state values - which was stopping the import tracker from starting up (because it got a 400 on `instances/state=submitted`.

### How to review

Check tests pass, that the import tracker starts up fine and that the `instances/state=submitted` still returns the correct results.

### Who can review

@nshumoogum 
