### PR TITLE
Feature/fix dataset state changes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -63,7 +63,7 @@ func routes(host, secretKey string, router *mux.Router, dataStore store.DataStor
 	api.router.HandleFunc("/datasets/{id}/editions/{edition}/versions/{version}/dimensions", api.getDimensions).Methods("GET")
 	api.router.HandleFunc("/datasets/{id}/editions/{edition}/versions/{version}/dimensions/{dimension}/options", api.getDimensionOptions).Methods("GET")
 
-	instance := instance.Store{api.host, api.dataStore.Backend}
+	instance := instance.Store{Host: api.host, Storer: api.dataStore.Backend}
 	api.router.HandleFunc("/instances", api.privateAuth.Check(instance.GetList)).Methods("GET")
 	api.router.HandleFunc("/instances", api.privateAuth.Check(instance.Add)).Methods("POST")
 	api.router.HandleFunc("/instances/{id}", api.privateAuth.Check(instance.Get)).Methods("GET")
@@ -71,7 +71,7 @@ func routes(host, secretKey string, router *mux.Router, dataStore store.DataStor
 	api.router.HandleFunc("/instances/{id}/events", api.privateAuth.Check(instance.AddEvent)).Methods("POST")
 	api.router.HandleFunc("/instances/{id}/inserted_observations/{inserted_observations}", api.privateAuth.Check(instance.UpdateObservations)).Methods("PUT")
 
-	dimension := dimension.Store{api.dataStore.Backend}
+	dimension := dimension.Store{Storer: api.dataStore.Backend}
 	api.router.HandleFunc("/instances/{id}/dimensions", dimension.GetNodes).Methods("GET")
 	api.router.HandleFunc("/instances/{id}/dimensions", api.privateAuth.Check(dimension.Add)).Methods("POST")
 	api.router.HandleFunc("/instances/{id}/dimensions/{dimension}/options", dimension.GetUnique).Methods("GET")

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -454,9 +454,15 @@ func (api *DatasetAPI) updateDataset(id string, version *models.Version) error {
 
 	currentDataset.Next.CollectionID = version.CollectionID
 	currentDataset.Next.Links = &models.DatasetLinks{
+		Editions: &models.LinkObject{
+			HRef: fmt.Sprintf("%s/datasets/%s/editions", api.host, version.Links.Dataset.ID),
+		},
 		LatestVersion: &models.LinkObject{
 			ID:   version.ID,
 			HRef: version.Links.Self.HRef,
+		},
+		Self: &models.LinkObject{
+			HRef: fmt.Sprintf("%s/datasets/%s", api.host, version.Links.Dataset.ID),
 		},
 	}
 	currentDataset.Next.State = publishedState

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -83,7 +83,7 @@ func (api *DatasetAPI) getDataset(w http.ResponseWriter, r *http.Request) {
 	var bytes []byte
 	if r.Header.Get(internalToken) != api.internalToken {
 		if dataset.Current == nil {
-			handleErrorType(datasetDocType, errs.DatasetNotFound, w)
+			handleErrorType(datasetDocType, errs.ErrDatasetNotFound, w)
 			return
 		}
 
@@ -96,7 +96,7 @@ func (api *DatasetAPI) getDataset(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		if dataset == nil {
-			handleErrorType(datasetDocType, errs.DatasetNotFound, w)
+			handleErrorType(datasetDocType, errs.ErrDatasetNotFound, w)
 		}
 		bytes, err = json.Marshal(dataset)
 		if err != nil {
@@ -289,7 +289,7 @@ func (api *DatasetAPI) addDataset(w http.ResponseWriter, r *http.Request) {
 
 	_, err := api.dataStore.Backend.GetDataset(datasetID)
 	if err != nil {
-		if err != errs.DatasetNotFound {
+		if err != errs.ErrDatasetNotFound {
 			log.Error(err, log.Data{"dataset_id": datasetID})
 			handleErrorType(datasetDocType, err, w)
 			return
@@ -618,25 +618,25 @@ func handleErrorType(docType string, err error, w http.ResponseWriter) {
 
 	switch docType {
 	default:
-		if err == errs.DatasetNotFound || err == errs.EditionNotFound || err == errs.VersionNotFound || err == errs.DimensionNodeNotFound || err == errs.InstanceNotFound {
+		if err == errs.ErrDatasetNotFound || err == errs.ErrEditionNotFound || err == errs.ErrVersionNotFound || err == errs.ErrDimensionNodeNotFound || err == errs.ErrInstanceNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	case "edition":
-		if err == errs.DatasetNotFound {
+		if err == errs.ErrDatasetNotFound {
 			http.Error(w, err.Error(), http.StatusBadRequest)
-		} else if err == errs.EditionNotFound {
+		} else if err == errs.ErrEditionNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	case "version":
-		if err == errs.DatasetNotFound {
+		if err == errs.ErrDatasetNotFound {
 			http.Error(w, err.Error(), http.StatusBadRequest)
-		} else if err == errs.EditionNotFound {
+		} else if err == errs.ErrEditionNotFound {
 			http.Error(w, err.Error(), http.StatusBadRequest)
-		} else if err == errs.VersionNotFound {
+		} else if err == errs.ErrVersionNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -506,7 +506,7 @@ func createNewVersionDoc(currentVersion *models.Version, version *models.Version
 func (api *DatasetAPI) updateDataset(id string, version *models.Version) error {
 	currentDataset, err := api.dataStore.Backend.GetDataset(id)
 	if err != nil {
-		log.ErrorC("Unable to update dataset", err, log.Data{"dataset_id": id})
+		log.ErrorC("unable to update dataset", err, log.Data{"dataset_id": id})
 		return err
 	}
 
@@ -537,7 +537,7 @@ func (api *DatasetAPI) updateDataset(id string, version *models.Version) error {
 	}
 
 	if err := api.dataStore.Backend.UpsertDataset(id, newDataset); err != nil {
-		log.ErrorC("Unable to update dataset", err, log.Data{"dataset_id": id})
+		log.ErrorC("unable to update dataset", err, log.Data{"dataset_id": id})
 		return err
 	}
 

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -14,11 +14,6 @@ import (
 )
 
 const (
-	createdState    = "created"
-	completedState  = "completed"
-	associatedState = "associated"
-	publishedState  = "published"
-
 	internalToken = "Internal-Token"
 
 	datasetDocType         = "dataset"
@@ -121,7 +116,7 @@ func (api *DatasetAPI) getEditions(w http.ResponseWriter, r *http.Request) {
 
 	var state string
 	if r.Header.Get(internalToken) != api.internalToken {
-		state = publishedState
+		state = models.PublishedState
 	}
 
 	if err := api.dataStore.Backend.CheckDatasetExists(id, state); err != nil {
@@ -159,7 +154,7 @@ func (api *DatasetAPI) getEdition(w http.ResponseWriter, r *http.Request) {
 
 	var state string
 	if r.Header.Get(internalToken) != api.internalToken {
-		state = publishedState
+		state = models.PublishedState
 	}
 
 	if err := api.dataStore.Backend.CheckDatasetExists(id, state); err != nil {
@@ -198,7 +193,7 @@ func (api *DatasetAPI) getVersions(w http.ResponseWriter, r *http.Request) {
 
 	var state string
 	if r.Header.Get(internalToken) != api.internalToken {
-		state = publishedState
+		state = models.PublishedState
 	}
 
 	if err := api.dataStore.Backend.CheckDatasetExists(id, state); err != nil {
@@ -243,7 +238,7 @@ func (api *DatasetAPI) getVersion(w http.ResponseWriter, r *http.Request) {
 
 	var state string
 	if r.Header.Get(internalToken) != api.internalToken {
-		state = publishedState
+		state = models.PublishedState
 	}
 
 	if err := api.dataStore.Backend.CheckDatasetExists(id, state); err != nil {
@@ -405,7 +400,7 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 
 	// Check current state of version document;
 	// if published do not try to update document
-	if currentVersion.State == publishedState {
+	if currentVersion.State == models.PublishedState {
 		http.Error(w, fmt.Sprintf("Unable to update document, already published"), http.StatusForbidden)
 		return
 	}
@@ -424,7 +419,7 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if version.State == publishedState {
+	if version.State == models.PublishedState {
 		if err := api.dataStore.Backend.UpdateEdition(datasetID, editionID, version.State); err != nil {
 			log.ErrorC("failed to update the state of edition document to published", err, nil)
 			handleErrorType(versionDocType, err, w)
@@ -439,8 +434,8 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if version.State == associatedState {
-		if err := api.dataStore.Backend.UpdateDatasetWithAssociation(datasetID, associatedState, version); err != nil {
+	if version.State == models.AssociatedState {
+		if err := api.dataStore.Backend.UpdateDatasetWithAssociation(datasetID, version.State, version); err != nil {
 			log.ErrorC("failed to update dataset document after a version of a dataset has been associated with a collection", err, nil)
 			handleErrorType(versionDocType, err, w)
 			return
@@ -523,7 +518,7 @@ func (api *DatasetAPI) updateDataset(id string, version *models.Version) error {
 			HRef: fmt.Sprintf("%s/datasets/%s", api.host, version.Links.Dataset.ID),
 		},
 	}
-	currentDataset.Next.State = publishedState
+	currentDataset.Next.State = models.PublishedState
 	currentDataset.Next.LastUpdated = time.Now()
 
 	// newDataset.Next will not be cleaned up due to keeping request to mongo

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -287,6 +287,20 @@ func (api *DatasetAPI) addDataset(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	datasetID := vars["id"]
 
+	_, err := api.dataStore.Backend.GetDataset(datasetID)
+	if err != nil {
+		if err != errs.DatasetNotFound {
+			log.Error(err, log.Data{"dataset_id": datasetID})
+			handleErrorType(datasetDocType, err, w)
+			return
+		}
+	} else {
+		err := fmt.Errorf("Forbidden - dataset already exists")
+		log.Error(err, log.Data{"dataset_id": datasetID})
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+
 	dataset, err := models.CreateDataset(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -380,11 +380,6 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if currentVersion.State == createdState || currentVersion.State == completedState {
-		http.Error(w, fmt.Sprintf("Version not found"), http.StatusNotFound)
-		return
-	}
-
 	// Combine update version document to existing version document
 	newVersion := createNewVersionDoc(currentVersion, version)
 

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -21,9 +21,9 @@ const (
 )
 
 var (
-	internalError   = errors.New("internal error")
-	badRequestError = errors.New("bad request")
-	notFoundError   = errors.New("not found")
+	errInternal   = errors.New("internal error")
+	errBadRequest = errors.New("bad request")
+	errNotFound   = errors.New("not found")
 
 	datasetPayload           = `{"contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"census","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"CensusEthnicity","theme":"population","periodicity":"yearly","state":"completed","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","url":"https://www.ons.gov.uk/"}}`
 	editionPayload           = `{"edition":"2017","state":"created"}`
@@ -57,7 +57,7 @@ func TestGetDatasetsReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetsFunc: func() ([]models.DatasetUpdate, error) {
-				return nil, internalError
+				return nil, errInternal
 			},
 		}
 
@@ -109,7 +109,7 @@ func TestGetDatasetReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(id string) (*models.DatasetUpdate, error) {
-				return nil, internalError
+				return nil, errInternal
 			},
 		}
 
@@ -139,7 +139,7 @@ func TestGetDatasetReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(id string) (*models.DatasetUpdate, error) {
-				return nil, errs.DatasetNotFound
+				return nil, errs.ErrDatasetNotFound
 			},
 		}
 
@@ -179,7 +179,7 @@ func TestGetEditionsReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(datasetID, state string) error {
-				return internalError
+				return errInternal
 			},
 		}
 
@@ -196,7 +196,7 @@ func TestGetEditionsReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(datasetID, state string) error {
-				return errs.DatasetNotFound
+				return errs.ErrDatasetNotFound
 			},
 		}
 
@@ -216,7 +216,7 @@ func TestGetEditionsReturnsError(t *testing.T) {
 				return nil
 			},
 			GetEditionsFunc: func(id, state string) (*models.EditionResults, error) {
-				return nil, errs.EditionNotFound
+				return nil, errs.ErrEditionNotFound
 			},
 		}
 
@@ -235,7 +235,7 @@ func TestGetEditionsReturnsError(t *testing.T) {
 				return nil
 			},
 			GetEditionsFunc: func(id, state string) (*models.EditionResults, error) {
-				return nil, errs.EditionNotFound
+				return nil, errs.ErrEditionNotFound
 			},
 		}
 
@@ -276,7 +276,7 @@ func TestGetEditionReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(datasetID, state string) error {
-				return internalError
+				return errInternal
 			},
 		}
 
@@ -293,7 +293,7 @@ func TestGetEditionReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(datasetID, state string) error {
-				return errs.DatasetNotFound
+				return errs.ErrDatasetNotFound
 			},
 		}
 
@@ -313,7 +313,7 @@ func TestGetEditionReturnsError(t *testing.T) {
 				return nil
 			},
 			GetEditionFunc: func(id, editionID, state string) (*models.Edition, error) {
-				return nil, errs.EditionNotFound
+				return nil, errs.ErrEditionNotFound
 			},
 		}
 
@@ -332,7 +332,7 @@ func TestGetEditionReturnsError(t *testing.T) {
 				return nil
 			},
 			GetEditionFunc: func(id, editionID, state string) (*models.Edition, error) {
-				return nil, errs.EditionNotFound
+				return nil, errs.ErrEditionNotFound
 			},
 		}
 
@@ -377,7 +377,7 @@ func TestGetVersionsReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(datasetID, state string) error {
-				return internalError
+				return errInternal
 			},
 		}
 
@@ -394,7 +394,7 @@ func TestGetVersionsReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(datasetID, state string) error {
-				return errs.DatasetNotFound
+				return errs.ErrDatasetNotFound
 			},
 		}
 
@@ -414,7 +414,7 @@ func TestGetVersionsReturnsError(t *testing.T) {
 				return nil
 			},
 			CheckEditionExistsFunc: func(datasetID, editionID, state string) error {
-				return errs.EditionNotFound
+				return errs.ErrEditionNotFound
 			},
 		}
 
@@ -438,7 +438,7 @@ func TestGetVersionsReturnsError(t *testing.T) {
 				return nil
 			},
 			GetVersionsFunc: func(datasetID, editionID, state string) (*models.VersionResults, error) {
-				return nil, errs.VersionNotFound
+				return nil, errs.ErrVersionNotFound
 			},
 		}
 
@@ -461,7 +461,7 @@ func TestGetVersionsReturnsError(t *testing.T) {
 				return nil
 			},
 			GetVersionsFunc: func(datasetID, editionID, state string) (*models.VersionResults, error) {
-				return nil, errs.VersionNotFound
+				return nil, errs.ErrVersionNotFound
 			},
 		}
 
@@ -515,7 +515,7 @@ func TestGetVersionReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(datasetID, state string) error {
-				return internalError
+				return errInternal
 			},
 		}
 
@@ -531,7 +531,7 @@ func TestGetVersionReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(datasetID, state string) error {
-				return errs.DatasetNotFound
+				return errs.ErrDatasetNotFound
 			},
 		}
 
@@ -552,7 +552,7 @@ func TestGetVersionReturnsError(t *testing.T) {
 				return nil
 			},
 			CheckEditionExistsFunc: func(datasetID, editionID, state string) error {
-				return errs.EditionNotFound
+				return errs.ErrEditionNotFound
 			},
 		}
 
@@ -576,7 +576,7 @@ func TestGetVersionReturnsError(t *testing.T) {
 				return nil
 			},
 			GetVersionFunc: func(datasetID, editionID, version, state string) (*models.Version, error) {
-				return nil, errs.VersionNotFound
+				return nil, errs.ErrVersionNotFound
 			},
 		}
 
@@ -599,7 +599,7 @@ func TestGetVersionReturnsError(t *testing.T) {
 				return nil
 			},
 			GetVersionFunc: func(datasetID, editionID, version, state string) (*models.Version, error) {
-				return nil, errs.VersionNotFound
+				return nil, errs.ErrVersionNotFound
 			},
 		}
 
@@ -622,7 +622,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
-				return nil, errs.DatasetNotFound
+				return nil, errs.ErrDatasetNotFound
 			},
 			UpsertDatasetFunc: func(id string, datasetDoc *models.DatasetUpdate) error {
 				return nil
@@ -648,10 +648,10 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
-				return nil, errs.DatasetNotFound
+				return nil, errs.ErrDatasetNotFound
 			},
 			UpsertDatasetFunc: func(string, *models.DatasetUpdate) error {
-				return badRequestError
+				return errBadRequest
 			},
 		}
 
@@ -670,7 +670,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
-				return nil, internalError
+				return nil, errInternal
 			},
 			UpsertDatasetFunc: func(string, *models.DatasetUpdate) error {
 				return nil
@@ -691,7 +691,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
-				return nil, errs.DatasetNotFound
+				return nil, errs.ErrDatasetNotFound
 			},
 			UpsertDatasetFunc: func(string, *models.DatasetUpdate) error {
 				return nil
@@ -705,7 +705,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 	})
 
-	Convey("When the dataset already exists and a request is sent to create the same dataset", t, func() {
+	Convey("When the dataset already exists and a request is sent to create the same dataset return status forbidden", t, func() {
 		var b string
 		b = datasetPayload
 		r := httptest.NewRequest("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
@@ -770,7 +770,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			UpdateDatasetFunc: func(string, *models.Dataset) error {
-				return badRequestError
+				return errBadRequest
 			},
 		}
 
@@ -789,7 +789,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			UpdateDatasetFunc: func(string, *models.Dataset) error {
-				return internalError
+				return errInternal
 			},
 		}
 
@@ -813,7 +813,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			UpdateDatasetFunc: func(string, *models.Dataset) error {
-				return errs.DatasetNotFound
+				return errs.ErrDatasetNotFound
 			},
 		}
 
@@ -1027,7 +1027,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetVersionFunc: func(string, string, string, string) (*models.Version, error) {
-				return nil, internalError
+				return nil, errInternal
 			},
 			UpdateVersionFunc: func(string, *models.Version) error {
 				return nil
@@ -1050,7 +1050,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetVersionFunc: func(string, string, string, string) (*models.Version, error) {
-				return nil, errs.VersionNotFound
+				return nil, errs.ErrVersionNotFound
 			},
 			UpdateVersionFunc: func(string, *models.Version) error {
 				return nil
@@ -1156,7 +1156,7 @@ func TestGetDimensionsReturnsErrors(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDimensionsFunc: func(datasetID, editionID, versionID string) (*models.DatasetDimensionResults, error) {
-				return nil, errs.VersionNotFound
+				return nil, errs.ErrVersionNotFound
 			},
 		}
 
@@ -1170,7 +1170,7 @@ func TestGetDimensionsReturnsErrors(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDimensionsFunc: func(datasetID, editionID, versionID string) (*models.DatasetDimensionResults, error) {
-				return nil, internalError
+				return nil, errInternal
 			},
 		}
 
@@ -1204,7 +1204,7 @@ func TestGetDimensionOptionsReturnsErrors(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDimensionOptionsFunc: func(datasetID, editionID, versionID, dimensions string) (*models.DimensionOptionResults, error) {
-				return nil, errs.DatasetNotFound
+				return nil, errs.ErrDatasetNotFound
 			},
 		}
 
@@ -1218,7 +1218,7 @@ func TestGetDimensionOptionsReturnsErrors(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDimensionOptionsFunc: func(datasetID, editionID, versionID, dimensions string) (*models.DimensionOptionResults, error) {
-				return nil, internalError
+				return nil, errInternal
 			},
 		}
 

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -1378,7 +1378,7 @@ func setUp(state string) *storetest.StorerMock {
 	}
 	mockedDataStore.UpsertVersion("1", versionDoc)
 
-	if state == publishedState {
+	if state == models.PublishedState {
 		datasetDoc := &models.DatasetUpdate{
 			ID: "123",
 			Next: &models.Dataset{
@@ -1390,7 +1390,7 @@ func setUp(state string) *storetest.StorerMock {
 		mockedDataStore.UpsertDataset("123", datasetDoc)
 	}
 
-	if state == associatedState {
+	if state == models.AssociatedState {
 		versionDoc := &models.Version{
 			State: state,
 		}

--- a/api/healthcheck.go
+++ b/api/healthcheck.go
@@ -8,6 +8,6 @@ import (
 
 // HealthCheck returns the health of the application.
 func (api *DatasetAPI) healthCheck(w http.ResponseWriter, r *http.Request) {
-	log.Debug("Healthcheck endpoint.", nil)
+	log.Debug("healthcheck endpoint.", nil)
 	w.WriteHeader(http.StatusOK)
 }

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -4,9 +4,9 @@ import "errors"
 
 // NotFound error messages for Dataset API
 var (
-	DatasetNotFound       = errors.New("Dataset not found")
-	EditionNotFound       = errors.New("Edition not found")
-	VersionNotFound       = errors.New("Version not found")
-	DimensionNodeNotFound = errors.New("Dimension node not found")
-	InstanceNotFound      = errors.New("Instance not found")
+	ErrDatasetNotFound       = errors.New("Dataset not found")
+	ErrEditionNotFound       = errors.New("Edition not found")
+	ErrVersionNotFound       = errors.New("Version not found")
+	ErrDimensionNodeNotFound = errors.New("Dimension node not found")
+	ErrInstanceNotFound      = errors.New("Instance not found")
 )

--- a/dimension/dimension.go
+++ b/dimension/dimension.go
@@ -65,7 +65,7 @@ func (s *Store) GetUnique(w http.ResponseWriter, r *http.Request) {
 	log.Debug("get dimension values", log.Data{"instance": id})
 }
 
-//AddDimension to a specific instance
+// Add represents adding a dimension to a specific instance
 func (s *Store) Add(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]
@@ -121,7 +121,7 @@ func unmarshalDimensionCache(reader io.Reader) (*models.CachedDimensionOption, e
 func handleErrorType(err error, w http.ResponseWriter) {
 	status := http.StatusInternalServerError
 
-	if err == errs.DatasetNotFound || err == errs.EditionNotFound || err == errs.VersionNotFound || err == errs.DimensionNodeNotFound || err == errs.InstanceNotFound {
+	if err == errs.ErrDatasetNotFound || err == errs.ErrEditionNotFound || err == errs.ErrVersionNotFound || err == errs.ErrDimensionNodeNotFound || err == errs.ErrInstanceNotFound {
 		status = http.StatusNotFound
 	}
 

--- a/dimension/dimension_test.go
+++ b/dimension/dimension_test.go
@@ -38,7 +38,7 @@ func TestAddNodeIDToDimensionReturnsOK(t *testing.T) {
 			},
 		}
 
-		dimension := &dimension.Store{mockedDataStore}
+		dimension := &dimension.Store{Storer: mockedDataStore}
 		dimension.AddNodeID(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -54,11 +54,11 @@ func TestAddNodeIDToDimensionReturnsBadRequest(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			UpdateDimensionNodeIDFunc: func(event *models.DimensionOption) error {
-				return errs.DimensionNodeNotFound
+				return errs.ErrDimensionNodeNotFound
 			},
 		}
 
-		dimension := &dimension.Store{mockedDataStore}
+		dimension := &dimension.Store{Storer: mockedDataStore}
 		dimension.AddNodeID(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusNotFound)
@@ -78,7 +78,7 @@ func TestAddNodeIDToDimensionReturnsInternalError(t *testing.T) {
 			},
 		}
 
-		dimension := &dimension.Store{mockedDataStore}
+		dimension := &dimension.Store{Storer: mockedDataStore}
 		dimension.AddNodeID(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -98,7 +98,7 @@ func TestAddDimensionToInstanceReturnsOk(t *testing.T) {
 			},
 		}
 
-		dimension := &dimension.Store{mockedDataStore}
+		dimension := &dimension.Store{Storer: mockedDataStore}
 		dimension.Add(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -115,11 +115,11 @@ func TestAddDimensionToInstanceReturnsNotFound(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			AddDimensionToInstanceFunc: func(event *models.CachedDimensionOption) error {
-				return errs.DimensionNodeNotFound
+				return errs.ErrDimensionNodeNotFound
 			},
 		}
 
-		dimension := &dimension.Store{mockedDataStore}
+		dimension := &dimension.Store{Storer: mockedDataStore}
 		dimension.Add(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusNotFound)
@@ -140,7 +140,7 @@ func TestAddDimensionToInstanceReturnsInternalError(t *testing.T) {
 			},
 		}
 
-		dimension := &dimension.Store{mockedDataStore}
+		dimension := &dimension.Store{Storer: mockedDataStore}
 		dimension.Add(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -160,7 +160,7 @@ func TestGetDimensionNodesReturnsOk(t *testing.T) {
 			},
 		}
 
-		dimension := &dimension.Store{mockedDataStore}
+		dimension := &dimension.Store{Storer: mockedDataStore}
 		dimension.GetNodes(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -176,11 +176,11 @@ func TestGetDimensionNodesReturnsNotFound(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			GetDimensionNodesFromInstanceFunc: func(id string) (*models.DimensionNodeResults, error) {
-				return nil, errs.InstanceNotFound
+				return nil, errs.ErrInstanceNotFound
 			},
 		}
 
-		dimension := &dimension.Store{mockedDataStore}
+		dimension := &dimension.Store{Storer: mockedDataStore}
 		dimension.GetNodes(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusNotFound)
@@ -200,7 +200,7 @@ func TestGetDimensionNodesReturnsInternalError(t *testing.T) {
 			},
 		}
 
-		dimension := &dimension.Store{mockedDataStore}
+		dimension := &dimension.Store{Storer: mockedDataStore}
 		dimension.GetNodes(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -220,7 +220,7 @@ func TestGetUniqueDimensionValuesReturnsOk(t *testing.T) {
 			},
 		}
 
-		dimension := &dimension.Store{mockedDataStore}
+		dimension := &dimension.Store{Storer: mockedDataStore}
 		dimension.GetUnique(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -236,11 +236,11 @@ func TestGetUniqueDimensionValuesReturnsNotFound(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetUniqueDimensionValuesFunc: func(id, dimension string) (*models.DimensionValues, error) {
-				return nil, errs.InstanceNotFound
+				return nil, errs.ErrInstanceNotFound
 			},
 		}
 
-		dimension := &dimension.Store{mockedDataStore}
+		dimension := &dimension.Store{Storer: mockedDataStore}
 		dimension.GetUnique(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusNotFound)
@@ -260,7 +260,7 @@ func TestGetUniqueDimensionValuesReturnsInternalError(t *testing.T) {
 			},
 		}
 
-		dimension := &dimension.Store{mockedDataStore}
+		dimension := &dimension.Store{Storer: mockedDataStore}
 		dimension.GetUnique(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)

--- a/instance/event_external_test.go
+++ b/instance/event_external_test.go
@@ -25,7 +25,7 @@ func TestAddEventReturnsOk(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.AddEvent(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -41,7 +41,7 @@ func TestAddEventToInstanceReturnsBadRequest(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.AddEvent(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
@@ -52,7 +52,7 @@ func TestAddEventToInstanceReturnsBadRequest(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.AddEvent(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
@@ -72,7 +72,7 @@ func TestAddEventToInstanceReturnsInternalError(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.AddEvent(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -173,7 +173,7 @@ func (s *Store) Update(w http.ResponseWriter, r *http.Request) {
 		// Only create edition if it doesn't already exist
 		editionDoc, err = s.GetEdition(datasetID, edition, "")
 		if err != nil {
-			if err != errs.EditionNotFound {
+			if err != errs.ErrEditionNotFound {
 				log.Error(err, nil)
 				handleErrorType(err, w)
 			}
@@ -344,7 +344,7 @@ func unmarshalInstance(reader io.Reader, post bool) (*models.Instance, error) {
 func handleErrorType(err error, w http.ResponseWriter) {
 	status := http.StatusInternalServerError
 
-	if err == errs.DatasetNotFound || err == errs.EditionNotFound || err == errs.VersionNotFound || err == errs.DimensionNodeNotFound || err == errs.InstanceNotFound {
+	if err == errs.ErrDatasetNotFound || err == errs.ErrEditionNotFound || err == errs.ErrVersionNotFound || err == errs.ErrDimensionNodeNotFound || err == errs.ErrInstanceNotFound {
 		status = http.StatusNotFound
 	}
 

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -207,7 +207,7 @@ func (s *Store) Update(w http.ResponseWriter, r *http.Request) {
 		// Update the latest version for the dataset edition
 		version, err := strconv.Atoi(editionDoc.Links.LatestVersion.ID)
 		if err != nil {
-			log.ErrorC("Unable to retrieve latest version", err, log.Data{"instance": id, "edition": edition, "version": editionDoc.Links.LatestVersion.ID})
+			log.ErrorC("unable to retrieve latest version", err, log.Data{"instance": id, "edition": edition, "version": editionDoc.Links.LatestVersion.ID})
 			handleErrorType(err, w)
 			return
 		}

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -24,13 +24,6 @@ type Store struct {
 	store.Storer
 }
 
-const (
-	completedState        = "completed"
-	editionConfirmedState = "edition-confirmed"
-	associatedState       = "associated"
-	publishedState        = "published"
-)
-
 //GetList a list of all instances
 func (s *Store) GetList(w http.ResponseWriter, r *http.Request) {
 	stateFilterQuery := r.URL.Query().Get("state")
@@ -133,22 +126,22 @@ func (s *Store) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch instance.State {
-	case editionConfirmedState:
-		if err = validateInstanceUpdate(completedState, currentInstance, instance); err != nil {
+	case models.EditionConfirmedState:
+		if err = validateInstanceUpdate(models.CompletedState, currentInstance, instance); err != nil {
 			log.Error(err, log.Data{"instance_id": id, "current_state": currentInstance.State})
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
-	case associatedState:
-		if err = validateInstanceUpdate(editionConfirmedState, currentInstance, instance); err != nil {
+	case models.AssociatedState:
+		if err = validateInstanceUpdate(models.EditionConfirmedState, currentInstance, instance); err != nil {
 			log.Error(err, log.Data{"instance_id": id, "current_state": currentInstance.State})
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
 
 		// TODO Update dataset.next state to associated and add collection id
-	case publishedState:
-		if err = validateInstanceUpdate(associatedState, currentInstance, instance); err != nil {
+	case models.PublishedState:
+		if err = validateInstanceUpdate(models.AssociatedState, currentInstance, instance); err != nil {
 			log.Error(err, log.Data{"instance_id": id, "current_state": currentInstance.State})
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
@@ -157,7 +150,7 @@ func (s *Store) Update(w http.ResponseWriter, r *http.Request) {
 		// TODO Update both edition and dataset states to published
 	}
 
-	if instance.State == editionConfirmedState {
+	if instance.State == models.EditionConfirmedState {
 		var editionDoc *models.Edition
 
 		datasetID := currentInstance.Links.Dataset.ID
@@ -257,7 +250,7 @@ func validateInstanceUpdate(expectedState string, currentInstance, instance *mod
 		err := fmt.Errorf("Unable to update resource, expected resource to have a state of %s", expectedState)
 		return err
 	}
-	if instance.State == editionConfirmedState && currentInstance.Edition == "" && instance.Edition == "" {
+	if instance.State == models.EditionConfirmedState && currentInstance.Edition == "" && instance.Edition == "" {
 		err := errors.New("Unable to update resource, missing a value for the edition")
 		return err
 	}

--- a/instance/instance_external_test.go
+++ b/instance/instance_external_test.go
@@ -39,7 +39,7 @@ func TestGetInstancesReturnsOK(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{"http://lochost://8080", mockedDataStore}
+		instance := &instance.Store{Host: "http://lochost://8080", Storer: mockedDataStore}
 		instance.GetList(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -61,7 +61,7 @@ func TestGetInstancesFiltersOnState(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{"http://lochost://8080", mockedDataStore}
+		instance := &instance.Store{Host: "http://lochost://8080", Storer: mockedDataStore}
 		instance.GetList(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -81,7 +81,7 @@ func TestGetInstancesFiltersOnState(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{"http://lochost://8080", mockedDataStore}
+		instance := &instance.Store{Host: "http://lochost://8080", Storer: mockedDataStore}
 		instance.GetList(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -102,7 +102,7 @@ func TestGetInstancesReturnsError(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.GetList(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -115,7 +115,7 @@ func TestGetInstancesReturnsError(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.GetList(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
@@ -135,7 +135,7 @@ func TestGetInstanceReturnsOK(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.Get(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -155,7 +155,7 @@ func TestGetInstanceReturnsInternalError(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.Get(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -176,7 +176,7 @@ func TestAddInstancesReturnsCreated(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.Add(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusCreated)
@@ -197,7 +197,7 @@ func TestAddInstancesReturnsBadRequest(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.Add(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
@@ -214,7 +214,7 @@ func TestAddInstancesReturnsBadRequest(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.Add(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
@@ -233,7 +233,7 @@ func TestAddInstancesReturnsInternalError(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.Add(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -257,7 +257,7 @@ func TestUpdateInstanceReturnsOk(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.Update(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -285,7 +285,7 @@ func TestUpdateInstanceReturnsOk(t *testing.T) {
 				return currentInstanceTestData, nil
 			},
 			GetEditionFunc: func(datasetID, edition, state string) (*models.Edition, error) {
-				return nil, errs.EditionNotFound
+				return nil, errs.ErrEditionNotFound
 			},
 			UpsertEditionFunc: func(datasetID, edition string, editionDoc *models.Edition) error {
 				return nil
@@ -298,7 +298,7 @@ func TestUpdateInstanceReturnsOk(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.Update(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -318,7 +318,7 @@ func TestUpdateInstanceFailure(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.Update(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
@@ -331,11 +331,11 @@ func TestUpdateInstanceFailure(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetInstanceFunc: func(id string) (*models.Instance, error) {
-				return nil, errs.InstanceNotFound
+				return nil, errs.ErrInstanceNotFound
 			},
 		}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.Update(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusNotFound)
@@ -370,7 +370,7 @@ func TestUpdateInstanceReturnsInternalError(t *testing.T) {
 			},
 		}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.Update(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -391,7 +391,7 @@ func TestInsertedObservationsReturnsOk(t *testing.T) {
 				return nil
 			},
 		}
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 
 		router := mux.NewRouter()
 		router.HandleFunc("/instances/{id}/inserted_observations/{inserted_observations}", instance.UpdateObservations).Methods("PUT")
@@ -409,7 +409,7 @@ func TestInsertedObservationsReturnsBadRequest(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 		instance.UpdateObservations(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
@@ -424,11 +424,11 @@ func TestInsertedObservationsReturnsNotFound(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			UpdateObservationInsertedFunc: func(id string, ob int64) error {
-				return errs.InstanceNotFound
+				return errs.ErrInstanceNotFound
 			},
 		}
 
-		instance := &instance.Store{host, mockedDataStore}
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
 
 		router := mux.NewRouter()
 		router.HandleFunc("/instances/{id}/inserted_observations/{inserted_observations}", instance.UpdateObservations).Methods("PUT")

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	session, err := mongo.Init()
 	if err != nil {
-		log.ErrorC("Failed to initialise mongo", err, nil)
+		log.ErrorC("failed to initialise mongo", err, nil)
 		os.Exit(1)
 	}
 
@@ -53,7 +53,7 @@ func main() {
 
 	// Gracefully shutdown the application closing any open resources.
 	gracefulShutdown := func() {
-		log.Info(fmt.Sprintf("Shutdown with timeout: %s", cfg.GracefulShutdownTimeout), nil)
+		log.Info(fmt.Sprintf("shutdown with timeout: %s", cfg.GracefulShutdownTimeout), nil)
 		ctx, cancel := context.WithTimeout(context.Background(), cfg.GracefulShutdownTimeout)
 
 		api.Close(ctx)
@@ -63,7 +63,7 @@ func main() {
 			log.Error(err, nil)
 		}
 
-		log.Info("Shutdown complete", nil)
+		log.Info("shutdown complete", nil)
 
 		cancel()
 		os.Exit(1)

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -54,7 +54,7 @@ type Dataset struct {
 	License           string           `bson:"license,omitempty"                json:"license,omitempty"`
 	Links             *DatasetLinks    `bson:"links,omitempty"                  json:"links,omitempty"`
 	Methodologies     []GeneralDetails `bson:"methodologies,omitempty"          json:"methodologies,omitempty"`
-	NationalStatistic bool             `bson:"national_statistic,omitempty"     json:"national_statistic,omitempty"`
+	NationalStatistic *bool            `bson:"national_statistic,omitempty"     json:"national_statistic,omitempty"`
 	NextRelease       string           `bson:"next_release,omitempty"           json:"next_release,omitempty"`
 	Publications      []GeneralDetails `bson:"publications,omitempty"           json:"publications,omitempty"`
 	Publisher         *Publisher       `bson:"publisher,omitempty"              json:"publisher,omitempty"`

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -11,11 +11,6 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-const (
-	createdState          = "created"
-	editionConfirmedState = "edition-confirmed"
-)
-
 // DatasetResults represents a structure for a list of datasets
 type DatasetResults struct {
 	Items []*Dataset `json:"items"`
@@ -188,7 +183,7 @@ func CreateDataset(reader io.Reader) (*Dataset, error) {
 	}
 
 	// Overwrite state to created
-	dataset.State = createdState
+	dataset.State = CreatedState
 
 	return &dataset, nil
 }
@@ -235,10 +230,10 @@ func ValidateVersion(version *Version) error {
 	var hasAssociation bool
 
 	switch version.State {
-	case "edition-confirmed":
-	case "associated":
+	case EditionConfirmedState:
+	case AssociatedState:
 		hasAssociation = true
-	case "published":
+	case PublishedState:
 		hasAssociation = true
 	default:
 		return errors.New("Incorrect state, can be one of the following: edition-confirmed, associated or published")

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -11,7 +11,10 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-const created = "created"
+const (
+	created               = "created"
+	editionConfirmedState = "edition-confirmed"
+)
 
 // DatasetResults represents a structure for a list of datasets
 type DatasetResults struct {
@@ -187,8 +190,6 @@ func CreateVersion(reader io.Reader) (*Version, error) {
 	var version Version
 	// Create unique id
 	version.ID = (uuid.NewV4()).String()
-	// set default state to be unpublished
-	version.State = created
 
 	err = json.Unmarshal(bytes, &version)
 	if err != nil {
@@ -221,13 +222,13 @@ func ValidateVersion(version *Version) error {
 	var hasAssociation bool
 
 	switch version.State {
-	case "created":
+	case "edition-confirmed":
 	case "associated":
 		hasAssociation = true
 	case "published":
 		hasAssociation = true
 	default:
-		return errors.New("Incorrect state, can be one of the following: created, associated or published")
+		return errors.New("Incorrect state, can be one of the following: edition-confirmed, associated or published")
 	}
 
 	if hasAssociation && version.CollectionID == "" {

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	created               = "created"
+	createdState          = "created"
 	editionConfirmedState = "edition-confirmed"
 )
 
@@ -89,6 +89,7 @@ type GeneralDetails struct {
 	Title       string `bson:"title,omitempty"          json:"title,omitempty"`
 }
 
+// Contact represents information of individual contact details
 type Contact struct {
 	ID          string    `bson:"_id,omitempty"            json:"id,omitempty"`
 	Email       string    `bson:"email,omitempty"          json:"email,omitempty"`
@@ -187,7 +188,7 @@ func CreateDataset(reader io.Reader) (*Dataset, error) {
 	}
 
 	// Overwrite state to created
-	dataset.State = created
+	dataset.State = createdState
 
 	return &dataset, nil
 }

--- a/models/dataset_test.go
+++ b/models/dataset_test.go
@@ -32,7 +32,7 @@ func TestCreateDataset(t *testing.T) {
 			So(dataset.Keywords[1], ShouldEqual, "test2")
 			So(dataset.License, ShouldEqual, "Office of National Statistics license")
 			So(dataset.Methodologies[0], ShouldResemble, methodology)
-			So(dataset.NationalStatistic, ShouldEqual, true)
+			So(dataset.NationalStatistic, ShouldResemble, &nationalStatistic)
 			So(dataset.NextRelease, ShouldEqual, "2016-05-05")
 			So(dataset.Publications[0], ShouldResemble, publications)
 			So(dataset.Publisher, ShouldResemble, &publisher)

--- a/models/dataset_test.go
+++ b/models/dataset_test.go
@@ -122,12 +122,12 @@ func TestValidateVersion(t *testing.T) {
 
 			err := ValidateVersion(&Version{State: "submitted"})
 			So(err, ShouldNotBeNil)
-			So(err, ShouldResemble, errors.New("Incorrect state, can be one of the following: created, associated or published"))
+			So(err, ShouldResemble, errors.New("Incorrect state, can be one of the following: edition-confirmed, associated or published"))
 		})
 
 		Convey("when mandatorey fields are missing from version document when state is set to created", func() {
 
-			err := ValidateVersion(&Version{State: "created"})
+			err := ValidateVersion(&Version{State: "edition-confirmed"})
 			So(err, ShouldNotBeNil)
 			So(err, ShouldResemble, errors.New("Missing mandatory fields: [license release_date]"))
 		})

--- a/models/dimension.go
+++ b/models/dimension.go
@@ -57,6 +57,7 @@ type PublicDimensionOption struct {
 	Option string               `bson:"option,omitempty"         json:"option"`
 }
 
+// DimensionOptionLinks represents a list of link objects related to dimension options
 type DimensionOptionLinks struct {
 	Code     LinkObject `bson:"code,omitempty"              json:"code"`
 	Version  LinkObject `bson:"version,omitempty"           json:"version"`

--- a/models/instance.go
+++ b/models/instance.go
@@ -73,12 +73,12 @@ func (e *Event) Validate() error {
 }
 
 var validStates = map[string]int{
-	"created":           1,
-	"submitted":         1,
-	"completed":         1,
-	"edition-confirmed": 1,
-	"associated":        1,
-	"published":         1,
+	CreatedState:          1,
+	SubmittedState:        1,
+	CompletedState:        1,
+	EditionConfirmedState: 1,
+	AssociatedState:       1,
+	PublishedState:        1,
 }
 
 // ValidateStateFilter checks the list of filter states from a whitelist

--- a/models/instance.go
+++ b/models/instance.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"time"
-
-	"github.com/ONSdigital/go-ns/log"
 )
 
 // Instance which presents a single dataset being imported
@@ -95,7 +93,6 @@ func ValidateStateFilter(filterList []string) error {
 
 	if invalidFilterStateValues != nil {
 		err := fmt.Errorf("Bad request - invalid filter state values: %v", invalidFilterStateValues)
-		log.Error(err, log.Data{"list-of-invalid-filter-states": invalidFilterStateValues})
 		return err
 	}
 

--- a/models/instance.go
+++ b/models/instance.go
@@ -44,6 +44,7 @@ type InstanceLinks struct {
 	Edition    *IDLink `bson:"edition,omitempty"    json:"edition,omitempty"`
 	Version    *IDLink `bson:"version,omitempty"    json:"version,omitempty"`
 	Self       *IDLink `bson:"self,omitempty"       json:"self,omitempty"`
+	Spatial    *IDLink `bson:"spatial,omitempty"    json:"spatial,omitempty"`
 }
 
 // IDLink holds the id and a link to the resource
@@ -93,7 +94,7 @@ func ValidateStateFilter(filterList []string) error {
 	}
 
 	if invalidFilterStateValues != nil {
-		err := fmt.Errorf("invalid filter state values")
+		err := fmt.Errorf("Bad request - invalid filter state values: %v", invalidFilterStateValues)
 		log.Error(err, log.Data{"list-of-invalid-filter-states": invalidFilterStateValues})
 		return err
 	}

--- a/models/instance_test.go
+++ b/models/instance_test.go
@@ -58,14 +58,14 @@ func TestValidateStateFilter(t *testing.T) {
 
 			err := ValidateStateFilter([]string{"foo"})
 			So(err, ShouldNotBeNil)
-			So(err, ShouldResemble, errors.New("invalid filter state values"))
+			So(err, ShouldResemble, errors.New("Bad request - invalid filter state values: [foo]"))
 		})
 
 		Convey("when the filter list contains more than one invalid state", func() {
 
 			err := ValidateStateFilter([]string{"foo", "bar"})
 			So(err, ShouldNotBeNil)
-			So(err, ShouldResemble, errors.New("invalid filter state values"))
+			So(err, ShouldResemble, errors.New("Bad request - invalid filter state values: [foo bar]"))
 		})
 	})
 }

--- a/models/state.go
+++ b/models/state.go
@@ -1,0 +1,10 @@
+package models
+
+const (
+	CreatedState          = "created"
+	SubmittedState        = "submitted"
+	CompletedState        = "completed"
+	EditionConfirmedState = "edition-confirmed"
+	AssociatedState       = "associated"
+	PublishedState        = "published"
+)

--- a/models/state.go
+++ b/models/state.go
@@ -1,5 +1,6 @@
 package models
 
+// A list of reusable states across application
 const (
 	CreatedState          = "created"
 	SubmittedState        = "submitted"

--- a/models/test_data.go
+++ b/models/test_data.go
@@ -16,6 +16,8 @@ var methodology = GeneralDetails{
 	Title:       "some methodology title",
 }
 
+var nationalStatistic = true
+
 var publications = GeneralDetails{
 	Description: "some publication description",
 	HRef:        "http://localhost:22000//datasets/publications",
@@ -55,7 +57,7 @@ var inputDataset = Dataset{
 	Methodologies: []GeneralDetails{
 		methodology,
 	},
-	NationalStatistic: true,
+	NationalStatistic: &nationalStatistic,
 	NextRelease:       "2016-05-05",
 	Publications: []GeneralDetails{
 		publications,

--- a/models/test_data.go
+++ b/models/test_data.go
@@ -100,7 +100,7 @@ var createdVersion = Version{
 	License:     "ONS License",
 	Links:       &links,
 	ReleaseDate: "2016-04-04",
-	State:       "created",
+	State:       "edition-confirmed",
 	Version:     1,
 }
 

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -273,7 +273,12 @@ func (m *Mongo) UpdateDataset(id string, dataset *models.Dataset) (err error) {
 	defer s.Close()
 
 	updates := createDatasetUpdateQuery(id, dataset)
-	err = s.DB(m.Database).C("datasets").UpdateId(id, bson.M{"$set": updates, "$setOnInsert": bson.M{"next.last_updated": time.Now()}})
+	if err = s.DB(m.Database).C("datasets").UpdateId(id, bson.M{"$set": updates, "$setOnInsert": bson.M{"next.last_updated": time.Now()}}); err != nil {
+		if err == mgo.ErrNotFound {
+			return errs.DatasetNotFound
+		}
+	}
+
 	return
 }
 
@@ -314,7 +319,7 @@ func createDatasetUpdateQuery(id string, dataset *models.Dataset) bson.M {
 		updates["next.methodologies"] = dataset.Methodologies
 	}
 
-	if dataset.NationalStatistic != false {
+	if dataset.NationalStatistic != nil {
 		updates["next.national_statistic"] = dataset.NationalStatistic
 	}
 

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -52,7 +52,7 @@ func (m *Mongo) GetDatasets() ([]models.DatasetUpdate, error) {
 	results := []models.DatasetUpdate{}
 	if err := iter.All(&results); err != nil {
 		if err == mgo.ErrNotFound {
-			return nil, errs.DatasetNotFound
+			return nil, errs.ErrDatasetNotFound
 		}
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (m *Mongo) GetDataset(id string) (*models.DatasetUpdate, error) {
 	err := s.DB(m.Database).C("datasets").Find(bson.M{"_id": id}).One(&dataset)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			return nil, errs.DatasetNotFound
+			return nil, errs.ErrDatasetNotFound
 		}
 		return nil, err
 	}
@@ -89,13 +89,13 @@ func (m *Mongo) GetEditions(id, state string) (*models.EditionResults, error) {
 	var results []models.Edition
 	if err := iter.All(&results); err != nil {
 		if err == mgo.ErrNotFound {
-			return nil, errs.EditionNotFound
+			return nil, errs.ErrEditionNotFound
 		}
 		return nil, err
 	}
 
 	if len(results) < 1 {
-		return nil, errs.EditionNotFound
+		return nil, errs.ErrEditionNotFound
 	}
 	return &models.EditionResults{Items: results}, nil
 }
@@ -127,7 +127,7 @@ func (m *Mongo) GetEdition(id, editionID, state string) (*models.Edition, error)
 	err := s.DB(m.Database).C("editions").Find(selector).One(&edition)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			return nil, errs.EditionNotFound
+			return nil, errs.ErrEditionNotFound
 		}
 		return nil, err
 	}
@@ -191,13 +191,13 @@ func (m *Mongo) GetVersions(id, editionID, state string) (*models.VersionResults
 	var results []models.Version
 	if err := iter.All(&results); err != nil {
 		if err == mgo.ErrNotFound {
-			return nil, errs.VersionNotFound
+			return nil, errs.ErrVersionNotFound
 		}
 		return nil, err
 	}
 
 	if len(results) < 1 {
-		return nil, errs.VersionNotFound
+		return nil, errs.ErrVersionNotFound
 	}
 
 	for i := 0; i < len(results); i++ {
@@ -240,7 +240,7 @@ func (m *Mongo) GetVersion(id, editionID, versionID, state string) (*models.Vers
 	err = s.DB(m.Database).C("instances").Find(selector).One(&version)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			return nil, errs.VersionNotFound
+			return nil, errs.ErrVersionNotFound
 		}
 		return nil, err
 	}
@@ -275,7 +275,7 @@ func (m *Mongo) UpdateDataset(id string, dataset *models.Dataset) (err error) {
 	updates := createDatasetUpdateQuery(id, dataset)
 	if err = s.DB(m.Database).C("datasets").UpdateId(id, bson.M{"$set": updates, "$setOnInsert": bson.M{"next.last_updated": time.Now()}}); err != nil {
 		if err == mgo.ErrNotFound {
-			return errs.DatasetNotFound
+			return errs.ErrDatasetNotFound
 		}
 	}
 
@@ -522,6 +522,7 @@ func (m *Mongo) UpsertContact(id string, update interface{}) (err error) {
 	return
 }
 
+// CheckDatasetExists checks that the dataset exists
 func (m *Mongo) CheckDatasetExists(id, state string) error {
 	s := m.Session.Copy()
 	defer s.Close()
@@ -544,12 +545,13 @@ func (m *Mongo) CheckDatasetExists(id, state string) error {
 	}
 
 	if count == 0 {
-		return errs.DatasetNotFound
+		return errs.ErrDatasetNotFound
 	}
 
 	return nil
 }
 
+// CheckEditionExists checks that the edition of a dataset exists
 func (m *Mongo) CheckEditionExists(id, editionID, state string) error {
 	s := m.Session.Copy()
 	defer s.Close()
@@ -574,7 +576,7 @@ func (m *Mongo) CheckEditionExists(id, editionID, state string) error {
 	}
 
 	if count == 0 {
-		return errs.EditionNotFound
+		return errs.ErrEditionNotFound
 	}
 
 	return nil

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -273,13 +273,15 @@ func (m *Mongo) UpdateDataset(id string, dataset *models.Dataset) (err error) {
 	defer s.Close()
 
 	updates := createDatasetUpdateQuery(id, dataset)
-	if err = s.DB(m.Database).C("datasets").UpdateId(id, bson.M{"$set": updates, "$setOnInsert": bson.M{"next.last_updated": time.Now()}}); err != nil {
+	update := bson.M{"$set": updates, "$setOnInsert": bson.M{"next.last_updated": time.Now()}}
+	if err = s.DB(m.Database).C("datasets").UpdateId(id, update); err != nil {
 		if err == mgo.ErrNotFound {
 			return errs.ErrDatasetNotFound
 		}
+		return err
 	}
 
-	return
+	return nil
 }
 
 func createDatasetUpdateQuery(id string, dataset *models.Dataset) bson.M {

--- a/mongo/dataset_test.go
+++ b/mongo/dataset_test.go
@@ -167,6 +167,7 @@ func TestDatasetUpdateQuery(t *testing.T) {
 		methodologies = append(methodologies, methodology)
 		publications = append(publications, publication)
 		relatedDatasets = append(relatedDatasets, relatedDataset)
+		nationalStatistic := true
 
 		expectedUpdate := bson.M{
 			"next.collection_id":            "12345678",
@@ -176,7 +177,7 @@ func TestDatasetUpdateQuery(t *testing.T) {
 			"next.license":                  "ONS License",
 			"next.links.access_rights.href": "http://ons.gov.uk/accessrights",
 			"next.methodologies":            methodologies,
-			"next.national_statistic":       true,
+			"next.national_statistic":       &nationalStatistic,
 			"next.next_release":             "2018-05-05",
 			"next.publications":             publications,
 			"next.publisher.href":           "http://ons.gov.uk",
@@ -204,7 +205,7 @@ func TestDatasetUpdateQuery(t *testing.T) {
 				},
 			},
 			Methodologies:     methodologies,
-			NationalStatistic: true,
+			NationalStatistic: &nationalStatistic,
 			NextRelease:       "2018-05-05",
 			Publications:      publications,
 			Publisher: &models.Publisher{
@@ -223,6 +224,27 @@ func TestDatasetUpdateQuery(t *testing.T) {
 		selector := createDatasetUpdateQuery("123", dataset)
 		So(selector, ShouldNotBeNil)
 		So(selector, ShouldResemble, expectedUpdate)
+	})
+
+	Convey("When national statistic is set to false", t, func() {
+		nationalStatistic := false
+		dataset := &models.Dataset{
+			NationalStatistic: &nationalStatistic,
+		}
+		expectedUpdate := bson.M{
+			"next.national_statistic": &nationalStatistic,
+		}
+		selector := createDatasetUpdateQuery("123", dataset)
+		So(selector, ShouldNotBeNil)
+		So(selector, ShouldResemble, expectedUpdate)
+	})
+
+	Convey("When national statistic is not set", t, func() {
+		dataset := &models.Dataset{}
+
+		selector := createDatasetUpdateQuery("123", dataset)
+		So(selector, ShouldNotBeNil)
+		So(selector, ShouldResemble, bson.M{})
 	})
 }
 

--- a/mongo/dataset_test.go
+++ b/mongo/dataset_test.go
@@ -212,7 +212,7 @@ func TestDatasetUpdateQuery(t *testing.T) {
 			URI:              "http://ons.gov.uk/dataset/123/landing-page",
 		}
 
-		selector := createDatasetUpdateQuery(dataset)
+		selector := createDatasetUpdateQuery("123", dataset)
 		So(selector, ShouldNotBeNil)
 		So(selector, ShouldResemble, expectedUpdate)
 	})

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -14,30 +14,30 @@ type Storer interface {
 	AddDimensionToInstance(dimension *models.CachedDimensionOption) error
 	AddEventToInstance(instanceID string, event *models.Event) error
 	AddInstance(instance *models.Instance) (*models.Instance, error)
-	CheckDatasetExists(id, state string) error
-	CheckEditionExists(id, editionID, state string) error
-	GetDataset(id string) (*models.DatasetUpdate, error)
+	CheckDatasetExists(ID, state string) error
+	CheckEditionExists(ID, editionID, state string) error
+	GetDataset(ID string) (*models.DatasetUpdate, error)
 	GetDatasets() ([]models.DatasetUpdate, error)
-	GetDimensionNodesFromInstance(id string) (*models.DimensionNodeResults, error)
+	GetDimensionNodesFromInstance(ID string) (*models.DimensionNodeResults, error)
 	GetDimensions(datasetID, editionID, versionID string) (*models.DatasetDimensionResults, error)
 	GetDimensionOptions(datasetID, editionID, versionID, dimension string) (*models.DimensionOptionResults, error)
-	GetEdition(id, editionID, state string) (*models.Edition, error)
-	GetEditions(id, state string) (*models.EditionResults, error)
+	GetEdition(ID, editionID, state string) (*models.Edition, error)
+	GetEditions(ID, state string) (*models.EditionResults, error)
 	GetInstances(filters []string) (*models.InstanceResults, error)
-	GetInstance(id string) (*models.Instance, error)
+	GetInstance(ID string) (*models.Instance, error)
 	GetNextVersion(datasetID, editionID string) (int, error)
-	GetUniqueDimensionValues(id, dimension string) (*models.DimensionValues, error)
+	GetUniqueDimensionValues(ID, dimension string) (*models.DimensionValues, error)
 	GetVersion(datasetID, editionID, version, state string) (*models.Version, error)
 	GetVersions(datasetID, editionID, state string) (*models.VersionResults, error)
-	UpdateDataset(id string, dataset *models.Dataset) error
-	UpdateDatasetWithAssociation(id, state string, version *models.Version) error
+	UpdateDataset(ID string, dataset *models.Dataset) error
+	UpdateDatasetWithAssociation(ID, state string, version *models.Version) error
 	UpdateDimensionNodeID(dimension *models.DimensionOption) error
 	UpdateEdition(datasetID, edition, state string) error
-	UpdateInstance(id string, instance *models.Instance) error
-	UpdateObservationInserted(id string, observationInserted int64) error
-	UpdateVersion(id string, version *models.Version) error
-	UpsertContact(id string, update interface{}) error
-	UpsertDataset(id string, datasetDoc *models.DatasetUpdate) error
+	UpdateInstance(ID string, instance *models.Instance) error
+	UpdateObservationInserted(ID string, observationInserted int64) error
+	UpdateVersion(ID string, version *models.Version) error
+	UpsertContact(ID string, update interface{}) error
+	UpsertDataset(ID string, datasetDoc *models.DatasetUpdate) error
 	UpsertEdition(datasetID, edition string, editionDoc *models.Edition) error
-	UpsertVersion(id string, versionDoc *models.Version) error
+	UpsertVersion(ID string, versionDoc *models.Version) error
 }

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -4,9 +4,8 @@
 package storetest
 
 import (
-	"sync"
-
 	"github.com/ONSdigital/dp-dataset-api/models"
+	"sync"
 )
 
 var (
@@ -56,19 +55,19 @@ var (
 //             AddInstanceFunc: func(instance *models.Instance) (*models.Instance, error) {
 // 	               panic("TODO: mock out the AddInstance method")
 //             },
-//             CheckDatasetExistsFunc: func(id string, state string) error {
+//             CheckDatasetExistsFunc: func(ID string, state string) error {
 // 	               panic("TODO: mock out the CheckDatasetExists method")
 //             },
-//             CheckEditionExistsFunc: func(id string, editionID string, state string) error {
+//             CheckEditionExistsFunc: func(ID string, editionID string, state string) error {
 // 	               panic("TODO: mock out the CheckEditionExists method")
 //             },
-//             GetDatasetFunc: func(id string) (*models.DatasetUpdate, error) {
+//             GetDatasetFunc: func(ID string) (*models.DatasetUpdate, error) {
 // 	               panic("TODO: mock out the GetDataset method")
 //             },
 //             GetDatasetsFunc: func() ([]models.DatasetUpdate, error) {
 // 	               panic("TODO: mock out the GetDatasets method")
 //             },
-//             GetDimensionNodesFromInstanceFunc: func(id string) (*models.DimensionNodeResults, error) {
+//             GetDimensionNodesFromInstanceFunc: func(ID string) (*models.DimensionNodeResults, error) {
 // 	               panic("TODO: mock out the GetDimensionNodesFromInstance method")
 //             },
 //             GetDimensionOptionsFunc: func(datasetID string, editionID string, versionID string, dimension string) (*models.DimensionOptionResults, error) {
@@ -77,22 +76,22 @@ var (
 //             GetDimensionsFunc: func(datasetID string, editionID string, versionID string) (*models.DatasetDimensionResults, error) {
 // 	               panic("TODO: mock out the GetDimensions method")
 //             },
-//             GetEditionFunc: func(id string, editionID string, state string) (*models.Edition, error) {
+//             GetEditionFunc: func(ID string, editionID string, state string) (*models.Edition, error) {
 // 	               panic("TODO: mock out the GetEdition method")
 //             },
-//             GetEditionsFunc: func(id string, state string) (*models.EditionResults, error) {
+//             GetEditionsFunc: func(ID string, state string) (*models.EditionResults, error) {
 // 	               panic("TODO: mock out the GetEditions method")
 //             },
-//             GetInstanceFunc: func(id string) (*models.Instance, error) {
+//             GetInstanceFunc: func(ID string) (*models.Instance, error) {
 // 	               panic("TODO: mock out the GetInstance method")
 //             },
-//             GetInstancesFunc: func(filter string) (*models.InstanceResults, error) {
+//             GetInstancesFunc: func(filters []string) (*models.InstanceResults, error) {
 // 	               panic("TODO: mock out the GetInstances method")
 //             },
 //             GetNextVersionFunc: func(datasetID string, editionID string) (int, error) {
 // 	               panic("TODO: mock out the GetNextVersion method")
 //             },
-//             GetUniqueDimensionValuesFunc: func(id string, dimension string) (*models.DimensionValues, error) {
+//             GetUniqueDimensionValuesFunc: func(ID string, dimension string) (*models.DimensionValues, error) {
 // 	               panic("TODO: mock out the GetUniqueDimensionValues method")
 //             },
 //             GetVersionFunc: func(datasetID string, editionID string, version string, state string) (*models.Version, error) {
@@ -101,10 +100,10 @@ var (
 //             GetVersionsFunc: func(datasetID string, editionID string, state string) (*models.VersionResults, error) {
 // 	               panic("TODO: mock out the GetVersions method")
 //             },
-//             UpdateDatasetFunc: func(id string, dataset *models.Dataset) error {
+//             UpdateDatasetFunc: func(ID string, dataset *models.Dataset) error {
 // 	               panic("TODO: mock out the UpdateDataset method")
 //             },
-//             UpdateDatasetWithAssociationFunc: func(id string, state string, version *models.Version) error {
+//             UpdateDatasetWithAssociationFunc: func(ID string, state string, version *models.Version) error {
 // 	               panic("TODO: mock out the UpdateDatasetWithAssociation method")
 //             },
 //             UpdateDimensionNodeIDFunc: func(dimension *models.DimensionOption) error {
@@ -113,25 +112,25 @@ var (
 //             UpdateEditionFunc: func(datasetID string, edition string, state string) error {
 // 	               panic("TODO: mock out the UpdateEdition method")
 //             },
-//             UpdateInstanceFunc: func(id string, instance *models.Instance) error {
+//             UpdateInstanceFunc: func(ID string, instance *models.Instance) error {
 // 	               panic("TODO: mock out the UpdateInstance method")
 //             },
-//             UpdateObservationInsertedFunc: func(id string, observationInserted int64) error {
+//             UpdateObservationInsertedFunc: func(ID string, observationInserted int64) error {
 // 	               panic("TODO: mock out the UpdateObservationInserted method")
 //             },
-//             UpdateVersionFunc: func(id string, version *models.Version) error {
+//             UpdateVersionFunc: func(ID string, version *models.Version) error {
 // 	               panic("TODO: mock out the UpdateVersion method")
 //             },
-//             UpsertContactFunc: func(id string, update interface{}) error {
+//             UpsertContactFunc: func(ID string, update interface{}) error {
 // 	               panic("TODO: mock out the UpsertContact method")
 //             },
-//             UpsertDatasetFunc: func(id string, datasetDoc *models.DatasetUpdate) error {
+//             UpsertDatasetFunc: func(ID string, datasetDoc *models.DatasetUpdate) error {
 // 	               panic("TODO: mock out the UpsertDataset method")
 //             },
 //             UpsertEditionFunc: func(datasetID string, edition string, editionDoc *models.Edition) error {
 // 	               panic("TODO: mock out the UpsertEdition method")
 //             },
-//             UpsertVersionFunc: func(id string, versionDoc *models.Version) error {
+//             UpsertVersionFunc: func(ID string, versionDoc *models.Version) error {
 // 	               panic("TODO: mock out the UpsertVersion method")
 //             },
 //         }
@@ -151,19 +150,19 @@ type StorerMock struct {
 	AddInstanceFunc func(instance *models.Instance) (*models.Instance, error)
 
 	// CheckDatasetExistsFunc mocks the CheckDatasetExists method.
-	CheckDatasetExistsFunc func(id string, state string) error
+	CheckDatasetExistsFunc func(ID string, state string) error
 
 	// CheckEditionExistsFunc mocks the CheckEditionExists method.
-	CheckEditionExistsFunc func(id string, editionID string, state string) error
+	CheckEditionExistsFunc func(ID string, editionID string, state string) error
 
 	// GetDatasetFunc mocks the GetDataset method.
-	GetDatasetFunc func(id string) (*models.DatasetUpdate, error)
+	GetDatasetFunc func(ID string) (*models.DatasetUpdate, error)
 
 	// GetDatasetsFunc mocks the GetDatasets method.
 	GetDatasetsFunc func() ([]models.DatasetUpdate, error)
 
 	// GetDimensionNodesFromInstanceFunc mocks the GetDimensionNodesFromInstance method.
-	GetDimensionNodesFromInstanceFunc func(id string) (*models.DimensionNodeResults, error)
+	GetDimensionNodesFromInstanceFunc func(ID string) (*models.DimensionNodeResults, error)
 
 	// GetDimensionOptionsFunc mocks the GetDimensionOptions method.
 	GetDimensionOptionsFunc func(datasetID string, editionID string, versionID string, dimension string) (*models.DimensionOptionResults, error)
@@ -172,22 +171,22 @@ type StorerMock struct {
 	GetDimensionsFunc func(datasetID string, editionID string, versionID string) (*models.DatasetDimensionResults, error)
 
 	// GetEditionFunc mocks the GetEdition method.
-	GetEditionFunc func(id string, editionID string, state string) (*models.Edition, error)
+	GetEditionFunc func(ID string, editionID string, state string) (*models.Edition, error)
 
 	// GetEditionsFunc mocks the GetEditions method.
-	GetEditionsFunc func(id string, state string) (*models.EditionResults, error)
+	GetEditionsFunc func(ID string, state string) (*models.EditionResults, error)
 
 	// GetInstanceFunc mocks the GetInstance method.
-	GetInstanceFunc func(id string) (*models.Instance, error)
+	GetInstanceFunc func(ID string) (*models.Instance, error)
 
 	// GetInstancesFunc mocks the GetInstances method.
-	GetInstancesFunc func(filter []string) (*models.InstanceResults, error)
+	GetInstancesFunc func(filters []string) (*models.InstanceResults, error)
 
 	// GetNextVersionFunc mocks the GetNextVersion method.
 	GetNextVersionFunc func(datasetID string, editionID string) (int, error)
 
 	// GetUniqueDimensionValuesFunc mocks the GetUniqueDimensionValues method.
-	GetUniqueDimensionValuesFunc func(id string, dimension string) (*models.DimensionValues, error)
+	GetUniqueDimensionValuesFunc func(ID string, dimension string) (*models.DimensionValues, error)
 
 	// GetVersionFunc mocks the GetVersion method.
 	GetVersionFunc func(datasetID string, editionID string, version string, state string) (*models.Version, error)
@@ -196,10 +195,10 @@ type StorerMock struct {
 	GetVersionsFunc func(datasetID string, editionID string, state string) (*models.VersionResults, error)
 
 	// UpdateDatasetFunc mocks the UpdateDataset method.
-	UpdateDatasetFunc func(id string, dataset *models.Dataset) error
+	UpdateDatasetFunc func(ID string, dataset *models.Dataset) error
 
 	// UpdateDatasetWithAssociationFunc mocks the UpdateDatasetWithAssociation method.
-	UpdateDatasetWithAssociationFunc func(id string, state string, version *models.Version) error
+	UpdateDatasetWithAssociationFunc func(ID string, state string, version *models.Version) error
 
 	// UpdateDimensionNodeIDFunc mocks the UpdateDimensionNodeID method.
 	UpdateDimensionNodeIDFunc func(dimension *models.DimensionOption) error
@@ -208,25 +207,25 @@ type StorerMock struct {
 	UpdateEditionFunc func(datasetID string, edition string, state string) error
 
 	// UpdateInstanceFunc mocks the UpdateInstance method.
-	UpdateInstanceFunc func(id string, instance *models.Instance) error
+	UpdateInstanceFunc func(ID string, instance *models.Instance) error
 
 	// UpdateObservationInsertedFunc mocks the UpdateObservationInserted method.
-	UpdateObservationInsertedFunc func(id string, observationInserted int64) error
+	UpdateObservationInsertedFunc func(ID string, observationInserted int64) error
 
 	// UpdateVersionFunc mocks the UpdateVersion method.
-	UpdateVersionFunc func(id string, version *models.Version) error
+	UpdateVersionFunc func(ID string, version *models.Version) error
 
 	// UpsertContactFunc mocks the UpsertContact method.
-	UpsertContactFunc func(id string, update interface{}) error
+	UpsertContactFunc func(ID string, update interface{}) error
 
 	// UpsertDatasetFunc mocks the UpsertDataset method.
-	UpsertDatasetFunc func(id string, datasetDoc *models.DatasetUpdate) error
+	UpsertDatasetFunc func(ID string, datasetDoc *models.DatasetUpdate) error
 
 	// UpsertEditionFunc mocks the UpsertEdition method.
 	UpsertEditionFunc func(datasetID string, edition string, editionDoc *models.Edition) error
 
 	// UpsertVersionFunc mocks the UpsertVersion method.
-	UpsertVersionFunc func(id string, versionDoc *models.Version) error
+	UpsertVersionFunc func(ID string, versionDoc *models.Version) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -249,15 +248,15 @@ type StorerMock struct {
 		}
 		// CheckDatasetExists holds details about calls to the CheckDatasetExists method.
 		CheckDatasetExists []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 			// State is the state argument value.
 			State string
 		}
 		// CheckEditionExists holds details about calls to the CheckEditionExists method.
 		CheckEditionExists []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 			// EditionID is the editionID argument value.
 			EditionID string
 			// State is the state argument value.
@@ -265,16 +264,16 @@ type StorerMock struct {
 		}
 		// GetDataset holds details about calls to the GetDataset method.
 		GetDataset []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 		}
 		// GetDatasets holds details about calls to the GetDatasets method.
 		GetDatasets []struct {
 		}
 		// GetDimensionNodesFromInstance holds details about calls to the GetDimensionNodesFromInstance method.
 		GetDimensionNodesFromInstance []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 		}
 		// GetDimensionOptions holds details about calls to the GetDimensionOptions method.
 		GetDimensionOptions []struct {
@@ -298,8 +297,8 @@ type StorerMock struct {
 		}
 		// GetEdition holds details about calls to the GetEdition method.
 		GetEdition []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 			// EditionID is the editionID argument value.
 			EditionID string
 			// State is the state argument value.
@@ -307,20 +306,20 @@ type StorerMock struct {
 		}
 		// GetEditions holds details about calls to the GetEditions method.
 		GetEditions []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 			// State is the state argument value.
 			State string
 		}
 		// GetInstance holds details about calls to the GetInstance method.
 		GetInstance []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 		}
 		// GetInstances holds details about calls to the GetInstances method.
 		GetInstances []struct {
-			// Filter is the filter argument value.
-			Filter []string
+			// Filters is the filters argument value.
+			Filters []string
 		}
 		// GetNextVersion holds details about calls to the GetNextVersion method.
 		GetNextVersion []struct {
@@ -331,8 +330,8 @@ type StorerMock struct {
 		}
 		// GetUniqueDimensionValues holds details about calls to the GetUniqueDimensionValues method.
 		GetUniqueDimensionValues []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 			// Dimension is the dimension argument value.
 			Dimension string
 		}
@@ -358,15 +357,15 @@ type StorerMock struct {
 		}
 		// UpdateDataset holds details about calls to the UpdateDataset method.
 		UpdateDataset []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 			// Dataset is the dataset argument value.
 			Dataset *models.Dataset
 		}
 		// UpdateDatasetWithAssociation holds details about calls to the UpdateDatasetWithAssociation method.
 		UpdateDatasetWithAssociation []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 			// State is the state argument value.
 			State string
 			// Version is the version argument value.
@@ -388,36 +387,36 @@ type StorerMock struct {
 		}
 		// UpdateInstance holds details about calls to the UpdateInstance method.
 		UpdateInstance []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 			// Instance is the instance argument value.
 			Instance *models.Instance
 		}
 		// UpdateObservationInserted holds details about calls to the UpdateObservationInserted method.
 		UpdateObservationInserted []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 			// ObservationInserted is the observationInserted argument value.
 			ObservationInserted int64
 		}
 		// UpdateVersion holds details about calls to the UpdateVersion method.
 		UpdateVersion []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 			// Version is the version argument value.
 			Version *models.Version
 		}
 		// UpsertContact holds details about calls to the UpsertContact method.
 		UpsertContact []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 			// Update is the update argument value.
 			Update interface{}
 		}
 		// UpsertDataset holds details about calls to the UpsertDataset method.
 		UpsertDataset []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 			// DatasetDoc is the datasetDoc argument value.
 			DatasetDoc *models.DatasetUpdate
 		}
@@ -432,8 +431,8 @@ type StorerMock struct {
 		}
 		// UpsertVersion holds details about calls to the UpsertVersion method.
 		UpsertVersion []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the ID argument value.
+			ID string
 			// VersionDoc is the versionDoc argument value.
 			VersionDoc *models.Version
 		}
@@ -538,32 +537,32 @@ func (mock *StorerMock) AddInstanceCalls() []struct {
 }
 
 // CheckDatasetExists calls CheckDatasetExistsFunc.
-func (mock *StorerMock) CheckDatasetExists(id string, state string) error {
+func (mock *StorerMock) CheckDatasetExists(ID string, state string) error {
 	if mock.CheckDatasetExistsFunc == nil {
 		panic("moq: StorerMock.CheckDatasetExistsFunc is nil but Storer.CheckDatasetExists was just called")
 	}
 	callInfo := struct {
-		Id    string
+		ID    string
 		State string
 	}{
-		Id:    id,
+		ID:    ID,
 		State: state,
 	}
 	lockStorerMockCheckDatasetExists.Lock()
 	mock.calls.CheckDatasetExists = append(mock.calls.CheckDatasetExists, callInfo)
 	lockStorerMockCheckDatasetExists.Unlock()
-	return mock.CheckDatasetExistsFunc(id, state)
+	return mock.CheckDatasetExistsFunc(ID, state)
 }
 
 // CheckDatasetExistsCalls gets all the calls that were made to CheckDatasetExists.
 // Check the length with:
 //     len(mockedStorer.CheckDatasetExistsCalls())
 func (mock *StorerMock) CheckDatasetExistsCalls() []struct {
-	Id    string
+	ID    string
 	State string
 } {
 	var calls []struct {
-		Id    string
+		ID    string
 		State string
 	}
 	lockStorerMockCheckDatasetExists.RLock()
@@ -573,35 +572,35 @@ func (mock *StorerMock) CheckDatasetExistsCalls() []struct {
 }
 
 // CheckEditionExists calls CheckEditionExistsFunc.
-func (mock *StorerMock) CheckEditionExists(id string, editionID string, state string) error {
+func (mock *StorerMock) CheckEditionExists(ID string, editionID string, state string) error {
 	if mock.CheckEditionExistsFunc == nil {
 		panic("moq: StorerMock.CheckEditionExistsFunc is nil but Storer.CheckEditionExists was just called")
 	}
 	callInfo := struct {
-		Id        string
+		ID        string
 		EditionID string
 		State     string
 	}{
-		Id:        id,
+		ID:        ID,
 		EditionID: editionID,
 		State:     state,
 	}
 	lockStorerMockCheckEditionExists.Lock()
 	mock.calls.CheckEditionExists = append(mock.calls.CheckEditionExists, callInfo)
 	lockStorerMockCheckEditionExists.Unlock()
-	return mock.CheckEditionExistsFunc(id, editionID, state)
+	return mock.CheckEditionExistsFunc(ID, editionID, state)
 }
 
 // CheckEditionExistsCalls gets all the calls that were made to CheckEditionExists.
 // Check the length with:
 //     len(mockedStorer.CheckEditionExistsCalls())
 func (mock *StorerMock) CheckEditionExistsCalls() []struct {
-	Id        string
+	ID        string
 	EditionID string
 	State     string
 } {
 	var calls []struct {
-		Id        string
+		ID        string
 		EditionID string
 		State     string
 	}
@@ -612,29 +611,29 @@ func (mock *StorerMock) CheckEditionExistsCalls() []struct {
 }
 
 // GetDataset calls GetDatasetFunc.
-func (mock *StorerMock) GetDataset(id string) (*models.DatasetUpdate, error) {
+func (mock *StorerMock) GetDataset(ID string) (*models.DatasetUpdate, error) {
 	if mock.GetDatasetFunc == nil {
 		panic("moq: StorerMock.GetDatasetFunc is nil but Storer.GetDataset was just called")
 	}
 	callInfo := struct {
-		Id string
+		ID string
 	}{
-		Id: id,
+		ID: ID,
 	}
 	lockStorerMockGetDataset.Lock()
 	mock.calls.GetDataset = append(mock.calls.GetDataset, callInfo)
 	lockStorerMockGetDataset.Unlock()
-	return mock.GetDatasetFunc(id)
+	return mock.GetDatasetFunc(ID)
 }
 
 // GetDatasetCalls gets all the calls that were made to GetDataset.
 // Check the length with:
 //     len(mockedStorer.GetDatasetCalls())
 func (mock *StorerMock) GetDatasetCalls() []struct {
-	Id string
+	ID string
 } {
 	var calls []struct {
-		Id string
+		ID string
 	}
 	lockStorerMockGetDataset.RLock()
 	calls = mock.calls.GetDataset
@@ -669,29 +668,29 @@ func (mock *StorerMock) GetDatasetsCalls() []struct {
 }
 
 // GetDimensionNodesFromInstance calls GetDimensionNodesFromInstanceFunc.
-func (mock *StorerMock) GetDimensionNodesFromInstance(id string) (*models.DimensionNodeResults, error) {
+func (mock *StorerMock) GetDimensionNodesFromInstance(ID string) (*models.DimensionNodeResults, error) {
 	if mock.GetDimensionNodesFromInstanceFunc == nil {
 		panic("moq: StorerMock.GetDimensionNodesFromInstanceFunc is nil but Storer.GetDimensionNodesFromInstance was just called")
 	}
 	callInfo := struct {
-		Id string
+		ID string
 	}{
-		Id: id,
+		ID: ID,
 	}
 	lockStorerMockGetDimensionNodesFromInstance.Lock()
 	mock.calls.GetDimensionNodesFromInstance = append(mock.calls.GetDimensionNodesFromInstance, callInfo)
 	lockStorerMockGetDimensionNodesFromInstance.Unlock()
-	return mock.GetDimensionNodesFromInstanceFunc(id)
+	return mock.GetDimensionNodesFromInstanceFunc(ID)
 }
 
 // GetDimensionNodesFromInstanceCalls gets all the calls that were made to GetDimensionNodesFromInstance.
 // Check the length with:
 //     len(mockedStorer.GetDimensionNodesFromInstanceCalls())
 func (mock *StorerMock) GetDimensionNodesFromInstanceCalls() []struct {
-	Id string
+	ID string
 } {
 	var calls []struct {
-		Id string
+		ID string
 	}
 	lockStorerMockGetDimensionNodesFromInstance.RLock()
 	calls = mock.calls.GetDimensionNodesFromInstance
@@ -782,35 +781,35 @@ func (mock *StorerMock) GetDimensionsCalls() []struct {
 }
 
 // GetEdition calls GetEditionFunc.
-func (mock *StorerMock) GetEdition(id string, editionID string, state string) (*models.Edition, error) {
+func (mock *StorerMock) GetEdition(ID string, editionID string, state string) (*models.Edition, error) {
 	if mock.GetEditionFunc == nil {
 		panic("moq: StorerMock.GetEditionFunc is nil but Storer.GetEdition was just called")
 	}
 	callInfo := struct {
-		Id        string
+		ID        string
 		EditionID string
 		State     string
 	}{
-		Id:        id,
+		ID:        ID,
 		EditionID: editionID,
 		State:     state,
 	}
 	lockStorerMockGetEdition.Lock()
 	mock.calls.GetEdition = append(mock.calls.GetEdition, callInfo)
 	lockStorerMockGetEdition.Unlock()
-	return mock.GetEditionFunc(id, editionID, state)
+	return mock.GetEditionFunc(ID, editionID, state)
 }
 
 // GetEditionCalls gets all the calls that were made to GetEdition.
 // Check the length with:
 //     len(mockedStorer.GetEditionCalls())
 func (mock *StorerMock) GetEditionCalls() []struct {
-	Id        string
+	ID        string
 	EditionID string
 	State     string
 } {
 	var calls []struct {
-		Id        string
+		ID        string
 		EditionID string
 		State     string
 	}
@@ -821,32 +820,32 @@ func (mock *StorerMock) GetEditionCalls() []struct {
 }
 
 // GetEditions calls GetEditionsFunc.
-func (mock *StorerMock) GetEditions(id string, state string) (*models.EditionResults, error) {
+func (mock *StorerMock) GetEditions(ID string, state string) (*models.EditionResults, error) {
 	if mock.GetEditionsFunc == nil {
 		panic("moq: StorerMock.GetEditionsFunc is nil but Storer.GetEditions was just called")
 	}
 	callInfo := struct {
-		Id    string
+		ID    string
 		State string
 	}{
-		Id:    id,
+		ID:    ID,
 		State: state,
 	}
 	lockStorerMockGetEditions.Lock()
 	mock.calls.GetEditions = append(mock.calls.GetEditions, callInfo)
 	lockStorerMockGetEditions.Unlock()
-	return mock.GetEditionsFunc(id, state)
+	return mock.GetEditionsFunc(ID, state)
 }
 
 // GetEditionsCalls gets all the calls that were made to GetEditions.
 // Check the length with:
 //     len(mockedStorer.GetEditionsCalls())
 func (mock *StorerMock) GetEditionsCalls() []struct {
-	Id    string
+	ID    string
 	State string
 } {
 	var calls []struct {
-		Id    string
+		ID    string
 		State string
 	}
 	lockStorerMockGetEditions.RLock()
@@ -856,29 +855,29 @@ func (mock *StorerMock) GetEditionsCalls() []struct {
 }
 
 // GetInstance calls GetInstanceFunc.
-func (mock *StorerMock) GetInstance(id string) (*models.Instance, error) {
+func (mock *StorerMock) GetInstance(ID string) (*models.Instance, error) {
 	if mock.GetInstanceFunc == nil {
 		panic("moq: StorerMock.GetInstanceFunc is nil but Storer.GetInstance was just called")
 	}
 	callInfo := struct {
-		Id string
+		ID string
 	}{
-		Id: id,
+		ID: ID,
 	}
 	lockStorerMockGetInstance.Lock()
 	mock.calls.GetInstance = append(mock.calls.GetInstance, callInfo)
 	lockStorerMockGetInstance.Unlock()
-	return mock.GetInstanceFunc(id)
+	return mock.GetInstanceFunc(ID)
 }
 
 // GetInstanceCalls gets all the calls that were made to GetInstance.
 // Check the length with:
 //     len(mockedStorer.GetInstanceCalls())
 func (mock *StorerMock) GetInstanceCalls() []struct {
-	Id string
+	ID string
 } {
 	var calls []struct {
-		Id string
+		ID string
 	}
 	lockStorerMockGetInstance.RLock()
 	calls = mock.calls.GetInstance
@@ -892,9 +891,9 @@ func (mock *StorerMock) GetInstances(filters []string) (*models.InstanceResults,
 		panic("moq: StorerMock.GetInstancesFunc is nil but Storer.GetInstances was just called")
 	}
 	callInfo := struct {
-		Filter []string
+		Filters []string
 	}{
-		Filter: filters,
+		Filters: filters,
 	}
 	lockStorerMockGetInstances.Lock()
 	mock.calls.GetInstances = append(mock.calls.GetInstances, callInfo)
@@ -906,10 +905,10 @@ func (mock *StorerMock) GetInstances(filters []string) (*models.InstanceResults,
 // Check the length with:
 //     len(mockedStorer.GetInstancesCalls())
 func (mock *StorerMock) GetInstancesCalls() []struct {
-	Filter []string
+	Filters []string
 } {
 	var calls []struct {
-		Filter []string
+		Filters []string
 	}
 	lockStorerMockGetInstances.RLock()
 	calls = mock.calls.GetInstances
@@ -953,32 +952,32 @@ func (mock *StorerMock) GetNextVersionCalls() []struct {
 }
 
 // GetUniqueDimensionValues calls GetUniqueDimensionValuesFunc.
-func (mock *StorerMock) GetUniqueDimensionValues(id string, dimension string) (*models.DimensionValues, error) {
+func (mock *StorerMock) GetUniqueDimensionValues(ID string, dimension string) (*models.DimensionValues, error) {
 	if mock.GetUniqueDimensionValuesFunc == nil {
 		panic("moq: StorerMock.GetUniqueDimensionValuesFunc is nil but Storer.GetUniqueDimensionValues was just called")
 	}
 	callInfo := struct {
-		Id        string
+		ID        string
 		Dimension string
 	}{
-		Id:        id,
+		ID:        ID,
 		Dimension: dimension,
 	}
 	lockStorerMockGetUniqueDimensionValues.Lock()
 	mock.calls.GetUniqueDimensionValues = append(mock.calls.GetUniqueDimensionValues, callInfo)
 	lockStorerMockGetUniqueDimensionValues.Unlock()
-	return mock.GetUniqueDimensionValuesFunc(id, dimension)
+	return mock.GetUniqueDimensionValuesFunc(ID, dimension)
 }
 
 // GetUniqueDimensionValuesCalls gets all the calls that were made to GetUniqueDimensionValues.
 // Check the length with:
 //     len(mockedStorer.GetUniqueDimensionValuesCalls())
 func (mock *StorerMock) GetUniqueDimensionValuesCalls() []struct {
-	Id        string
+	ID        string
 	Dimension string
 } {
 	var calls []struct {
-		Id        string
+		ID        string
 		Dimension string
 	}
 	lockStorerMockGetUniqueDimensionValues.RLock()
@@ -1070,32 +1069,32 @@ func (mock *StorerMock) GetVersionsCalls() []struct {
 }
 
 // UpdateDataset calls UpdateDatasetFunc.
-func (mock *StorerMock) UpdateDataset(id string, dataset *models.Dataset) error {
+func (mock *StorerMock) UpdateDataset(ID string, dataset *models.Dataset) error {
 	if mock.UpdateDatasetFunc == nil {
 		panic("moq: StorerMock.UpdateDatasetFunc is nil but Storer.UpdateDataset was just called")
 	}
 	callInfo := struct {
-		Id      string
+		ID      string
 		Dataset *models.Dataset
 	}{
-		Id:      id,
+		ID:      ID,
 		Dataset: dataset,
 	}
 	lockStorerMockUpdateDataset.Lock()
 	mock.calls.UpdateDataset = append(mock.calls.UpdateDataset, callInfo)
 	lockStorerMockUpdateDataset.Unlock()
-	return mock.UpdateDatasetFunc(id, dataset)
+	return mock.UpdateDatasetFunc(ID, dataset)
 }
 
 // UpdateDatasetCalls gets all the calls that were made to UpdateDataset.
 // Check the length with:
 //     len(mockedStorer.UpdateDatasetCalls())
 func (mock *StorerMock) UpdateDatasetCalls() []struct {
-	Id      string
+	ID      string
 	Dataset *models.Dataset
 } {
 	var calls []struct {
-		Id      string
+		ID      string
 		Dataset *models.Dataset
 	}
 	lockStorerMockUpdateDataset.RLock()
@@ -1105,35 +1104,35 @@ func (mock *StorerMock) UpdateDatasetCalls() []struct {
 }
 
 // UpdateDatasetWithAssociation calls UpdateDatasetWithAssociationFunc.
-func (mock *StorerMock) UpdateDatasetWithAssociation(id string, state string, version *models.Version) error {
+func (mock *StorerMock) UpdateDatasetWithAssociation(ID string, state string, version *models.Version) error {
 	if mock.UpdateDatasetWithAssociationFunc == nil {
 		panic("moq: StorerMock.UpdateDatasetWithAssociationFunc is nil but Storer.UpdateDatasetWithAssociation was just called")
 	}
 	callInfo := struct {
-		Id      string
+		ID      string
 		State   string
 		Version *models.Version
 	}{
-		Id:      id,
+		ID:      ID,
 		State:   state,
 		Version: version,
 	}
 	lockStorerMockUpdateDatasetWithAssociation.Lock()
 	mock.calls.UpdateDatasetWithAssociation = append(mock.calls.UpdateDatasetWithAssociation, callInfo)
 	lockStorerMockUpdateDatasetWithAssociation.Unlock()
-	return mock.UpdateDatasetWithAssociationFunc(id, state, version)
+	return mock.UpdateDatasetWithAssociationFunc(ID, state, version)
 }
 
 // UpdateDatasetWithAssociationCalls gets all the calls that were made to UpdateDatasetWithAssociation.
 // Check the length with:
 //     len(mockedStorer.UpdateDatasetWithAssociationCalls())
 func (mock *StorerMock) UpdateDatasetWithAssociationCalls() []struct {
-	Id      string
+	ID      string
 	State   string
 	Version *models.Version
 } {
 	var calls []struct {
-		Id      string
+		ID      string
 		State   string
 		Version *models.Version
 	}
@@ -1214,32 +1213,32 @@ func (mock *StorerMock) UpdateEditionCalls() []struct {
 }
 
 // UpdateInstance calls UpdateInstanceFunc.
-func (mock *StorerMock) UpdateInstance(id string, instance *models.Instance) error {
+func (mock *StorerMock) UpdateInstance(ID string, instance *models.Instance) error {
 	if mock.UpdateInstanceFunc == nil {
 		panic("moq: StorerMock.UpdateInstanceFunc is nil but Storer.UpdateInstance was just called")
 	}
 	callInfo := struct {
-		Id       string
+		ID       string
 		Instance *models.Instance
 	}{
-		Id:       id,
+		ID:       ID,
 		Instance: instance,
 	}
 	lockStorerMockUpdateInstance.Lock()
 	mock.calls.UpdateInstance = append(mock.calls.UpdateInstance, callInfo)
 	lockStorerMockUpdateInstance.Unlock()
-	return mock.UpdateInstanceFunc(id, instance)
+	return mock.UpdateInstanceFunc(ID, instance)
 }
 
 // UpdateInstanceCalls gets all the calls that were made to UpdateInstance.
 // Check the length with:
 //     len(mockedStorer.UpdateInstanceCalls())
 func (mock *StorerMock) UpdateInstanceCalls() []struct {
-	Id       string
+	ID       string
 	Instance *models.Instance
 } {
 	var calls []struct {
-		Id       string
+		ID       string
 		Instance *models.Instance
 	}
 	lockStorerMockUpdateInstance.RLock()
@@ -1249,32 +1248,32 @@ func (mock *StorerMock) UpdateInstanceCalls() []struct {
 }
 
 // UpdateObservationInserted calls UpdateObservationInsertedFunc.
-func (mock *StorerMock) UpdateObservationInserted(id string, observationInserted int64) error {
+func (mock *StorerMock) UpdateObservationInserted(ID string, observationInserted int64) error {
 	if mock.UpdateObservationInsertedFunc == nil {
 		panic("moq: StorerMock.UpdateObservationInsertedFunc is nil but Storer.UpdateObservationInserted was just called")
 	}
 	callInfo := struct {
-		Id                  string
+		ID                  string
 		ObservationInserted int64
 	}{
-		Id:                  id,
+		ID:                  ID,
 		ObservationInserted: observationInserted,
 	}
 	lockStorerMockUpdateObservationInserted.Lock()
 	mock.calls.UpdateObservationInserted = append(mock.calls.UpdateObservationInserted, callInfo)
 	lockStorerMockUpdateObservationInserted.Unlock()
-	return mock.UpdateObservationInsertedFunc(id, observationInserted)
+	return mock.UpdateObservationInsertedFunc(ID, observationInserted)
 }
 
 // UpdateObservationInsertedCalls gets all the calls that were made to UpdateObservationInserted.
 // Check the length with:
 //     len(mockedStorer.UpdateObservationInsertedCalls())
 func (mock *StorerMock) UpdateObservationInsertedCalls() []struct {
-	Id                  string
+	ID                  string
 	ObservationInserted int64
 } {
 	var calls []struct {
-		Id                  string
+		ID                  string
 		ObservationInserted int64
 	}
 	lockStorerMockUpdateObservationInserted.RLock()
@@ -1284,32 +1283,32 @@ func (mock *StorerMock) UpdateObservationInsertedCalls() []struct {
 }
 
 // UpdateVersion calls UpdateVersionFunc.
-func (mock *StorerMock) UpdateVersion(id string, version *models.Version) error {
+func (mock *StorerMock) UpdateVersion(ID string, version *models.Version) error {
 	if mock.UpdateVersionFunc == nil {
 		panic("moq: StorerMock.UpdateVersionFunc is nil but Storer.UpdateVersion was just called")
 	}
 	callInfo := struct {
-		Id      string
+		ID      string
 		Version *models.Version
 	}{
-		Id:      id,
+		ID:      ID,
 		Version: version,
 	}
 	lockStorerMockUpdateVersion.Lock()
 	mock.calls.UpdateVersion = append(mock.calls.UpdateVersion, callInfo)
 	lockStorerMockUpdateVersion.Unlock()
-	return mock.UpdateVersionFunc(id, version)
+	return mock.UpdateVersionFunc(ID, version)
 }
 
 // UpdateVersionCalls gets all the calls that were made to UpdateVersion.
 // Check the length with:
 //     len(mockedStorer.UpdateVersionCalls())
 func (mock *StorerMock) UpdateVersionCalls() []struct {
-	Id      string
+	ID      string
 	Version *models.Version
 } {
 	var calls []struct {
-		Id      string
+		ID      string
 		Version *models.Version
 	}
 	lockStorerMockUpdateVersion.RLock()
@@ -1319,32 +1318,32 @@ func (mock *StorerMock) UpdateVersionCalls() []struct {
 }
 
 // UpsertContact calls UpsertContactFunc.
-func (mock *StorerMock) UpsertContact(id string, update interface{}) error {
+func (mock *StorerMock) UpsertContact(ID string, update interface{}) error {
 	if mock.UpsertContactFunc == nil {
 		panic("moq: StorerMock.UpsertContactFunc is nil but Storer.UpsertContact was just called")
 	}
 	callInfo := struct {
-		Id     string
+		ID     string
 		Update interface{}
 	}{
-		Id:     id,
+		ID:     ID,
 		Update: update,
 	}
 	lockStorerMockUpsertContact.Lock()
 	mock.calls.UpsertContact = append(mock.calls.UpsertContact, callInfo)
 	lockStorerMockUpsertContact.Unlock()
-	return mock.UpsertContactFunc(id, update)
+	return mock.UpsertContactFunc(ID, update)
 }
 
 // UpsertContactCalls gets all the calls that were made to UpsertContact.
 // Check the length with:
 //     len(mockedStorer.UpsertContactCalls())
 func (mock *StorerMock) UpsertContactCalls() []struct {
-	Id     string
+	ID     string
 	Update interface{}
 } {
 	var calls []struct {
-		Id     string
+		ID     string
 		Update interface{}
 	}
 	lockStorerMockUpsertContact.RLock()
@@ -1354,32 +1353,32 @@ func (mock *StorerMock) UpsertContactCalls() []struct {
 }
 
 // UpsertDataset calls UpsertDatasetFunc.
-func (mock *StorerMock) UpsertDataset(id string, datasetDoc *models.DatasetUpdate) error {
+func (mock *StorerMock) UpsertDataset(ID string, datasetDoc *models.DatasetUpdate) error {
 	if mock.UpsertDatasetFunc == nil {
 		panic("moq: StorerMock.UpsertDatasetFunc is nil but Storer.UpsertDataset was just called")
 	}
 	callInfo := struct {
-		Id         string
+		ID         string
 		DatasetDoc *models.DatasetUpdate
 	}{
-		Id:         id,
+		ID:         ID,
 		DatasetDoc: datasetDoc,
 	}
 	lockStorerMockUpsertDataset.Lock()
 	mock.calls.UpsertDataset = append(mock.calls.UpsertDataset, callInfo)
 	lockStorerMockUpsertDataset.Unlock()
-	return mock.UpsertDatasetFunc(id, datasetDoc)
+	return mock.UpsertDatasetFunc(ID, datasetDoc)
 }
 
 // UpsertDatasetCalls gets all the calls that were made to UpsertDataset.
 // Check the length with:
 //     len(mockedStorer.UpsertDatasetCalls())
 func (mock *StorerMock) UpsertDatasetCalls() []struct {
-	Id         string
+	ID         string
 	DatasetDoc *models.DatasetUpdate
 } {
 	var calls []struct {
-		Id         string
+		ID         string
 		DatasetDoc *models.DatasetUpdate
 	}
 	lockStorerMockUpsertDataset.RLock()
@@ -1428,32 +1427,32 @@ func (mock *StorerMock) UpsertEditionCalls() []struct {
 }
 
 // UpsertVersion calls UpsertVersionFunc.
-func (mock *StorerMock) UpsertVersion(id string, versionDoc *models.Version) error {
+func (mock *StorerMock) UpsertVersion(ID string, versionDoc *models.Version) error {
 	if mock.UpsertVersionFunc == nil {
 		panic("moq: StorerMock.UpsertVersionFunc is nil but Storer.UpsertVersion was just called")
 	}
 	callInfo := struct {
-		Id         string
+		ID         string
 		VersionDoc *models.Version
 	}{
-		Id:         id,
+		ID:         ID,
 		VersionDoc: versionDoc,
 	}
 	lockStorerMockUpsertVersion.Lock()
 	mock.calls.UpsertVersion = append(mock.calls.UpsertVersion, callInfo)
 	lockStorerMockUpsertVersion.Unlock()
-	return mock.UpsertVersionFunc(id, versionDoc)
+	return mock.UpsertVersionFunc(ID, versionDoc)
 }
 
 // UpsertVersionCalls gets all the calls that were made to UpsertVersion.
 // Check the length with:
 //     len(mockedStorer.UpsertVersionCalls())
 func (mock *StorerMock) UpsertVersionCalls() []struct {
-	Id         string
+	ID         string
 	VersionDoc *models.Version
 } {
 	var calls []struct {
-		Id         string
+		ID         string
 		VersionDoc *models.Version
 	}
 	lockStorerMockUpsertVersion.RLock()


### PR DESCRIPTION
### What

Bug fixes, this includes the following:

* Versions can only have states of edition-confirmed, associated and published
* Add missing links to dataset resource (includes editions and self)
* Use pointer for boolean field `national_statistics`
* If dataset exists already, request to create dataset will fail and
 not overwrite current document - otherwise the wrong request could lead
 to a loss of data
* Update error message for an invalid state value being set to be more
 explicit on why update failed

### How to review

Check logic, changes abide the spec and all tests pass. Acceptance tests are still being extended for this piece of work (so no need to run them against this branch - if you do expect them to fail)

### Who can review

Team B
