### PR TITLE
Move sanitized logging of config to after envconfig.Process

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"time"
 
-	"github.com/ONSdigital/go-ns/log"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -52,10 +51,6 @@ func Get() (*Configuration, error) {
 			Database:   "datasets",
 		},
 	}
-
-	sanitized := *cfg
-	sanitized.SecretKey = ""
-	log.Info("config on startup", log.Data{"config": sanitized})
 
 	return cfg, envconfig.Process("", cfg)
 }

--- a/main.go
+++ b/main.go
@@ -34,6 +34,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	sanitized := *cfg
+	sanitized.SecretKey = ""
+	log.Info("config on startup", log.Data{"config": sanitized})
+
 	generateDownloadsProducer, err := kafka.NewProducer(cfg.KafkaAddr, cfg.GenerateDownloadsTopic, 0)
 	if err != nil {
 		log.Error(errors.Wrap(err, "error creating kakfa producer"), nil)


### PR DESCRIPTION
### What

Move sanitized logging of config to after envconfig.Process so that the actual configured variables are picked up not just the defaults

### How to review

Ensure non-default values are logged

### Who can review
anyone