### PR TITLE
Updates to dataset details reset the state if it was published

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -367,7 +367,14 @@ func (api *DatasetAPI) putDataset(w http.ResponseWriter, r *http.Request) {
 	}
 	defer r.Body.Close()
 
-	if err := api.dataStore.Backend.UpdateDataset(datasetID, dataset); err != nil {
+	currentDataset, err := api.dataStore.Backend.GetDataset(datasetID)
+	if err != nil {
+		log.ErrorC("failed to find dataset", err, log.Data{"dataset_id": datasetID})
+		handleErrorType(datasetDocType, err, w)
+		return
+	}
+
+	if err := api.dataStore.Backend.UpdateDataset(datasetID, dataset, currentDataset.Next.State); err != nil {
 		log.ErrorC("failed to update dataset resource", err, log.Data{"dataset_id": datasetID})
 		handleErrorType(datasetDocType, err, w)
 		return

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -374,10 +374,18 @@ func (api *DatasetAPI) putDataset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := api.dataStore.Backend.UpdateDataset(datasetID, dataset, currentDataset.Next.State); err != nil {
-		log.ErrorC("failed to update dataset resource", err, log.Data{"dataset_id": datasetID})
-		handleErrorType(datasetDocType, err, w)
-		return
+	if dataset.State == models.PublishedState {
+		if err := api.publishDataset(currentDataset, nil); err != nil {
+			log.ErrorC("failed to update dataset document to published", err, log.Data{"dataset_id": datasetID})
+			handleErrorType(versionDocType, err, w)
+			return
+		}
+	} else {
+		if err := api.dataStore.Backend.UpdateDataset(datasetID, dataset, currentDataset.Next.State); err != nil {
+			log.ErrorC("failed to update dataset resource", err, log.Data{"dataset_id": datasetID})
+			handleErrorType(datasetDocType, err, w)
+			return
+		}
 	}
 
 	setJSONContentType(w)
@@ -399,7 +407,8 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = api.dataStore.Backend.CheckDatasetExists(datasetID, ""); err != nil {
+	currentDataset, err := api.dataStore.Backend.GetDataset(datasetID)
+	if err != nil {
 		log.ErrorC("failed to find dataset", err, log.Data{"dataset_id": datasetID, "edition": edition, "version": version})
 		handleErrorType(versionDocType, err, w)
 		return
@@ -442,7 +451,7 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Pass in newVersion variable to include relevant data needed for update on dataset API (e.g. links)
-		if err := api.publishDataset(datasetID, newVersion); err != nil {
+		if err := api.publishDataset(currentDataset, newVersion); err != nil {
 			log.ErrorC("failed to update dataset document once version state changes to publish", err, log.Data{"dataset_id": datasetID, "edition": edition, "version": version})
 			handleErrorType(versionDocType, err, w)
 			return
@@ -586,18 +595,14 @@ func createNewVersionDoc(currentVersion *models.Version, version *models.Version
 	return version
 }
 
-func (api *DatasetAPI) publishDataset(id string, version *models.Version) error {
-	currentDataset, err := api.dataStore.Backend.GetDataset(id)
-	if err != nil {
-		log.ErrorC("unable to update dataset", err, log.Data{"dataset_id": id})
-		return err
-	}
+func (api *DatasetAPI) publishDataset(currentDataset *models.DatasetUpdate, version *models.Version) error {
+	if version != nil {
+		currentDataset.Next.CollectionID = version.CollectionID
 
-	currentDataset.Next.CollectionID = version.CollectionID
-
-	currentDataset.Next.Links.LatestVersion = &models.LinkObject{
-		ID:   version.Links.Version.ID,
-		HRef: version.Links.Version.HRef,
+		currentDataset.Next.Links.LatestVersion = &models.LinkObject{
+			ID:   version.Links.Version.ID,
+			HRef: version.Links.Version.HRef,
+		}
 	}
 
 	currentDataset.Next.State = models.PublishedState
@@ -613,8 +618,8 @@ func (api *DatasetAPI) publishDataset(id string, version *models.Version) error 
 		Next:    currentDataset.Next,
 	}
 
-	if err := api.dataStore.Backend.UpsertDataset(id, newDataset); err != nil {
-		log.ErrorC("unable to update dataset", err, log.Data{"dataset_id": id})
+	if err := api.dataStore.Backend.UpsertDataset(currentDataset.ID, newDataset); err != nil {
+		log.ErrorC("unable to update dataset", err, log.Data{"dataset_id": currentDataset.ID})
 		return err
 	}
 

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -311,30 +311,18 @@ func (api *DatasetAPI) addDataset(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	dataset.State = models.CreatedState
-
-	var accessRights string
-	if dataset.Links != nil {
-		if dataset.Links.AccessRights != nil {
-			if dataset.Links.AccessRights.HRef != "" {
-				accessRights = dataset.Links.AccessRights.HRef
-			}
-		}
-	}
-
 	dataset.ID = datasetID
-	dataset.Links = &models.DatasetLinks{
-		Editions: &models.LinkObject{
-			HRef: fmt.Sprintf("%s/datasets/%s/editions", api.host, datasetID),
-		},
-		Self: &models.LinkObject{
-			HRef: fmt.Sprintf("%s/datasets/%s", api.host, datasetID),
-		},
+
+	if dataset.Links == nil {
+		dataset.Links = &models.DatasetLinks{}
 	}
 
-	if accessRights != "" {
-		dataset.Links.AccessRights = &models.LinkObject{
-			HRef: accessRights,
-		}
+	dataset.Links.Editions = &models.LinkObject{
+		HRef: fmt.Sprintf("%s/datasets/%s/editions", api.host, datasetID),
+	}
+
+	dataset.Links.Self = &models.LinkObject{
+		HRef: fmt.Sprintf("%s/datasets/%s", api.host, datasetID),
 	}
 
 	dataset.LastUpdated = time.Now()
@@ -598,30 +586,13 @@ func (api *DatasetAPI) publishDataset(id string, version *models.Version) error 
 		return err
 	}
 
-	var accessRights string
-
-	if currentDataset.Next.Links != nil {
-		if currentDataset.Next.Links.AccessRights != nil {
-			accessRights = currentDataset.Next.Links.AccessRights.HRef
-		}
-	}
-
 	currentDataset.Next.CollectionID = version.CollectionID
-	currentDataset.Next.Links = &models.DatasetLinks{
-		AccessRights: &models.LinkObject{
-			HRef: accessRights,
-		},
-		Editions: &models.LinkObject{
-			HRef: fmt.Sprintf("%s/datasets/%s/editions", api.host, version.Links.Dataset.ID),
-		},
-		LatestVersion: &models.LinkObject{
-			ID:   version.Links.Version.ID,
-			HRef: version.Links.Version.HRef,
-		},
-		Self: &models.LinkObject{
-			HRef: fmt.Sprintf("%s/datasets/%s", api.host, version.Links.Dataset.ID),
-		},
+
+	currentDataset.Next.Links.LatestVersion = &models.LinkObject{
+		ID:   version.Links.Version.ID,
+		HRef: version.Links.Version.HRef,
 	}
+
 	currentDataset.Next.State = models.PublishedState
 	currentDataset.Next.LastUpdated = time.Now()
 

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -903,8 +903,8 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		mockedDataStore := &storetest.StorerMock{
-			CheckDatasetExistsFunc: func(string, string) error {
-				return nil
+			GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
 			},
 			CheckEditionExistsFunc: func(string, string, string) error {
 				return nil
@@ -943,7 +943,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
-		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 3)
 		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 2)
@@ -968,8 +968,8 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		mockedDataStore := &storetest.StorerMock{
-			CheckDatasetExistsFunc: func(string, string) error {
-				return nil
+			GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
 			},
 			CheckEditionExistsFunc: func(string, string, string) error {
 				return nil
@@ -994,7 +994,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
-		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 3)
 		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 2)
@@ -1022,8 +1022,8 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		mockedDataStore := &storetest.StorerMock{
-			CheckDatasetExistsFunc: func(string, string) error {
-				return nil
+			GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
 			},
 			CheckEditionExistsFunc: func(string, string, string) error {
 				return nil
@@ -1054,7 +1054,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		}
 
 		So(w.Code, ShouldEqual, http.StatusOK)
-		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
 		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 1)
@@ -1079,9 +1079,6 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		mockedDataStore := &storetest.StorerMock{
-			CheckDatasetExistsFunc: func(string, string) error {
-				return nil
-			},
 			CheckEditionExistsFunc: func(string, string, string) error {
 				return nil
 			},
@@ -1137,7 +1134,6 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
-		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 3)
 		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 2)
@@ -1161,8 +1157,8 @@ func TestPutVersionGenerateDownloadsError(t *testing.T) {
 			GetVersionFunc: func(datasetID string, editionID string, version string, state string) (*models.Version, error) {
 				return &v, nil
 			},
-			CheckDatasetExistsFunc: func(ID string, state string) error {
-				return nil
+			GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
 			},
 			CheckEditionExistsFunc: func(ID string, editionID string, state string) error {
 				return nil
@@ -1196,8 +1192,8 @@ func TestPutVersionGenerateDownloadsError(t *testing.T) {
 			Convey("and the expected store calls are made with the expected parameters", func() {
 				genCalls := mockDownloadGenerator.GenerateCalls()
 
-				So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
-				So(mockedDataStore.CheckDatasetExistsCalls()[0].ID, ShouldEqual, "123")
+				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+				So(mockedDataStore.GetDatasetCalls()[0].ID, ShouldEqual, "123")
 
 				So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 				So(mockedDataStore.CheckEditionExistsCalls()[0].ID, ShouldEqual, "123")
@@ -1230,8 +1226,8 @@ func TestPutEmptyVersion(t *testing.T) {
 			GetVersionFunc: func(datasetID string, editionID string, version string, state string) (*models.Version, error) {
 				return &v, nil
 			},
-			CheckDatasetExistsFunc: func(ID string, state string) error {
-				return nil
+			GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
 			},
 			CheckEditionExistsFunc: func(ID string, editionID string, state string) error {
 				return nil
@@ -1267,8 +1263,8 @@ func TestPutEmptyVersion(t *testing.T) {
 				v.Downloads = xlsDownload
 				return &v, nil
 			},
-			CheckDatasetExistsFunc: func(ID string, state string) error {
-				return nil
+			GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
 			},
 			CheckEditionExistsFunc: func(ID string, editionID string, state string) error {
 				return nil
@@ -1298,9 +1294,8 @@ func TestPutEmptyVersion(t *testing.T) {
 			})
 
 			Convey("and the expected external calls are made with the correct parameters", func() {
-				So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
-				So(mockedDataStore.CheckDatasetExistsCalls()[0].ID, ShouldEqual, "123")
-				So(mockedDataStore.CheckDatasetExistsCalls()[0].State, ShouldEqual, "")
+				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+				So(mockedDataStore.GetDatasetCalls()[0].ID, ShouldEqual, "123")
 
 				So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 				So(mockedDataStore.CheckEditionExistsCalls()[0].ID, ShouldEqual, "123")
@@ -1340,8 +1335,8 @@ func TestPutVersionReturnsError(t *testing.T) {
 			GetVersionFunc: func(string, string, string, string) (*models.Version, error) {
 				return &models.Version{State: models.AssociatedState}, nil
 			},
-			CheckDatasetExistsFunc: func(string, string) error {
-				return nil
+			GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
 			},
 		}
 
@@ -1350,7 +1345,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldEqual, "Failed to parse json body\n")
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 	})
 
@@ -1371,8 +1366,8 @@ func TestPutVersionReturnsError(t *testing.T) {
 			GetVersionFunc: func(string, string, string, string) (*models.Version, error) {
 				return nil, errInternal
 			},
-			CheckDatasetExistsFunc: func(string, string) error {
-				return nil
+			GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
 			},
 		}
 
@@ -1381,7 +1376,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(w.Body.String(), ShouldEqual, "internal error\n")
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 	})
 
@@ -1402,8 +1397,8 @@ func TestPutVersionReturnsError(t *testing.T) {
 			GetVersionFunc: func(string, string, string, string) (*models.Version, error) {
 				return &models.Version{}, errs.ErrVersionNotFound
 			},
-			CheckDatasetExistsFunc: func(string, string) error {
-				return errs.ErrDatasetNotFound
+			GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
+				return nil, errs.ErrDatasetNotFound
 			},
 			CheckEditionExistsFunc: func(string, string, string) error {
 				return nil
@@ -1415,7 +1410,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(w.Body.String(), ShouldEqual, "Dataset not found\n")
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 	})
@@ -1437,8 +1432,8 @@ func TestPutVersionReturnsError(t *testing.T) {
 			GetVersionFunc: func(string, string, string, string) (*models.Version, error) {
 				return &models.Version{}, errs.ErrVersionNotFound
 			},
-			CheckDatasetExistsFunc: func(string, string) error {
-				return nil
+			GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
 			},
 			CheckEditionExistsFunc: func(string, string, string) error {
 				return errs.ErrEditionNotFound
@@ -1450,7 +1445,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(w.Body.String(), ShouldEqual, "Edition not found\n")
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 	})
@@ -1472,8 +1467,8 @@ func TestPutVersionReturnsError(t *testing.T) {
 			GetVersionFunc: func(string, string, string, string) (*models.Version, error) {
 				return &models.Version{}, errs.ErrVersionNotFound
 			},
-			CheckDatasetExistsFunc: func(string, string) error {
-				return nil
+			GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
 			},
 			CheckEditionExistsFunc: func(string, string, string) error {
 				return nil
@@ -1488,7 +1483,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(w.Body.String(), ShouldEqual, "Version not found\n")
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
-		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
@@ -1541,8 +1536,8 @@ func TestPutVersionReturnsError(t *testing.T) {
 					State: models.PublishedState,
 				}, nil
 			},
-			CheckDatasetExistsFunc: func(string, string) error {
-				return nil
+			GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
 			},
 		}
 
@@ -1551,7 +1546,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 		So(w.Body.String(), ShouldEqual, "unable to update version as it has been published\n")
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
 	})
 
 	Convey("When the request body is invalid return status bad request", t, func() {
@@ -1571,8 +1566,8 @@ func TestPutVersionReturnsError(t *testing.T) {
 			GetVersionFunc: func(string, string, string, string) (*models.Version, error) {
 				return &models.Version{State: "associated"}, nil
 			},
-			CheckDatasetExistsFunc: func(string, string) error {
-				return nil
+			GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
 			},
 			CheckEditionExistsFunc: func(string, string, string) error {
 				return nil
@@ -1587,7 +1582,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(w.Body.String(), ShouldEqual, "Missing collection_id for association between version and a collection\n")
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
-		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -1105,8 +1105,8 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 				return &models.DatasetUpdate{
 					ID:      "123",
-					Next:    &models.Dataset{},
-					Current: &models.Dataset{},
+					Next:    &models.Dataset{Links: &models.DatasetLinks{}},
+					Current: &models.Dataset{Links: &models.DatasetLinks{}},
 				}, nil
 			},
 			UpsertDatasetFunc: func(string, *models.DatasetUpdate) error {

--- a/mongo/dataset_test.go
+++ b/mongo/dataset_test.go
@@ -226,7 +226,7 @@ func TestDatasetUpdateQuery(t *testing.T) {
 			URI:              "http://ons.gov.uk/dataset/123/landing-page",
 		}
 
-		selector := createDatasetUpdateQuery("123", dataset)
+		selector := createDatasetUpdateQuery("123", dataset, models.CreatedState)
 		So(selector, ShouldNotBeNil)
 		So(selector, ShouldResemble, expectedUpdate)
 	})
@@ -239,7 +239,7 @@ func TestDatasetUpdateQuery(t *testing.T) {
 		expectedUpdate := bson.M{
 			"next.national_statistic": &nationalStatistic,
 		}
-		selector := createDatasetUpdateQuery("123", dataset)
+		selector := createDatasetUpdateQuery("123", dataset, models.CreatedState)
 		So(selector, ShouldNotBeNil)
 		So(selector, ShouldResemble, expectedUpdate)
 	})
@@ -247,7 +247,7 @@ func TestDatasetUpdateQuery(t *testing.T) {
 	Convey("When national statistic is not set", t, func() {
 		dataset := &models.Dataset{}
 
-		selector := createDatasetUpdateQuery("123", dataset)
+		selector := createDatasetUpdateQuery("123", dataset, models.CreatedState)
 		So(selector, ShouldNotBeNil)
 		So(selector, ShouldResemble, bson.M{})
 	})

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -35,7 +35,7 @@ type Storer interface {
 	GetUniqueDimensionValues(ID, dimension string) (*models.DimensionValues, error)
 	GetVersion(datasetID, editionID, version, state string) (*models.Version, error)
 	GetVersions(datasetID, editionID, state string) (*models.VersionResults, error)
-	UpdateDataset(ID string, dataset *models.Dataset) error
+	UpdateDataset(ID string, dataset *models.Dataset, currentState string) error
 	UpdateDatasetWithAssociation(ID, state string, version *models.Version) error
 	UpdateDimensionNodeID(dimension *models.DimensionOption) error
 	UpdateEdition(datasetID, edition string, latestVersion *models.Version) error

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -116,7 +116,7 @@ var (
 //             UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
 // 	               panic("TODO: mock out the UpdateBuildSearchTaskState method")
 //             },
-//             UpdateDatasetFunc: func(ID string, dataset *models.Dataset) error {
+//             UpdateDatasetFunc: func(ID string, dataset *models.Dataset, currentState string) error {
 // 	               panic("TODO: mock out the UpdateDataset method")
 //             },
 //             UpdateDatasetWithAssociationFunc: func(ID string, state string, version *models.Version) error {
@@ -223,7 +223,7 @@ type StorerMock struct {
 	UpdateBuildSearchTaskStateFunc func(id string, dimension string, state string) error
 
 	// UpdateDatasetFunc mocks the UpdateDataset method.
-	UpdateDatasetFunc func(ID string, dataset *models.Dataset) error
+	UpdateDatasetFunc func(ID string, dataset *models.Dataset, currentState string) error
 
 	// UpdateDatasetWithAssociationFunc mocks the UpdateDatasetWithAssociation method.
 	UpdateDatasetWithAssociationFunc func(ID string, state string, version *models.Version) error
@@ -387,8 +387,8 @@ type StorerMock struct {
 		}
 		// UpdateBuildHierarchyTaskState holds details about calls to the UpdateBuildHierarchyTaskState method.
 		UpdateBuildHierarchyTaskState []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the id argument value.
+			ID string
 			// Dimension is the dimension argument value.
 			Dimension string
 			// State is the state argument value.
@@ -396,8 +396,8 @@ type StorerMock struct {
 		}
 		// UpdateBuildSearchTaskState holds details about calls to the UpdateBuildSearchTaskState method.
 		UpdateBuildSearchTaskState []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the id argument value.
+			ID string
 			// Dimension is the dimension argument value.
 			Dimension string
 			// State is the state argument value.
@@ -409,6 +409,8 @@ type StorerMock struct {
 			ID string
 			// Dataset is the dataset argument value.
 			Dataset *models.Dataset
+			// CurrentState is the currentState argument value.
+			CurrentState string
 		}
 		// UpdateDatasetWithAssociation holds details about calls to the UpdateDatasetWithAssociation method.
 		UpdateDatasetWithAssociation []struct {
@@ -435,8 +437,8 @@ type StorerMock struct {
 		}
 		// UpdateImportObservationsTaskState holds details about calls to the UpdateImportObservationsTaskState method.
 		UpdateImportObservationsTaskState []struct {
-			// Id is the id argument value.
-			Id string
+			// ID is the id argument value.
+			ID string
 			// State is the state argument value.
 			State string
 		}
@@ -1148,11 +1150,11 @@ func (mock *StorerMock) UpdateBuildHierarchyTaskState(id string, dimension strin
 		panic("moq: StorerMock.UpdateBuildHierarchyTaskStateFunc is nil but Storer.UpdateBuildHierarchyTaskState was just called")
 	}
 	callInfo := struct {
-		Id        string
+		ID        string
 		Dimension string
 		State     string
 	}{
-		Id:        id,
+		ID:        id,
 		Dimension: dimension,
 		State:     state,
 	}
@@ -1166,12 +1168,12 @@ func (mock *StorerMock) UpdateBuildHierarchyTaskState(id string, dimension strin
 // Check the length with:
 //     len(mockedStorer.UpdateBuildHierarchyTaskStateCalls())
 func (mock *StorerMock) UpdateBuildHierarchyTaskStateCalls() []struct {
-	Id        string
+	ID        string
 	Dimension string
 	State     string
 } {
 	var calls []struct {
-		Id        string
+		ID        string
 		Dimension string
 		State     string
 	}
@@ -1187,11 +1189,11 @@ func (mock *StorerMock) UpdateBuildSearchTaskState(id string, dimension string, 
 		panic("moq: StorerMock.UpdateBuildSearchTaskStateFunc is nil but Storer.UpdateBuildSearchTaskState was just called")
 	}
 	callInfo := struct {
-		Id        string
+		ID        string
 		Dimension string
 		State     string
 	}{
-		Id:        id,
+		ID:        id,
 		Dimension: dimension,
 		State:     state,
 	}
@@ -1205,12 +1207,12 @@ func (mock *StorerMock) UpdateBuildSearchTaskState(id string, dimension string, 
 // Check the length with:
 //     len(mockedStorer.UpdateBuildSearchTaskStateCalls())
 func (mock *StorerMock) UpdateBuildSearchTaskStateCalls() []struct {
-	Id        string
+	ID        string
 	Dimension string
 	State     string
 } {
 	var calls []struct {
-		Id        string
+		ID        string
 		Dimension string
 		State     string
 	}
@@ -1221,33 +1223,37 @@ func (mock *StorerMock) UpdateBuildSearchTaskStateCalls() []struct {
 }
 
 // UpdateDataset calls UpdateDatasetFunc.
-func (mock *StorerMock) UpdateDataset(ID string, dataset *models.Dataset) error {
+func (mock *StorerMock) UpdateDataset(ID string, dataset *models.Dataset, currentState string) error {
 	if mock.UpdateDatasetFunc == nil {
 		panic("moq: StorerMock.UpdateDatasetFunc is nil but Storer.UpdateDataset was just called")
 	}
 	callInfo := struct {
-		ID      string
-		Dataset *models.Dataset
+		ID           string
+		Dataset      *models.Dataset
+		CurrentState string
 	}{
-		ID:      ID,
-		Dataset: dataset,
+		ID:           ID,
+		Dataset:      dataset,
+		CurrentState: currentState,
 	}
 	lockStorerMockUpdateDataset.Lock()
 	mock.calls.UpdateDataset = append(mock.calls.UpdateDataset, callInfo)
 	lockStorerMockUpdateDataset.Unlock()
-	return mock.UpdateDatasetFunc(ID, dataset)
+	return mock.UpdateDatasetFunc(ID, dataset, currentState)
 }
 
 // UpdateDatasetCalls gets all the calls that were made to UpdateDataset.
 // Check the length with:
 //     len(mockedStorer.UpdateDatasetCalls())
 func (mock *StorerMock) UpdateDatasetCalls() []struct {
-	ID      string
-	Dataset *models.Dataset
+	ID           string
+	Dataset      *models.Dataset
+	CurrentState string
 } {
 	var calls []struct {
-		ID      string
-		Dataset *models.Dataset
+		ID           string
+		Dataset      *models.Dataset
+		CurrentState string
 	}
 	lockStorerMockUpdateDataset.RLock()
 	calls = mock.calls.UpdateDataset
@@ -1370,10 +1376,10 @@ func (mock *StorerMock) UpdateImportObservationsTaskState(id string, state strin
 		panic("moq: StorerMock.UpdateImportObservationsTaskStateFunc is nil but Storer.UpdateImportObservationsTaskState was just called")
 	}
 	callInfo := struct {
-		Id    string
+		ID    string
 		State string
 	}{
-		Id:    id,
+		ID:    id,
 		State: state,
 	}
 	lockStorerMockUpdateImportObservationsTaskState.Lock()
@@ -1386,11 +1392,11 @@ func (mock *StorerMock) UpdateImportObservationsTaskState(id string, state strin
 // Check the length with:
 //     len(mockedStorer.UpdateImportObservationsTaskStateCalls())
 func (mock *StorerMock) UpdateImportObservationsTaskStateCalls() []struct {
-	Id    string
+	ID    string
 	State string
 } {
 	var calls []struct {
-		Id    string
+		ID    string
 		State string
 	}
 	lockStorerMockUpdateImportObservationsTaskState.RLock()


### PR DESCRIPTION
### What

When the last change to a dataset 'next' doc was the publish step, force the state to be changed to created alongside user defined changes if the user is not providing an alternative state. 

### How to review

Check states can be changed and documents can be published as before
Check acceptance tests pass - https://github.com/ONSdigital/dp-api-tests/pull/40

### Who can review

anyone