### PR TITLE
Allow the dataset status to be updated via the PUT endpoint.

### DIFF
--- a/models/dataset.go
+++ b/models/dataset.go
@@ -182,9 +182,6 @@ func CreateDataset(reader io.Reader) (*Dataset, error) {
 		return nil, errors.New("Failed to parse json body")
 	}
 
-	// Overwrite state to created
-	dataset.State = CreatedState
-
 	return &dataset, nil
 }
 

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -182,6 +182,10 @@ func CreateDataset(reader io.Reader) (*Dataset, error) {
 		return nil, errors.New("Failed to parse json body")
 	}
 
+	if dataset.State == "" {
+		dataset.State = CreatedState
+	}
+
 	return &dataset, nil
 }
 

--- a/models/dataset_test.go
+++ b/models/dataset_test.go
@@ -39,7 +39,7 @@ func TestCreateDataset(t *testing.T) {
 			So(dataset.QMI, ShouldResemble, &qmi)
 			So(dataset.RelatedDatasets[0], ShouldResemble, relatedDatasets)
 			So(dataset.ReleaseFrequency, ShouldEqual, "yearly")
-			So(dataset.State, ShouldEqual, "created")
+			So(dataset.State, ShouldEqual, "associated")
 			So(dataset.Theme, ShouldEqual, "population")
 			So(dataset.Title, ShouldEqual, "CensusEthnicity")
 			So(dataset.URI, ShouldEqual, "http://localhost:22000/datasets/123/breadcrumbs")

--- a/models/test_data.go
+++ b/models/test_data.go
@@ -41,37 +41,41 @@ var relatedDatasets = GeneralDetails{
 	Title: "Census Age",
 }
 
-var inputDataset = Dataset{
-	CollectionID: collectionID,
-	Contacts: []ContactDetails{
-		contacts,
-	},
-	Description: "census",
-	Keywords:    []string{"test", "test2"},
-	License:     "Office of National Statistics license",
-	Links: &DatasetLinks{
-		AccessRights: &LinkObject{
-			HRef: "http://ons.gov.uk/accessrights",
+
+// Create a fully populated dataset object to use in testing.
+func createTestDataset() *Dataset {
+	return &Dataset{
+		CollectionID: collectionID,
+		Contacts: []ContactDetails{
+			contacts,
 		},
-	},
-	Methodologies: []GeneralDetails{
-		methodology,
-	},
-	NationalStatistic: &nationalStatistic,
-	NextRelease:       "2016-05-05",
-	Publications: []GeneralDetails{
-		publications,
-	},
-	Publisher: &publisher,
-	QMI:       &qmi,
-	RelatedDatasets: []GeneralDetails{
-		relatedDatasets,
-	},
-	ReleaseFrequency: "yearly",
-	State:            "associated",
-	Theme:            "population",
-	Title:            "CensusEthnicity",
-	URI:              "http://localhost:22000/datasets/123/breadcrumbs",
+		Description: "census",
+		Keywords:    []string{"test", "test2"},
+		License:     "Office of National Statistics license",
+		Links: &DatasetLinks{
+			AccessRights: &LinkObject{
+				HRef: "http://ons.gov.uk/accessrights",
+			},
+		},
+		Methodologies: []GeneralDetails{
+			methodology,
+		},
+		NationalStatistic: &nationalStatistic,
+		NextRelease:       "2016-05-05",
+		Publications: []GeneralDetails{
+			publications,
+		},
+		Publisher: &publisher,
+		QMI:       &qmi,
+		RelatedDatasets: []GeneralDetails{
+			relatedDatasets,
+		},
+		ReleaseFrequency: "yearly",
+		State:            EditionConfirmedState,
+		Theme:            "population",
+		Title:            "CensusEthnicity",
+		URI:              "http://localhost:22000/datasets/123/breadcrumbs",
+	}
 }
 
 var dimension = CodeList{
@@ -124,7 +128,7 @@ var createdVersion = Version{
 	Edition:     "2017",
 	Links:       &links,
 	ReleaseDate: "2016-04-04",
-	State:       "edition-confirmed",
+	State:       EditionConfirmedState,
 	Version:     1,
 }
 
@@ -135,7 +139,7 @@ var associatedVersion = Version{
 	Edition:      "2017",
 	Links:        &links,
 	ReleaseDate:  "2017-10-12",
-	State:        "associated",
+	State:        EditionConfirmedState,
 	Temporal:     &[]TemporalFrequency{temporal},
 	Version:      1,
 }
@@ -147,7 +151,7 @@ var publishedVersion = Version{
 	Edition:      "2017",
 	Links:        &links,
 	ReleaseDate:  "2017-10-12",
-	State:        "published",
+	State:        EditionConfirmedState,
 	Temporal:     &[]TemporalFrequency{temporal},
 	Version:      1,
 }

--- a/models/test_data.go
+++ b/models/test_data.go
@@ -68,7 +68,7 @@ var inputDataset = Dataset{
 		relatedDatasets,
 	},
 	ReleaseFrequency: "yearly",
-	State:            "published",
+	State:            "associated",
 	Theme:            "population",
 	Title:            "CensusEthnicity",
 	URI:              "http://localhost:22000/datasets/123/breadcrumbs",

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -369,6 +369,10 @@ func createDatasetUpdateQuery(id string, dataset *models.Dataset) bson.M {
 		updates["next.release_frequency"] = dataset.ReleaseFrequency
 	}
 
+	if dataset.State != "" {
+		updates["next.state"] = dataset.State
+	}
+
 	if dataset.Theme != "" {
 		updates["next.theme"] = dataset.Theme
 	}


### PR DESCRIPTION
### What

Allow the dataset status to be updated via the PUT endpoint. It was only possible to update the state via the version endpoint before, but it is a requirement to be able to update the datasets and versions independently.

Note: this does not validate that the status is valid. This will either need to be added as a separate PR or as an extension to this one.

### How to review

See code changes.

### Who can review

Anyone ( @nshumoogum 😉  )
