### PR TITLE
Fail dimension update if dimension is not found

### DIFF
--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -8,6 +8,7 @@ var (
 	ErrEditionNotFound       = errors.New("Edition not found")
 	ErrVersionNotFound       = errors.New("Version not found")
 	ErrDimensionNodeNotFound = errors.New("Dimension node not found")
+	ErrDimensionNotFound     = errors.New("Dimension not found")
 	ErrDimensionsNotFound    = errors.New("Dimensions not found")
 	ErrInstanceNotFound      = errors.New("Instance not found")
 )

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -149,11 +149,12 @@ func (s *Store) UpdateDimension(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update instance-dimension
+	notFound := true
 	for i := range instance.Dimensions {
 
 		// For the chosen dimension
 		if instance.Dimensions[i].Name == dimension {
-
+			notFound = false
 			// Assign update info, conditionals to allow updating of both or either without blanking other
 			if dim.Label != "" {
 				instance.Dimensions[i].Label = dim.Label
@@ -164,6 +165,12 @@ func (s *Store) UpdateDimension(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 
+	}
+
+	if notFound {
+		log.ErrorC("dimension not found", errs.ErrDimensionNotFound, log.Data{"instance": id, "dimension": dimension})
+		handleErrorType(errs.ErrDimensionNotFound, w)
+		return
 	}
 
 	// Update instance
@@ -537,7 +544,7 @@ func unmarshalInstance(reader io.Reader, post bool) (*models.Instance, error) {
 func handleErrorType(err error, w http.ResponseWriter) {
 	status := http.StatusInternalServerError
 
-	if err == errs.ErrDatasetNotFound || err == errs.ErrEditionNotFound || err == errs.ErrVersionNotFound || err == errs.ErrDimensionNodeNotFound || err == errs.ErrInstanceNotFound {
+	if err == errs.ErrDatasetNotFound || err == errs.ErrEditionNotFound || err == errs.ErrVersionNotFound || err == errs.ErrDimensionNotFound || err == errs.ErrDimensionNodeNotFound || err == errs.ErrInstanceNotFound {
 		status = http.StatusNotFound
 	}
 

--- a/instance/instance_external_test.go
+++ b/instance/instance_external_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 const secretKey = "coffee"
-const host = "http://locahost:8080"
+const host = "http://localhost:8080"
 
 var internalError = errors.New("internal error")
 
@@ -600,7 +600,6 @@ func TestStore_UpdateImportTask_ReturnsInternalError(t *testing.T) {
 	})
 }
 
-
 func TestUpdateDimensionReturnsNotFound(t *testing.T) {
 	t.Parallel()
 	Convey("When update dimension return status not found", t, func() {
@@ -667,16 +666,18 @@ func TestUpdateDimensionReturnsBadRequest(t *testing.T) {
 	})
 }
 
-func TestUpdateDimensionReturnsOk(t *testing.T) {
+func TestUpdateDimensionReturnsNotFoundWithWrongName(t *testing.T) {
 	t.Parallel()
 	Convey("When update dimension fails to update an instance", t, func() {
-		body := strings.NewReader("{}")
-		r := createRequestWithToken("PUT", "http://localhost:22000/instances/123/dimensions/age", body)
+		body := strings.NewReader(`{"label":"notages"}`)
+		r := createRequestWithToken("PUT", "http://localhost:22000/instances/123/dimensions/notage", body)
 		w := httptest.NewRecorder()
 
 		mockedDataStore := &storetest.StorerMock{
 			GetInstanceFunc: func(id string) (*models.Instance, error) {
-				return &models.Instance{}, nil
+				return &models.Instance{State: models.EditionConfirmedState,
+					InstanceID: "123",
+					Dimensions: []models.CodeList{{Name: "age", ID: "age"}}}, nil
 			},
 			UpdateInstanceFunc: func(id string, i *models.Instance) error {
 				return nil
@@ -684,7 +685,40 @@ func TestUpdateDimensionReturnsOk(t *testing.T) {
 		}
 
 		instance := &instance.Store{Host: host, Storer: mockedDataStore}
-		instance.UpdateDimension(w, r)
+		router := mux.NewRouter()
+		router.HandleFunc("/instances/{id}/dimensions/{dimension}", instance.UpdateDimension).Methods("PUT")
+
+		router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpdateInstanceCalls()), ShouldEqual, 0)
+	})
+}
+
+func TestUpdateDimensionReturnsOk(t *testing.T) {
+	t.Parallel()
+	Convey("When update dimension fails to update an instance", t, func() {
+		body := strings.NewReader(`{"label":"ages"}`)
+		r := createRequestWithToken("PUT", "http://localhost:22000/instances/123/dimensions/age", body)
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			GetInstanceFunc: func(id string) (*models.Instance, error) {
+				return &models.Instance{State: models.EditionConfirmedState,
+					InstanceID: "123",
+					Dimensions: []models.CodeList{{Name: "age", ID: "age"}}}, nil
+			},
+			UpdateInstanceFunc: func(id string, i *models.Instance) error {
+				return nil
+			},
+		}
+
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
+		router := mux.NewRouter()
+		router.HandleFunc("/instances/{id}/dimensions/{dimension}", instance.UpdateDimension).Methods("PUT")
+
+		router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)


### PR DESCRIPTION
### What

Previously, if the dimension name didn't exist, nothing would be updated but a 200 status was still returned. This change ensures 404s are returned when a request is made to a dimension that doesn't exist.

### How to review

Check tests pass

### Who can review

@MikeData 