### PR TITLE
Feature/protect completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,38 @@
 dp-dataset-api
 ==================
-A ONS API used to navigate datasets which are published.
+A ONS API used to navigate datasets, editions and versions - which are published.
+
+### Installation
 
 #### Database
-* Run ```brew install mongo```
-* Run ```brew services start mongodb```
-* Run ```./scripts/InitDatabase.sh```
+* Run `brew install mongo`
+* Run `brew services start mongodb`
+* Run `./scripts/InitDatabase.sh`
+
+### State changes
+
+Normal sequential order of states:
+
+1. `created` (only on *instance*)
+2. `submitted` (only on *instance*)
+3. `completed` (only on *instance*)
+4. `edition-confirmed` (only on *instance* - this will create an *edition* and *version*,
+    in other words the *instance* will now be accessible by `version` endpoints).
+    Also the dataset `next` sub-document will also get updated here and so will the *edition*
+    (authorised users will see a different latest *version* link versus unauthorised users)
+5. `associated` (only on *version*) - dataset `next` sub-document will be updated again and so will the *edition*
+6. `published` (only on *version*) - both *edition* and *dataset* are updated - must not be changed
+
+There is the possibility to **rollback** from `associate`  to `edition-confirmed`
+where a PST user has attached the _version_ to the wrong collection and so not only does
+the `collection_id` need to be updated with the new one (or removed all together)
+but the state will need to revert back to `edition-confirmed`.
+
+Lastly, **skipping a state**: it is possibly to jump from `edition-confirmed` to `published`
+as long as all the mandatory fields are there. There also might be a scenario whereby
+the state can change from `created` to `completed`, missing out the step to `submitted`
+due to race conditions, this is not expected to happen,
+the path to get to `completed` is longer than the `submitted` one.
 
 ### Healthcheck
 

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -133,22 +133,23 @@ func (s *Store) Update(w http.ResponseWriter, r *http.Request) {
 	// Combine existing links and spatial link
 	instance.Links = updateLinks(instance, currentInstance)
 
+	logData := log.Data{"instance_id": id, "current_state": currentInstance.State, "requested_state": instance.State}
 	switch instance.State {
 	case models.CompletedState:
 		if err = validateInstanceUpdate(models.SubmittedState, currentInstance, instance); err != nil {
-			log.Error(err, log.Data{"instance_id": id, "current_state": currentInstance.State})
+			log.Error(err, logData)
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
 	case models.EditionConfirmedState:
 		if err = validateInstanceUpdate(models.CompletedState, currentInstance, instance); err != nil {
-			log.Error(err, log.Data{"instance_id": id, "current_state": currentInstance.State})
+			log.Error(err, logData)
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
 	case models.AssociatedState:
 		if err = validateInstanceUpdate(models.EditionConfirmedState, currentInstance, instance); err != nil {
-			log.Error(err, log.Data{"instance_id": id, "current_state": currentInstance.State})
+			log.Error(err, logData)
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
@@ -156,7 +157,7 @@ func (s *Store) Update(w http.ResponseWriter, r *http.Request) {
 		// TODO Update dataset.next state to associated and add collection id
 	case models.PublishedState:
 		if err = validateInstanceUpdate(models.AssociatedState, currentInstance, instance); err != nil {
-			log.Error(err, log.Data{"instance_id": id, "current_state": currentInstance.State})
+			log.Error(err, logData)
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -134,6 +134,12 @@ func (s *Store) Update(w http.ResponseWriter, r *http.Request) {
 	instance.Links = updateLinks(instance, currentInstance)
 
 	switch instance.State {
+	case models.CompletedState:
+		if err = validateInstanceUpdate(models.SubmittedState, currentInstance, instance); err != nil {
+			log.Error(err, log.Data{"instance_id": id, "current_state": currentInstance.State})
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 	case models.EditionConfirmedState:
 		if err = validateInstanceUpdate(models.CompletedState, currentInstance, instance); err != nil {
 			log.Error(err, log.Data{"instance_id": id, "current_state": currentInstance.State})

--- a/models/dataset_test.go
+++ b/models/dataset_test.go
@@ -161,7 +161,7 @@ func TestValidateVersion(t *testing.T) {
 			So(err, ShouldResemble, errors.New("Incorrect state, can be one of the following: edition-confirmed, associated or published"))
 		})
 
-		Convey("when mandatorey fields are missing from version document when state is set to created", func() {
+		Convey("when mandatory fields are missing from version document when state is set to created", func() {
 
 			err := ValidateVersion(&Version{State: EditionConfirmedState})
 			So(err, ShouldNotBeNil)


### PR DESCRIPTION
### What

Check existing status when a receiving requests to change it to `completed`

### How to review

Ensure you cannot set `completed` when the status is not `submitted`

### Who can review

You.