### PR TITLE
Feature/hide auth endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -97,9 +97,9 @@ func routes(host, secretKey string, router *mux.Router, dataStore store.DataStor
 	api.router.HandleFunc("/instances/{id}/import_tasks", api.privateAuth.Check(instancePublishChecker.Check(instanceAPI.UpdateImportTask))).Methods("PUT")
 
 	dimension := dimension.Store{Storer: api.dataStore.Backend}
-	api.router.HandleFunc("/instances/{id}/dimensions", dimension.GetNodes).Methods("GET")
+	api.router.HandleFunc("/instances/{id}/dimensions", api.privateAuth.Check(dimension.GetNodes)).Methods("GET")
 	api.router.HandleFunc("/instances/{id}/dimensions", api.privateAuth.Check(instancePublishChecker.Check(dimension.Add))).Methods("POST")
-	api.router.HandleFunc("/instances/{id}/dimensions/{dimension}/options", dimension.GetUnique).Methods("GET")
+	api.router.HandleFunc("/instances/{id}/dimensions/{dimension}/options", api.privateAuth.Check(dimension.GetUnique)).Methods("GET")
 	api.router.HandleFunc("/instances/{id}/dimensions/{dimension}/options/{value}/node_id/{node_id}",
 		api.privateAuth.Check(instancePublishChecker.Check(dimension.AddNodeID))).Methods("PUT")
 

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -837,7 +837,7 @@ func (api *DatasetAPI) getMetadata(w http.ResponseWriter, r *http.Request) {
 		// Check for current sub document
 		if datasetDoc.Current == nil || datasetDoc.Current.State != models.PublishedState {
 			log.ErrorC("found dataset but currently unpublished", errs.ErrDatasetNotFound, log.Data{"dataset_id": datasetID, "edition": edition, "version": version, "dataset": datasetDoc.Current})
-			http.Error(w, errs.ErrDatasetNotFound.Error(), http.StatusBadRequest)
+			http.Error(w, errs.ErrDatasetNotFound.Error(), http.StatusNotFound)
 			return
 		}
 

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store"
 	"github.com/ONSdigital/dp-dataset-api/store/datastoretest"
-	"github.com/ONSdigital/go-ns/log"
+	"github.com/ian-kent/go-log/log"
 
 	"github.com/ONSdigital/dp-dataset-api/url"
 	"github.com/gorilla/mux"
@@ -155,7 +155,9 @@ func TestGetDatasetReturnsError(t *testing.T) {
 
 	Convey("When there is no dataset document return status 404", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456", nil)
+		r.Header.Add("internal-token", "coffee")
 		w := httptest.NewRecorder()
+
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(id string) (*models.DatasetUpdate, error) {
 				return nil, errs.ErrDatasetNotFound
@@ -206,11 +208,13 @@ func TestGetEditionsReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldResemble, "internal error\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
 	})
 
-	Convey("When the dataset does not exist return status bad request", t, func() {
+	Convey("When the dataset does not exist return status not found", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions", nil)
 		r.Header.Add("internal-token", "coffee")
 		w := httptest.NewRecorder()
@@ -222,7 +226,9 @@ func TestGetEditionsReturnsError(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Dataset not found\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
 	})
@@ -243,6 +249,8 @@ func TestGetEditionsReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Edition not found\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 1)
 	})
@@ -262,6 +270,8 @@ func TestGetEditionsReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Edition not found\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 1)
 	})
@@ -303,11 +313,13 @@ func TestGetEditionReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldResemble, "internal error\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 0)
 	})
 
-	Convey("When the dataset does not exist return status bad request", t, func() {
+	Convey("When the dataset does not exist return status not found", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678", nil)
 		r.Header.Add("internal-token", "coffee")
 		w := httptest.NewRecorder()
@@ -319,7 +331,9 @@ func TestGetEditionReturnsError(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Dataset not found\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 0)
 	})
@@ -340,6 +354,8 @@ func TestGetEditionReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Edition not found\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
 	})
@@ -359,6 +375,8 @@ func TestGetEditionReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Edition not found\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
 	})
@@ -404,12 +422,14 @@ func TestGetVersionsReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldResemble, "internal error\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.GetVersionsCalls()), ShouldEqual, 0)
 	})
 
-	Convey("When the dataset does not exist return status bad request", t, func() {
+	Convey("When the dataset does not exist return status not found", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678/versions", nil)
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -420,13 +440,15 @@ func TestGetVersionsReturnsError(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Dataset not found\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.GetVersionsCalls()), ShouldEqual, 0)
 	})
 
-	Convey("When the edition of a dataset does not exist return status bad request", t, func() {
+	Convey("When the edition of a dataset does not exist return status not found", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678/versions", nil)
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -440,7 +462,9 @@ func TestGetVersionsReturnsError(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Edition not found\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetVersionsCalls()), ShouldEqual, 0)
@@ -465,6 +489,8 @@ func TestGetVersionsReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Version not found\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetVersionsCalls()), ShouldEqual, 1)
@@ -488,6 +514,36 @@ func TestGetVersionsReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Version not found\n")
+
+		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetVersionsCalls()), ShouldEqual, 1)
+	})
+
+	Convey("When a published version has an incorrect state for an edition of a dataset return an internal error", t, func() {
+		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678/versions", nil)
+		w := httptest.NewRecorder()
+
+		version := models.Version{State: "gobbly-gook"}
+		items := []models.Version{version}
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(datasetID, state string) error {
+				return nil
+			},
+			CheckEditionExistsFunc: func(datasetID, editionID, state string) error {
+				return nil
+			},
+			GetVersionsFunc: func(datasetID, editionID, state string) (*models.VersionResults, error) {
+				return &models.VersionResults{Items: items}, nil
+			},
+		}
+
+		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldResemble, "Incorrect resource state\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetVersionsCalls()), ShouldEqual, 1)
@@ -509,6 +565,7 @@ func TestGetVersionReturnsOK(t *testing.T) {
 			},
 			GetVersionFunc: func(datasetID, editionID, version, state string) (*models.Version, error) {
 				return &models.Version{
+					State: models.EditionConfirmedState,
 					Links: &models.VersionLinks{
 						Self: &models.LinkObject{},
 						Version: &models.LinkObject{
@@ -542,10 +599,12 @@ func TestGetVersionReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldResemble, "internal error\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 	})
 
-	Convey("When the dataset does not exist for return status bad request", t, func() {
+	Convey("When the dataset does not exist for return status not found", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678/versions/1", nil)
 		r.Header.Add("internal_token", "coffee")
 		w := httptest.NewRecorder()
@@ -557,13 +616,15 @@ func TestGetVersionReturnsError(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Dataset not found\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 0)
 	})
 
-	Convey("When the edition of a dataset does not exist return status bad request", t, func() {
+	Convey("When the edition of a dataset does not exist return status not found", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678/versions/1", nil)
 		r.Header.Add("internal_token", "coffee")
 		w := httptest.NewRecorder()
@@ -578,7 +639,9 @@ func TestGetVersionReturnsError(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Edition not found\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 0)
@@ -603,6 +666,8 @@ func TestGetVersionReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Version not found\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
@@ -626,6 +691,43 @@ func TestGetVersionReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Version not found\n")
+
+		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
+	})
+
+	Convey("When an unpublished version has an incorrect state for an edition of a dataset return an internal error", t, func() {
+		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678/versions/1", nil)
+		r.Header.Add("internal_token", "coffee")
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(datasetID, state string) error {
+				return nil
+			},
+			CheckEditionExistsFunc: func(datasetID, editionID, state string) error {
+				return nil
+			},
+			GetVersionFunc: func(datasetID, editionID, version, state string) (*models.Version, error) {
+				return &models.Version{
+					State: "gobbly-gook",
+					Links: &models.VersionLinks{
+						Self: &models.LinkObject{},
+						Version: &models.LinkObject{
+							HRef: "href",
+						},
+					},
+				}, nil
+			},
+		}
+
+		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldResemble, "Incorrect resource state\n")
+
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
@@ -678,6 +780,8 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Body.String(), ShouldResemble, "Failed to parse json body\n")
+
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 	})
@@ -700,11 +804,13 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldResemble, "internal error\n")
+
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 	})
 
-	Convey("When the request does not contain a valid internal token return status unauthorised", t, func() {
+	Convey("When the request does not contain a valid internal token return status not found", t, func() {
 		var b string
 		b = datasetPayload
 		r := httptest.NewRequest("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
@@ -720,7 +826,9 @@ func TestPostDatasetReturnsError(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusUnauthorized)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Resource not found\n")
+
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 	})
@@ -747,6 +855,8 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
+		So(w.Body.String(), ShouldResemble, "forbidden - dataset already exists\n")
+
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 	})
@@ -798,6 +908,8 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Body.String(), ShouldResemble, "Failed to parse json body\n")
+
 		So(len(mockedDataStore.UpsertVersionCalls()), ShouldEqual, 0)
 	})
 
@@ -823,6 +935,8 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldResemble, "internal error\n")
+
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 2)
 	})
 
@@ -848,10 +962,12 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Dataset not found\n")
+
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 2)
 	})
 
-	Convey("When the request does not contain a valid internal token return status unauthorised", t, func() {
+	Convey("When the request does not contain a valid internal token return status not found", t, func() {
 		var b string
 		b = "{\"edition\":\"2017\",\"state\":\"created\",\"license\":\"ONS\",\"release_date\":\"2017-04-04\",\"version\":\"1\"}"
 		r, err := http.NewRequest("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
@@ -866,7 +982,9 @@ func TestPutDatasetReturnsError(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusUnauthorized)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldResemble, "Resource not found\n")
+
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 0)
 	})
 }
@@ -1332,8 +1450,9 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock)
 		api.router.ServeHTTP(w, r)
-		So(w.Body.String(), ShouldEqual, "Failed to parse json body\n")
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Body.String(), ShouldEqual, "Failed to parse json body\n")
+
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
@@ -1365,12 +1484,13 @@ func TestPutVersionReturnsError(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(w.Body.String(), ShouldEqual, "internal error\n")
+
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 	})
 
-	Convey("When the dataset document cannot be found for version return status bad request", t, func() {
+	Convey("When the dataset document cannot be found for version return status not found", t, func() {
 		generatorMock := &mocks.DownloadsGeneratorMock{
 			GenerateFunc: func(datasetID string, edition string, versionID string, version string) error {
 				return nil
@@ -1397,15 +1517,16 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock)
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(w.Body.String(), ShouldEqual, "Dataset not found\n")
+
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 	})
 
-	Convey("When the edition document cannot be found for version return status bad request", t, func() {
+	Convey("When the edition document cannot be found for version return status not found", t, func() {
 		generatorMock := &mocks.DownloadsGeneratorMock{
 			GenerateFunc: func(string, string, string, string) error {
 				return nil
@@ -1432,8 +1553,9 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock)
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(w.Body.String(), ShouldEqual, "Edition not found\n")
+
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
@@ -1472,6 +1594,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(w.Body.String(), ShouldEqual, "Version not found\n")
+
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
@@ -1479,7 +1602,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 	})
 
-	Convey("When the request does not contain a valid internal token return status unauthorised", t, func() {
+	Convey("When the request does not contain a valid internal token return status not found", t, func() {
 		generatorMock := &mocks.DownloadsGeneratorMock{
 			GenerateFunc: func(string, string, string, string) error {
 				return nil
@@ -1501,8 +1624,9 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock)
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusUnauthorized)
-		So(w.Body.String(), ShouldEqual, "No authentication header provided\n")
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldEqual, "Resource not found\n")
+
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 	})
@@ -1535,6 +1659,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 		So(w.Body.String(), ShouldEqual, "unable to update version as it has been published\n")
+
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 0)
 	})
@@ -1571,6 +1696,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(w.Body.String(), ShouldEqual, "Missing collection_id for association between version and a collection\n")
+
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
@@ -1586,7 +1712,7 @@ func TestGetDimensionsReturnsOk(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetVersionFunc: func(datasetID, edition, version, state string) (*models.Version, error) {
-				return &models.Version{}, nil
+				return &models.Version{State: models.AssociatedState}, nil
 			},
 			GetDimensionsFunc: func(datasetID, versionID string) ([]bson.M, error) {
 				return []bson.M{}, nil
@@ -1621,7 +1747,7 @@ func TestGetDimensionsReturnsErrors(t *testing.T) {
 		So(len(mockedDataStore.GetDimensionsCalls()), ShouldEqual, 0)
 	})
 
-	Convey("When the request contain an invalid version return bad request error", t, func() {
+	Convey("When the request contain an invalid version return not found", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/dimensions", nil)
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1632,7 +1758,7 @@ func TestGetDimensionsReturnsErrors(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(w.Body.String(), ShouldEqual, "Version not found\n")
 
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
@@ -1644,7 +1770,7 @@ func TestGetDimensionsReturnsErrors(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetVersionFunc: func(datasetID, edition, version, state string) (*models.Version, error) {
-				return &models.Version{}, nil
+				return &models.Version{State: models.AssociatedState}, nil
 			},
 			GetDimensionsFunc: func(datasetID, versionID string) ([]bson.M, error) {
 				return nil, errs.ErrDimensionsNotFound
@@ -1659,6 +1785,24 @@ func TestGetDimensionsReturnsErrors(t *testing.T) {
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetDimensionsCalls()), ShouldEqual, 1)
 	})
+
+	Convey("When the version has an invalid state return internal server error", t, func() {
+		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/dimensions", nil)
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetVersionFunc: func(datasetID, edition, version, state string) (*models.Version, error) {
+				return &models.Version{State: "gobbly-gook"}, nil
+			},
+		}
+
+		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldEqual, "Incorrect resource state\n")
+
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDimensionsCalls()), ShouldEqual, 0)
+	})
 }
 
 func TestGetDimensionOptionsReturnsOk(t *testing.T) {
@@ -1668,7 +1812,7 @@ func TestGetDimensionOptionsReturnsOk(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetVersionFunc: func(datasetID, edition, version, state string) (*models.Version, error) {
-				return &models.Version{}, nil
+				return &models.Version{State: models.AssociatedState}, nil
 			},
 			GetDimensionOptionsFunc: func(version *models.Version, dimensions string) (*models.DimensionOptionResults, error) {
 				return &models.DimensionOptionResults{}, nil
@@ -1695,6 +1839,10 @@ func TestGetDimensionOptionsReturnsErrors(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldEqual, "Version not found\n")
+
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDimensionOptionsCalls()), ShouldEqual, 0)
 	})
 
 	Convey("When an internal error causes failure to retrieve dimension options, then return internal server error", t, func() {
@@ -1702,7 +1850,7 @@ func TestGetDimensionOptionsReturnsErrors(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetVersionFunc: func(datasetID, edition, version, state string) (*models.Version, error) {
-				return &models.Version{}, nil
+				return &models.Version{State: models.AssociatedState}, nil
 			},
 			GetDimensionOptionsFunc: func(version *models.Version, dimensions string) (*models.DimensionOptionResults, error) {
 				return nil, errInternal
@@ -1712,6 +1860,28 @@ func TestGetDimensionOptionsReturnsErrors(t *testing.T) {
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldEqual, "internal error\n")
+
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDimensionOptionsCalls()), ShouldEqual, 1)
+	})
+
+	Convey("When the version has an invalid state return internal server error", t, func() {
+		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/dimensions/age/options", nil)
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetVersionFunc: func(datasetID, edition, version, state string) (*models.Version, error) {
+				return &models.Version{State: "gobbly-gook"}, nil
+			},
+		}
+
+		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldEqual, "Incorrect resource state\n")
+
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDimensionOptionsCalls()), ShouldEqual, 0)
 	})
 }
 
@@ -1845,7 +2015,7 @@ func TestGetMetadataReturnsError(t *testing.T) {
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 0)
 	})
 
-	Convey("When the dataset document cannot be found for version return status bad request", t, func() {
+	Convey("When the dataset document cannot be found for version return status not found", t, func() {
 
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/metadata", nil)
 		w := httptest.NewRecorder()
@@ -1858,14 +2028,14 @@ func TestGetMetadataReturnsError(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(w.Body.String(), ShouldEqual, "Dataset not found\n")
 
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 0)
 	})
 
-	Convey("When the edition document cannot be found for version return status bad request", t, func() {
+	Convey("When the edition document cannot be found for version return status not found", t, func() {
 
 		datasetDoc := createDatasetDoc()
 
@@ -1883,7 +2053,7 @@ func TestGetMetadataReturnsError(t *testing.T) {
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(w.Body.String(), ShouldEqual, "Edition not found\n")
 
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -1914,6 +2084,35 @@ func TestGetMetadataReturnsError(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(w.Body.String(), ShouldEqual, "Version not found\n")
+
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
+	})
+
+	Convey("When the version document state is invalid return an internal server error", t, func() {
+
+		datasetDoc := createDatasetDoc()
+
+		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/metadata", nil)
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
+				return datasetDoc, nil
+			},
+			CheckEditionExistsFunc: func(datasetId, edition, state string) error {
+				return nil
+			},
+			GetVersionFunc: func(datasetID, edition, version, state string) (*models.Version, error) {
+				return &models.Version{State: "gobbly-gook"}, nil
+			},
+		}
+
+		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{})
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldEqual, "Incorrect resource state\n")
 
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
@@ -2037,62 +2236,6 @@ func TestCreateNewVersionDoc(t *testing.T) {
 	})
 }
 
-func setUp(state string) *storetest.StorerMock {
-	mockedDataStore := &storetest.StorerMock{
-		GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
-			return &models.DatasetUpdate{ID: "123", Next: &models.Dataset{}}, nil
-		},
-		GetEditionFunc: func(string, string, string) (*models.Edition, error) {
-			return &models.Edition{}, nil
-		},
-		GetNextVersionFunc: func(string, string) (int, error) {
-			return 1, nil
-		},
-		UpdateDatasetWithAssociationFunc: func(string, string, *models.Version) error {
-			return nil
-		},
-		UpdateEditionFunc: func(string, string, *models.Version) error {
-			return nil
-		},
-		UpsertDatasetFunc: func(string, *models.DatasetUpdate) error {
-			return nil
-		},
-		UpsertVersionFunc: func(string, *models.Version) error {
-			return nil
-		},
-	}
-
-	mockedDataStore.GetEdition("123", "2017", state)
-
-	mockedDataStore.GetNextVersion("123", "2017")
-
-	versionDoc := &models.Version{
-		State: state,
-	}
-	mockedDataStore.UpsertVersion("1", versionDoc)
-
-	if state == models.PublishedState {
-		datasetDoc := &models.DatasetUpdate{
-			ID: "123",
-			Next: &models.Dataset{
-				State: state,
-			},
-		}
-		mockedDataStore.UpdateEdition("123", "2017", &models.Version{State: state})
-		mockedDataStore.GetDataset("123")
-		mockedDataStore.UpsertDataset("123", datasetDoc)
-	}
-
-	if state == models.AssociatedState {
-		versionDoc := &models.Version{
-			State: state,
-		}
-		mockedDataStore.UpdateDatasetWithAssociation("123", state, versionDoc)
-	}
-
-	return mockedDataStore
-}
-
 // createDatasetDoc returns a datasetUpdate doc containing minimal fields but
 // there is a clear difference between the current and next sub documents
 func createDatasetDoc() *models.DatasetUpdate {
@@ -2124,6 +2267,7 @@ func createVersionDoc() *models.Version {
 		StartDate: "2014-05-09",
 	}
 	versionDoc := &models.Version{
+		State:        models.EditionConfirmedState,
 		CollectionID: "3434",
 		Temporal:     &[]models.TemporalFrequency{temporal},
 	}

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store"
 	"github.com/ONSdigital/dp-dataset-api/store/datastoretest"
-	"github.com/ian-kent/go-log/log"
+	"github.com/ONSdigital/go-ns/log"
 
 	"github.com/ONSdigital/dp-dataset-api/url"
 	"github.com/gorilla/mux"

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -2,7 +2,7 @@ package apierrors
 
 import "errors"
 
-// NotFound error messages for Dataset API
+// Error messages for Dataset API
 var (
 	ErrDatasetNotFound       = errors.New("Dataset not found")
 	ErrEditionNotFound       = errors.New("Edition not found")
@@ -11,4 +11,8 @@ var (
 	ErrDimensionNotFound     = errors.New("Dimension not found")
 	ErrDimensionsNotFound    = errors.New("Dimensions not found")
 	ErrInstanceNotFound      = errors.New("Instance not found")
+	ErrUnauthorised          = errors.New("Unauthorised access to API")
+	ErrNoAuthHeader          = errors.New("No authentication header provided")
+	ErrResourceState         = errors.New("Incorrect resource state")
+	ErrVersionMissingState   = errors.New("Missing state from version")
 )

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -15,4 +15,5 @@ var (
 	ErrNoAuthHeader          = errors.New("No authentication header provided")
 	ErrResourceState         = errors.New("Incorrect resource state")
 	ErrVersionMissingState   = errors.New("Missing state from version")
+	ErrInternalServer        = errors.New("internal error")
 )

--- a/auth/authentication.go
+++ b/auth/authentication.go
@@ -1,9 +1,9 @@
 package auth
 
 import (
-	"errors"
 	"net/http"
 
+	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/go-ns/log"
 )
 
@@ -18,13 +18,13 @@ func (a *Authenticator) Check(handle func(http.ResponseWriter, *http.Request)) h
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		key := r.Header.Get(a.HeaderName)
 		if key == "" {
-			http.Error(w, "No authentication header provided", http.StatusUnauthorized)
-			log.Error(errors.New("client missing token"), log.Data{"header": a.HeaderName})
+			http.Error(w, "Resource not found", http.StatusNotFound)
+			log.Error(errs.ErrNoAuthHeader, log.Data{"header": a.HeaderName})
 			return
 		}
 		if key != a.SecretKey {
-			http.Error(w, "Unauthorised access to API", http.StatusUnauthorized)
-			log.Error(errors.New("unauthorised access to API"), log.Data{"header": a.HeaderName})
+			http.Error(w, "Resource not found", http.StatusNotFound)
+			log.Error(errs.ErrUnauthorised, log.Data{"header": a.HeaderName})
 			return
 		}
 		// The request has been authenticated, now run the clients request

--- a/auth/authentication_test.go
+++ b/auth/authentication_test.go
@@ -16,7 +16,8 @@ func TestMiddleWareAuthenticationReturnsForbidden(t *testing.T) {
 		So(err, ShouldBeNil)
 		w := httptest.NewRecorder()
 		auth.Check(mockHTTPHandler).ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusUnauthorized)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldEqual, "Resource not found\n")
 	})
 }
 
@@ -29,7 +30,8 @@ func TestMiddleWareAuthenticationReturnsUnauthorised(t *testing.T) {
 		So(err, ShouldBeNil)
 		w := httptest.NewRecorder()
 		auth.Check(mockHTTPHandler).ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusUnauthorized)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldEqual, "Resource not found\n")
 	})
 }
 

--- a/dimension/dimension.go
+++ b/dimension/dimension.go
@@ -25,6 +25,21 @@ func (s *Store) GetNodes(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]
 
+	// Get instance
+	instance, err := s.GetInstance(id)
+	if err != nil {
+		log.ErrorC("Failed to GET instance", err, log.Data{"instance": id})
+		handleErrorType(err, w)
+		return
+	}
+
+	// Early return if instance state is invalid
+	if err = models.CheckState("instance", instance.State); err != nil {
+		log.ErrorC("current instance has an invalid state", err, log.Data{"state": instance.State})
+		handleErrorType(errs.ErrInternalServer, w)
+		return
+	}
+
 	results, err := s.GetDimensionNodesFromInstance(id)
 	if err != nil {
 		log.Error(err, nil)
@@ -48,6 +63,21 @@ func (s *Store) GetUnique(w http.ResponseWriter, r *http.Request) {
 	id := vars["id"]
 	dimension := vars["dimension"]
 
+	// Get instance
+	instance, err := s.GetInstance(id)
+	if err != nil {
+		log.ErrorC("Failed to GET instance", err, log.Data{"instance": id})
+		handleErrorType(err, w)
+		return
+	}
+
+	// Early return if instance state is invalid
+	if err = models.CheckState("instance", instance.State); err != nil {
+		log.ErrorC("current instance has an invalid state", err, log.Data{"state": instance.State})
+		handleErrorType(errs.ErrInternalServer, w)
+		return
+	}
+
 	values, err := s.GetUniqueDimensionValues(id, dimension)
 	if err != nil {
 		log.Error(err, nil)
@@ -69,6 +99,22 @@ func (s *Store) GetUnique(w http.ResponseWriter, r *http.Request) {
 func (s *Store) Add(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]
+
+	// Get instance
+	instance, err := s.GetInstance(id)
+	if err != nil {
+		log.ErrorC("Failed to GET instance", err, log.Data{"instance": id})
+		handleErrorType(err, w)
+		return
+	}
+
+	// Early return if instance state is invalid
+	if err = models.CheckState("instance", instance.State); err != nil {
+		log.ErrorC("current instance has an invalid state", err, log.Data{"state": instance.State})
+		handleErrorType(errs.ErrInternalServer, w)
+		return
+	}
+
 	option, err := unmarshalDimensionCache(r.Body)
 	if err != nil {
 		log.Error(err, nil)
@@ -89,6 +135,21 @@ func (s *Store) AddNodeID(w http.ResponseWriter, r *http.Request) {
 	dimensionName := vars["dimension"]
 	value := vars["value"]
 	nodeID := vars["node_id"]
+
+	// Get instance
+	instance, err := s.GetInstance(id)
+	if err != nil {
+		log.ErrorC("Failed to GET instance when attempting to update a dimension of that instance.", err, log.Data{"instance": id})
+		handleErrorType(err, w)
+		return
+	}
+
+	// Early return if instance state is invalid
+	if err = models.CheckState("instance", instance.State); err != nil {
+		log.ErrorC("current instance has an invalid state", err, log.Data{"state": instance.State})
+		handleErrorType(errs.ErrInternalServer, w)
+		return
+	}
 
 	dim := models.DimensionOption{Name: dimensionName, Option: value, NodeID: nodeID, InstanceID: id}
 	if err := s.UpdateDimensionNodeID(&dim); err != nil {

--- a/dimension/dimension.go
+++ b/dimension/dimension.go
@@ -28,7 +28,7 @@ func (s *Store) GetNodes(w http.ResponseWriter, r *http.Request) {
 	// Get instance
 	instance, err := s.GetInstance(id)
 	if err != nil {
-		log.ErrorC("Failed to GET instance", err, log.Data{"instance": id})
+		log.ErrorC("failed to GET instance", err, log.Data{"instance": id})
 		handleErrorType(err, w)
 		return
 	}
@@ -66,7 +66,7 @@ func (s *Store) GetUnique(w http.ResponseWriter, r *http.Request) {
 	// Get instance
 	instance, err := s.GetInstance(id)
 	if err != nil {
-		log.ErrorC("Failed to GET instance", err, log.Data{"instance": id})
+		log.ErrorC("failed to GET instance", err, log.Data{"instance": id})
 		handleErrorType(err, w)
 		return
 	}

--- a/instance/event_external_test.go
+++ b/instance/event_external_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store/datastoretest"
 	. "github.com/smartystreets/goconvey/convey"
+
+	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 )
 
 func TestAddEventReturnsOk(t *testing.T) {
@@ -68,7 +70,7 @@ func TestAddEventToInstanceReturnsInternalError(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			AddEventToInstanceFunc: func(id string, event *models.Event) error {
-				return internalError
+				return errs.ErrInternalServer
 			},
 		}
 

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -65,6 +65,13 @@ func (s *Store) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Early return if instance state is invalid
+	if err = models.CheckState("instance", instance.State); err != nil {
+		log.ErrorC("instance has an invalid state", err, log.Data{"state": instance.State})
+		internalError(w, err)
+		return
+	}
+
 	bytes, err := json.Marshal(instance)
 	if err != nil {
 		internalError(w, err)
@@ -72,7 +79,7 @@ func (s *Store) Get(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeBody(w, bytes)
-	log.Debug("get all instances", nil)
+	log.Debug("get instance", log.Data{"instance_id": id})
 }
 
 //Add an instance
@@ -121,6 +128,13 @@ func (s *Store) UpdateDimension(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.ErrorC("Failed to GET instance when attempting to update a dimension of that instance.", err, log.Data{"instance": id})
 		handleErrorType(err, w)
+		return
+	}
+
+	// Early return if instance state is invalid
+	if err = models.CheckState("instance", instance.State); err != nil {
+		log.ErrorC("current instance has an invalid state", err, log.Data{"state": instance.State})
+		handleErrorType(errs.ErrInternalServer, w)
 		return
 	}
 
@@ -202,6 +216,13 @@ func (s *Store) Update(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Error(err, nil)
 		handleErrorType(err, w)
+		return
+	}
+
+	// Early return if instance state is invalid
+	if err = models.CheckState("instance", currentInstance.State); err != nil {
+		log.ErrorC("current instance has an invalid state", err, log.Data{"state": currentInstance.State})
+		handleErrorType(errs.ErrInternalServer, w)
 		return
 	}
 

--- a/instance/instance_external_test.go
+++ b/instance/instance_external_test.go
@@ -1,25 +1,23 @@
 package instance_test
 
 import (
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/instance"
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store/datastoretest"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
+
+	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 )
 
 const secretKey = "coffee"
 const host = "http://localhost:8080"
-
-var internalError = errors.New("internal error")
 
 func createRequestWithToken(method, url string, body io.Reader) *http.Request {
 	r := httptest.NewRequest(method, url, body)
@@ -98,7 +96,7 @@ func TestGetInstancesReturnsError(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			GetInstancesFunc: func([]string) (*models.InstanceResults, error) {
-				return nil, internalError
+				return nil, errs.ErrInternalServer
 			},
 		}
 
@@ -131,7 +129,7 @@ func TestGetInstanceReturnsOK(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
-				return &models.Instance{}, nil
+				return &models.Instance{State: models.CreatedState}, nil
 			},
 		}
 
@@ -145,13 +143,13 @@ func TestGetInstanceReturnsOK(t *testing.T) {
 
 func TestGetInstanceReturnsInternalError(t *testing.T) {
 	t.Parallel()
-	Convey("Get instance returns an internal error", t, func() {
+	Convey("Given an internal error is returned from mongo, then response returns an internal error", t, func() {
 		r := createRequestWithToken("GET", "http://localhost:21800/instances/123", nil)
 		w := httptest.NewRecorder()
 
 		mockedDataStore := &storetest.StorerMock{
 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
-				return nil, internalError
+				return nil, errs.ErrInternalServer
 			},
 		}
 
@@ -159,6 +157,26 @@ func TestGetInstanceReturnsInternalError(t *testing.T) {
 		instance.Get(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldResemble, "internal error\n")
+
+		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+	})
+
+	Convey("Given instance state is invalid, then response returns an internal error", t, func() {
+		r := createRequestWithToken("GET", "http://localhost:21800/instances/123", nil)
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			GetInstanceFunc: func(ID string) (*models.Instance, error) {
+				return &models.Instance{State: "gobbly gook"}, nil
+			},
+		}
+
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
+		instance.Get(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldResemble, "Incorrect resource state\n")
 		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
 	})
 }
@@ -229,7 +247,7 @@ func TestAddInstancesReturnsInternalError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			AddInstanceFunc: func(*models.Instance) (*models.Instance, error) {
-				return nil, internalError
+				return nil, errs.ErrInternalServer
 			},
 		}
 
@@ -250,7 +268,7 @@ func TestUpdateInstanceReturnsOk(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			GetInstanceFunc: func(id string) (*models.Instance, error) {
-				return &models.Instance{}, nil
+				return &models.Instance{State: models.CreatedState}, nil
 			},
 			UpdateInstanceFunc: func(id string, i *models.Instance) error {
 				return nil
@@ -315,6 +333,49 @@ func TestUpdateInstanceReturnsOk(t *testing.T) {
 		So(len(mockedDataStore.UpsertEditionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetNextVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpdateInstanceCalls()), ShouldEqual, 1)
+	})
+}
+
+func TestUpdateInstanceReturnsInternalError(t *testing.T) {
+	t.Parallel()
+	Convey("Given an internal error is returned from mongo, then response returns an internal error", t, func() {
+		body := strings.NewReader(`{"state":"created"}`)
+		r := createRequestWithToken("PUT", "http://localhost:21800/instances/123", body)
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			GetInstanceFunc: func(id string) (*models.Instance, error) {
+				return nil, errs.ErrInternalServer
+			},
+		}
+
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
+		instance.Update(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldResemble, "internal error\n")
+
+		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpdateInstanceCalls()), ShouldEqual, 0)
+	})
+
+	Convey("Given the current instance state is invalid, then response returns an internal error", t, func() {
+		r := createRequestWithToken("PUT", "http://localhost:21800/instances/123", strings.NewReader(`{"state":"completed", "edition": "2017"}`))
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetInstanceFunc: func(id string) (*models.Instance, error) {
+				return &models.Instance{State: "gobbly gook"}, nil
+			},
+		}
+
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
+		instance.Update(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldResemble, "internal error\n")
+
+		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpdateInstanceCalls()), ShouldEqual, 0)
 	})
 }
 
@@ -587,7 +648,7 @@ func TestStore_UpdateImportTask_ReturnsInternalError(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			UpdateImportObservationsTaskStateFunc: func(id string, state string) error {
-				return internalError
+				return errs.ErrInternalServer
 			},
 		}
 
@@ -624,10 +685,57 @@ func TestUpdateInstanceReturnsErrorWhenStateIsPublished(t *testing.T) {
 	})
 }
 
+func TestUpdateDimensionReturnsInternalError(t *testing.T) {
+	t.Parallel()
+	Convey("Given an internal error is returned from mongo, then response returns an internal error", t, func() {
+		body := strings.NewReader(`{"label":"ages"}`)
+		r := createRequestWithToken("PUT", "http://localhost:22000/instances/123/dimensions/age", body)
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			GetInstanceFunc: func(id string) (*models.Instance, error) {
+				return nil, errs.ErrInternalServer
+			},
+			UpdateInstanceFunc: func(id string, i *models.Instance) error {
+				return nil
+			},
+		}
+
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
+		instance.UpdateDimension(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpdateInstanceCalls()), ShouldEqual, 0)
+	})
+
+	Convey("Given the instance state is invalid, then response returns an internal error", t, func() {
+		body := strings.NewReader(`{"label":"ages"}`)
+		r := createRequestWithToken("PUT", "http://localhost:22000/instances/123/dimensions/age", body)
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			GetInstanceFunc: func(id string) (*models.Instance, error) {
+				return &models.Instance{State: "gobbly gook"}, nil
+			},
+			UpdateInstanceFunc: func(id string, i *models.Instance) error {
+				return nil
+			},
+		}
+
+		instance := &instance.Store{Host: host, Storer: mockedDataStore}
+		instance.UpdateDimension(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpdateInstanceCalls()), ShouldEqual, 0)
+	})
+}
+
 func TestUpdateDimensionReturnsNotFound(t *testing.T) {
 	t.Parallel()
 	Convey("When update dimension return status not found", t, func() {
-		r := createRequestWithToken("PUT", "http://localhost:22000/instances/dimensions/age", nil)
+		r := createRequestWithToken("PUT", "http://localhost:22000/instances/123/dimensions/age", nil)
 		w := httptest.NewRecorder()
 
 		mockedDataStore := &storetest.StorerMock{
@@ -679,7 +787,7 @@ func TestUpdateDimensionReturnsBadRequest(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			GetInstanceFunc: func(id string) (*models.Instance, error) {
-				return &models.Instance{}, nil
+				return &models.Instance{State: models.CompletedState}, nil
 			},
 		}
 

--- a/models/dataset_test.go
+++ b/models/dataset_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
@@ -156,6 +157,13 @@ func TestValidateVersion(t *testing.T) {
 	})
 
 	Convey("Return with errors", t, func() {
+		Convey("when the version state is empty", func() {
+
+			err := ValidateVersion(&Version{State: ""})
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldResemble, errors.New("Missing state from version").Error())
+		})
+
 		Convey("when the version state is set to an invalid value", func() {
 
 			err := ValidateVersion(&Version{State: SubmittedState})
@@ -235,4 +243,46 @@ func TestCreateDownloadList(t *testing.T) {
 		So(dl, ShouldResemble, expected)
 	})
 
+}
+
+func TestCheckState(t *testing.T) {
+	Convey("Successfully return without any errors", t, func() {
+		Convey("when the version has state of edition-confirmed", func() {
+
+			err := CheckState("version", EditionConfirmedState)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("when the version has state of associated", func() {
+
+			err := CheckState("version", AssociatedState)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("when the version has state of published", func() {
+
+			err := CheckState("version", PublishedState)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("when a resource has state of created", func() {
+
+			err := CheckState("resource", CreatedState)
+			So(err, ShouldBeNil)
+		})
+	})
+
+	Convey("Return with errors", t, func() {
+		Convey("when the version has state of gobbly-gook", func() {
+
+			err := CheckState("version", "gobbly-gook")
+			So(err.Error(), ShouldEqual, errs.ErrResourceState.Error())
+		})
+
+		Convey("when the version has a missing state", func() {
+
+			err := CheckState("version", "")
+			So(err.Error(), ShouldEqual, errs.ErrResourceState.Error())
+		})
+	})
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -951,12 +951,12 @@ definitions:
         description: "The uri to the location of this resource on the web"
   DatasetLinks:
     description: "A list of links related to this resource"
-    readOnly: true
     type: object
     properties:
       access_rights:
         $ref: '#/definitions/AccessRightsLink'
       editions:
+        readOnly: true
         type: object
         properties:
           href:
@@ -1242,6 +1242,9 @@ definitions:
       description:
         type: string
         description: "The dimension description"
+      label:
+        type: string
+        description: "A human readable label for dimension"
   Instances:
     type: object
     properties:


### PR DESCRIPTION
### What

Hide authenticated endpoints. If a user calls an endpoint which requires authentication return not found to hide the fact that the endpoint exists due to securing unpublished data.

### How to review

Check changes make sense and the code is logical, make sure unit tests pass and have been extended for new functionality. Also run acceptance tests, by running this service with `Make acceptance`, and running datasetAPI tests in `dp-api-tests` repo on branch `feature/hide-auth-endpoints-dataset`.

### Who can review

Anyone

#### Notes

This work is paired with this pull request: https://github.com/ONSdigital/dp-api-tests/pull/42
