### PR TITLE
Get dimensions for unpublished version when authenticated

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -746,13 +746,15 @@ func (api *DatasetAPI) getDimensionOptions(w http.ResponseWriter, r *http.Reques
 	dimension := vars["dimension"]
 
 	var state string
+	authenticated := true
 	if r.Header.Get(internalToken) != api.internalToken {
 		state = models.PublishedState
+		authenticated = false
 	}
 
 	version, err := api.dataStore.Backend.GetVersion(datasetID, editionID, versionID, state)
 	if err != nil {
-		log.ErrorC("failed to get version", err, log.Data{"dataset_id": datasetID, "edition": editionID, "version": versionID})
+		log.ErrorC("failed to get version", err, log.Data{"dataset_id": datasetID, "edition": editionID, "version": versionID, "authenticated": authenticated})
 		handleErrorType(versionDocType, err, w)
 		return
 	}

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -745,7 +745,19 @@ func (api *DatasetAPI) getDimensionOptions(w http.ResponseWriter, r *http.Reques
 	versionID := vars["version"]
 	dimension := vars["dimension"]
 
-	results, err := api.dataStore.Backend.GetDimensionOptions(datasetID, editionID, versionID, dimension)
+	var state string
+	if r.Header.Get(internalToken) != api.internalToken {
+		state = models.PublishedState
+	}
+
+	version, err := api.dataStore.Backend.GetVersion(datasetID, editionID, versionID, state)
+	if err != nil {
+		log.ErrorC("failed to get version", err, log.Data{"dataset_id": datasetID, "edition": editionID, "version": versionID})
+		handleErrorType(versionDocType, err, w)
+		return
+	}
+
+	results, err := api.dataStore.Backend.GetDimensionOptions(version, dimension)
 	if err != nil {
 		log.ErrorC("failed to get a list of dimension options", err, log.Data{"dataset_id": datasetID, "edition": editionID, "version": versionID, "dimension": dimension})
 		handleErrorType(dimensionOptionDocType, err, w)

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -1699,7 +1699,10 @@ func TestGetDimensionOptionsReturnsOk(t *testing.T) {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/dimensions/age/options", nil)
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
-			GetDimensionOptionsFunc: func(datasetID, editionID, versionID, dimensions string) (*models.DimensionOptionResults, error) {
+			GetVersionFunc: func(datasetID, edition, version, state string) (*models.Version, error) {
+				return &models.Version{}, nil
+			},
+			GetDimensionOptionsFunc: func(version *models.Version, dimensions string) (*models.DimensionOptionResults, error) {
 				return &models.DimensionOptionResults{}, nil
 			},
 		}
@@ -1716,7 +1719,10 @@ func TestGetDimensionOptionsReturnsErrors(t *testing.T) {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/dimensions/age/options", nil)
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
-			GetDimensionOptionsFunc: func(datasetID, editionID, versionID, dimensions string) (*models.DimensionOptionResults, error) {
+			GetVersionFunc: func(datasetID, edition, version, state string) (*models.Version, error) {
+				return &models.Version{}, nil
+			},
+			GetDimensionOptionsFunc: func(version *models.Version, dimensions string) (*models.DimensionOptionResults, error) {
 				return nil, errs.ErrDatasetNotFound
 			},
 		}
@@ -1730,7 +1736,10 @@ func TestGetDimensionOptionsReturnsErrors(t *testing.T) {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/dimensions/age/options", nil)
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
-			GetDimensionOptionsFunc: func(datasetID, editionID, versionID, dimensions string) (*models.DimensionOptionResults, error) {
+			GetVersionFunc: func(datasetID, edition, version, state string) (*models.Version, error) {
+				return &models.Version{}, nil
+			},
+			GetDimensionOptionsFunc: func(version *models.Version, dimensions string) (*models.DimensionOptionResults, error) {
 				return nil, errInternal
 			},
 		}

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -212,7 +212,7 @@ func TestGetEditionsReturnsError(t *testing.T) {
 
 	Convey("When the dataset does not exist return status bad request", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions", nil)
-		r.Header.Add("internal_token", "coffee")
+		r.Header.Add("internal-token", "coffee")
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(datasetID, state string) error {
@@ -229,7 +229,7 @@ func TestGetEditionsReturnsError(t *testing.T) {
 
 	Convey("When no editions exist against an existing dataset return status not found", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions", nil)
-		r.Header.Add("internal_token", "coffee")
+		r.Header.Add("internal-token", "coffee")
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(datasetID, state string) error {
@@ -309,7 +309,7 @@ func TestGetEditionReturnsError(t *testing.T) {
 
 	Convey("When the dataset does not exist return status bad request", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678", nil)
-		r.Header.Add("internal_token", "coffee")
+		r.Header.Add("internal-token", "coffee")
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(datasetID, state string) error {
@@ -326,7 +326,7 @@ func TestGetEditionReturnsError(t *testing.T) {
 
 	Convey("When edition does not exist for a dataset return status not found", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678", nil)
-		r.Header.Add("internal_token", "coffee")
+		r.Header.Add("internal-token", "coffee")
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(datasetID, state string) error {
@@ -1505,38 +1505,6 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldEqual, "No authentication header provided\n")
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
-	})
-
-	Convey("Given the version doc is 'published', when we try to set state to 'completed', then we see a status of forbidden", t, func() {
-		generatorMock := &mocks.DownloadsGeneratorMock{
-			GenerateFunc: func(string, string, string, string) error {
-				return nil
-			},
-		}
-
-		var b string
-		b = versionPayload
-		r, err := http.NewRequest("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-		r.Header.Add("internal-token", "coffee")
-		So(err, ShouldBeNil)
-		w := httptest.NewRecorder()
-		mockedDataStore := &storetest.StorerMock{
-			GetVersionFunc: func(string, string, string, string) (*models.Version, error) {
-				return &models.Version{
-					State: models.PublishedState,
-				}, nil
-			},
-			CheckDatasetExistsFunc: func(string, string) error {
-				return nil
-			},
-		}
-
-		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusForbidden)
-		So(w.Body.String(), ShouldEqual, "unable to update version as it has been published\n")
-		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 0)
 	})
 
 	Convey("When the version document has already been published return status forbidden", t, func() {

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -1695,7 +1695,7 @@ func TestGetDimensionsReturnsErrors(t *testing.T) {
 
 func TestGetDimensionOptionsReturnsOk(t *testing.T) {
 	t.Parallel()
-	Convey("", t, func() {
+	Convey("When a valid dimension is provided then a list of options can be returned successfully", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/dimensions/age/options", nil)
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1715,15 +1715,12 @@ func TestGetDimensionOptionsReturnsOk(t *testing.T) {
 
 func TestGetDimensionOptionsReturnsErrors(t *testing.T) {
 	t.Parallel()
-	Convey("", t, func() {
+	Convey("When the version doesn't exist in a request for dimension options, then return not found", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/dimensions/age/options", nil)
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetVersionFunc: func(datasetID, edition, version, state string) (*models.Version, error) {
-				return &models.Version{}, nil
-			},
-			GetDimensionOptionsFunc: func(version *models.Version, dimensions string) (*models.DimensionOptionResults, error) {
-				return nil, errs.ErrDatasetNotFound
+				return nil, errs.ErrVersionNotFound
 			},
 		}
 
@@ -1732,7 +1729,7 @@ func TestGetDimensionOptionsReturnsErrors(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 	})
 
-	Convey("", t, func() {
+	Convey("When an internal error causes failure to retrieve dimension options, then return internal server error", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/dimensions/age/options", nil)
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{

--- a/mongo/dimension_store.go
+++ b/mongo/dimension_store.go
@@ -89,19 +89,13 @@ func (m *Mongo) GetDimensions(datasetID, versionID string) ([]bson.M, error) {
 }
 
 // GetDimensionOptions returns all dimension options for a dimensions within a dataset.
-func (m *Mongo) GetDimensionOptions(datasetID, editionID, versionID, dimension string) (*models.DimensionOptionResults, error) {
+func (m *Mongo) GetDimensionOptions(version *models.Version, dimension string) (*models.DimensionOptionResults, error) {
 	s := m.Session.Copy()
 	defer s.Close()
 
-	version, err := m.GetVersion(datasetID, editionID, versionID, models.PublishedState)
-	if err != nil {
-		return nil, err
-	}
-
 	var values []models.PublicDimensionOption
 	iter := s.DB(m.Database).C(dimensionOptions).Find(bson.M{"instance_id": version.ID, "name": dimension}).Iter()
-	err = iter.All(&values)
-	if err != nil {
+	if err := iter.All(&values); err != nil {
 		return nil, err
 	}
 

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -26,7 +26,7 @@ type Storer interface {
 	GetDatasets() ([]models.DatasetUpdate, error)
 	GetDimensionNodesFromInstance(ID string) (*models.DimensionNodeResults, error)
 	GetDimensions(datasetID, versionID string) ([]bson.M, error)
-	GetDimensionOptions(datasetID, editionID, versionID, dimension string) (*models.DimensionOptionResults, error)
+	GetDimensionOptions(version *models.Version, dimension string) (*models.DimensionOptionResults, error)
 	GetEdition(ID, editionID, state string) (*models.Edition, error)
 	GetEditions(ID, state string) (*models.EditionResults, error)
 	GetInstances(filters []string) (*models.InstanceResults, error)

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -76,7 +76,7 @@ var (
 //             GetDimensionNodesFromInstanceFunc: func(ID string) (*models.DimensionNodeResults, error) {
 // 	               panic("TODO: mock out the GetDimensionNodesFromInstance method")
 //             },
-//             GetDimensionOptionsFunc: func(datasetID string, editionID string, versionID string, dimension string) (*models.DimensionOptionResults, error) {
+//             GetDimensionOptionsFunc: func(version *models.Version, dimension string) (*models.DimensionOptionResults, error) {
 // 	               panic("TODO: mock out the GetDimensionOptions method")
 //             },
 //             GetDimensionsFunc: func(datasetID string, versionID string) ([]bson.M, error) {
@@ -180,7 +180,7 @@ type StorerMock struct {
 	GetDimensionNodesFromInstanceFunc func(ID string) (*models.DimensionNodeResults, error)
 
 	// GetDimensionOptionsFunc mocks the GetDimensionOptions method.
-	GetDimensionOptionsFunc func(datasetID string, editionID string, versionID string, dimension string) (*models.DimensionOptionResults, error)
+	GetDimensionOptionsFunc func(version *models.Version, dimension string) (*models.DimensionOptionResults, error)
 
 	// GetDimensionsFunc mocks the GetDimensions method.
 	GetDimensionsFunc func(datasetID string, versionID string) ([]bson.M, error)
@@ -301,12 +301,8 @@ type StorerMock struct {
 		}
 		// GetDimensionOptions holds details about calls to the GetDimensionOptions method.
 		GetDimensionOptions []struct {
-			// DatasetID is the datasetID argument value.
-			DatasetID string
-			// EditionID is the editionID argument value.
-			EditionID string
-			// VersionID is the versionID argument value.
-			VersionID string
+			// Version is the version argument value.
+			Version *models.Version
 			// Dimension is the dimension argument value.
 			Dimension string
 		}
@@ -742,40 +738,32 @@ func (mock *StorerMock) GetDimensionNodesFromInstanceCalls() []struct {
 }
 
 // GetDimensionOptions calls GetDimensionOptionsFunc.
-func (mock *StorerMock) GetDimensionOptions(datasetID string, editionID string, versionID string, dimension string) (*models.DimensionOptionResults, error) {
+func (mock *StorerMock) GetDimensionOptions(version *models.Version, dimension string) (*models.DimensionOptionResults, error) {
 	if mock.GetDimensionOptionsFunc == nil {
 		panic("moq: StorerMock.GetDimensionOptionsFunc is nil but Storer.GetDimensionOptions was just called")
 	}
 	callInfo := struct {
-		DatasetID string
-		EditionID string
-		VersionID string
+		Version   *models.Version
 		Dimension string
 	}{
-		DatasetID: datasetID,
-		EditionID: editionID,
-		VersionID: versionID,
+		Version:   version,
 		Dimension: dimension,
 	}
 	lockStorerMockGetDimensionOptions.Lock()
 	mock.calls.GetDimensionOptions = append(mock.calls.GetDimensionOptions, callInfo)
 	lockStorerMockGetDimensionOptions.Unlock()
-	return mock.GetDimensionOptionsFunc(datasetID, editionID, versionID, dimension)
+	return mock.GetDimensionOptionsFunc(version, dimension)
 }
 
 // GetDimensionOptionsCalls gets all the calls that were made to GetDimensionOptions.
 // Check the length with:
 //     len(mockedStorer.GetDimensionOptionsCalls())
 func (mock *StorerMock) GetDimensionOptionsCalls() []struct {
-	DatasetID string
-	EditionID string
-	VersionID string
+	Version   *models.Version
 	Dimension string
 } {
 	var calls []struct {
-		DatasetID string
-		EditionID string
-		VersionID string
+		Version   *models.Version
 		Dimension string
 	}
 	lockStorerMockGetDimensionOptions.RLock()


### PR DESCRIPTION
### What

Updated the getDimensionOptions handler to use authentication to determine which version documents, and by extension dimension options, a user is allowed to access.

### How to review

Check authenticated requests can access unpublished documents, but when authentication fails only published documents can be accessed.

With:
https://github.com/ONSdigital/dp-api-tests/pull/36
https://github.com/ONSdigital/dp-filter-api/pull/56

### Who can review

Anyone
