### PR TITLE
Allow the dataset api to update published versions with public links

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -1093,8 +1093,9 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) ht
 				// Note that a new version will be created which contain only the download information to prevent
 				// any forbidden fields from being set on the published version
 				if currentVersion.Downloads != nil {
+					newVersion := new(models.Version)
 					if currentVersion.Downloads.CSV != nil && currentVersion.Downloads.CSV.Public != "" {
-						newVersion := &models.Version{
+						newVersion = &models.Version{
 							Downloads: &models.DownloadList{
 								CSV: &models.DownloadObject{
 									Public: currentVersion.Downloads.CSV.Public,
@@ -1103,22 +1104,9 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) ht
 								},
 							},
 						}
-
-						b, err := json.Marshal(newVersion)
-						if err != nil {
-							http.Error(w, err.Error(), http.StatusForbidden)
-							return
-						}
-
-						if err := r.Body.Close(); err != nil {
-							log.ErrorC("could not close response body", err, nil)
-						}
-						r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
-						handle(w, r)
-						return
 					}
 					if currentVersion.Downloads.XLS != nil && currentVersion.Downloads.XLS.URL != "" {
-						newVersion := &models.Version{
+						newVersion = &models.Version{
 							Downloads: &models.DownloadList{
 								XLS: &models.DownloadObject{
 									Public: currentVersion.Downloads.CSV.Public,
@@ -1127,7 +1115,8 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) ht
 								},
 							},
 						}
-
+					}
+					if newVersion != nil {
 						b, err := json.Marshal(newVersion)
 						if err != nil {
 							http.Error(w, err.Error(), http.StatusForbidden)

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -1100,18 +1100,18 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) ht
 								CSV: &models.DownloadObject{
 									Public: currentVersion.Downloads.CSV.Public,
 									Size:   currentVersion.Downloads.CSV.Size,
-									URL:    currentVersion.Downloads.CSV.URL,
+									HRef:   currentVersion.Downloads.CSV.HRef,
 								},
 							},
 						}
 					}
-					if currentVersion.Downloads.XLS != nil && currentVersion.Downloads.XLS.URL != "" {
+					if currentVersion.Downloads.XLS != nil && currentVersion.Downloads.XLS.Public != "" {
 						newVersion = &models.Version{
 							Downloads: &models.DownloadList{
 								XLS: &models.DownloadObject{
 									Public: currentVersion.Downloads.CSV.Public,
 									Size:   currentVersion.Downloads.CSV.Size,
-									URL:    currentVersion.Downloads.CSV.URL,
+									HRef:   currentVersion.Downloads.CSV.HRef,
 								},
 							},
 						}

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -1077,16 +1076,13 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) ht
 
 		if versionDoc != nil {
 			if versionDoc.State == models.PublishedState {
-				var buf bytes.Buffer
-				tee := io.TeeReader(r.Body, &buf)
-
 				defer func() {
 					if err := r.Body.Close(); err != nil {
 						log.ErrorC("could not close response body", err, nil)
 					}
 				}()
 
-				versionDoc, err := models.CreateVersion(tee)
+				versionDoc, err := models.CreateVersion(r.Body)
 				if err != nil {
 					log.ErrorC("failed to model version resource based on request", err, log.Data{"dataset_id": id, "edition": edition, "version": version})
 					http.Error(w, err.Error(), http.StatusBadRequest)

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -1063,7 +1063,7 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) ht
 		edition := vars["edition"]
 		version := vars["version"]
 
-		versionDoc, err := d.Datastore.GetVersion(id, edition, version, "")
+		currentVersion, err := d.Datastore.GetVersion(id, edition, version, "")
 		if err != nil {
 			if err != errs.ErrVersionNotFound {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -1074,8 +1074,8 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) ht
 			return
 		}
 
-		if versionDoc != nil {
-			if versionDoc.State == models.PublishedState {
+		if currentVersion != nil {
+			if currentVersion.State == models.PublishedState {
 				defer func() {
 					if err := r.Body.Close(); err != nil {
 						log.ErrorC("could not close response body", err, nil)
@@ -1144,7 +1144,7 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) ht
 				}
 
 				err = errors.New("unable to update version as it has been published")
-				log.Error(err, log.Data{"version": versionDoc})
+				log.Error(err, log.Data{"version": currentVersion})
 				http.Error(w, err.Error(), http.StatusForbidden)
 				return
 			}

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -1093,7 +1093,7 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) ht
 					return
 				}
 
-				// We can allow public download links to be modified by the exporters when a version is publishe
+				// We can allow public download links to be modified by the exporters when a version is published
 				if versionDoc.Downloads != nil {
 					if versionDoc.Downloads.CSV != nil && versionDoc.Downloads.CSV.Public != "" {
 						if err := r.Body.Close(); err != nil {

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -1082,7 +1082,7 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) ht
 					}
 				}()
 
-				currentVersion, err := models.CreateVersion(r.Body)
+				versionDoc, err := models.CreateVersion(r.Body)
 				if err != nil {
 					log.ErrorC("failed to model version resource based on request", err, log.Data{"dataset_id": id, "edition": edition, "version": version})
 					http.Error(w, err.Error(), http.StatusBadRequest)
@@ -1092,26 +1092,26 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) ht
 				// We can allow public download links to be modified by the exporters when a version is published.
 				// Note that a new version will be created which contain only the download information to prevent
 				// any forbidden fields from being set on the published version
-				if currentVersion.Downloads != nil {
+				if versionDoc.Downloads != nil {
 					newVersion := new(models.Version)
-					if currentVersion.Downloads.CSV != nil && currentVersion.Downloads.CSV.Public != "" {
+					if versionDoc.Downloads.CSV != nil && versionDoc.Downloads.CSV.Public != "" {
 						newVersion = &models.Version{
 							Downloads: &models.DownloadList{
 								CSV: &models.DownloadObject{
-									Public: currentVersion.Downloads.CSV.Public,
-									Size:   currentVersion.Downloads.CSV.Size,
-									HRef:   currentVersion.Downloads.CSV.HRef,
+									Public: versionDoc.Downloads.CSV.Public,
+									Size:   versionDoc.Downloads.CSV.Size,
+									HRef:   versionDoc.Downloads.CSV.HRef,
 								},
 							},
 						}
 					}
-					if currentVersion.Downloads.XLS != nil && currentVersion.Downloads.XLS.Public != "" {
+					if versionDoc.Downloads.XLS != nil && versionDoc.Downloads.XLS.Public != "" {
 						newVersion = &models.Version{
 							Downloads: &models.DownloadList{
 								XLS: &models.DownloadObject{
-									Public: currentVersion.Downloads.CSV.Public,
-									Size:   currentVersion.Downloads.CSV.Size,
-									HRef:   currentVersion.Downloads.CSV.HRef,
+									Public: versionDoc.Downloads.CSV.Public,
+									Size:   versionDoc.Downloads.CSV.Size,
+									HRef:   versionDoc.Downloads.CSV.HRef,
 								},
 							},
 						}

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -1113,7 +1113,7 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) ht
 						if err := r.Body.Close(); err != nil {
 							log.ErrorC("could not close response body", err, nil)
 						}
-						r.Body = ioutil.NopCloser(ioutil.NopCloser(bytes.NewBuffer(b)))
+						r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
 						handle(w, r)
 						return
 					}
@@ -1137,7 +1137,7 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) ht
 						if err := r.Body.Close(); err != nil {
 							log.ErrorC("could not close response body", err, nil)
 						}
-						r.Body = ioutil.NopCloser(ioutil.NopCloser(bytes.NewBuffer(b)))
+						r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
 						handle(w, r)
 						return
 					}

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -1376,7 +1376,14 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 						},
 					},
 					ReleaseDate: "2017-12-12",
-					State:       models.EditionConfirmedState,
+					Downloads: &models.DownloadList{
+						CSV: &models.DownloadObject{
+							Private: "s3://csv-exported/myfile.csv",
+							URL:     "http://localhost:23600/datasets/123/editions/2017/versions/1.csv",
+							Size:    "1234",
+						},
+					},
+					State: models.EditionConfirmedState,
 				}, nil
 			},
 			UpdateVersionFunc: func(string, *models.Version) error {

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -1379,7 +1379,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 					Downloads: &models.DownloadList{
 						CSV: &models.DownloadObject{
 							Private: "s3://csv-exported/myfile.csv",
-							URL:     "http://localhost:23600/datasets/123/editions/2017/versions/1.csv",
+							HRef:    "http://localhost:23600/datasets/123/editions/2017/versions/1.csv",
 							Size:    "1234",
 						},
 					},
@@ -1500,7 +1500,7 @@ func TestPutEmptyVersion(t *testing.T) {
 	var v models.Version
 	json.Unmarshal([]byte(versionAssociatedPayload), &v)
 	v.State = models.AssociatedState
-	xlsDownload := &models.DownloadList{XLS: &models.DownloadObject{Size: "1", URL: "/hello"}}
+	xlsDownload := &models.DownloadList{XLS: &models.DownloadObject{Size: "1", HRef: "/hello"}}
 
 	Convey("given an existing version with empty downloads", t, func() {
 		mockedDataStore := &storetest.StorerMock{

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -161,7 +161,7 @@ type DownloadList struct {
 
 // DownloadObject represents information on the downloadable file
 type DownloadObject struct {
-	URL string `bson:"url,omitempty"  json:"url,omitempty"`
+	HRef string `bson:"href,omitempty"  json:"href,omitempty"`
 	// TODO size is in bytes and probably should be an int64 instead of a string this
 	// will have to change for several services (filter API, exporter services and web)
 	Size    string `bson:"size,omitempty" json:"size,omitempty"`
@@ -321,7 +321,7 @@ func ValidateVersion(version *Version) error {
 
 	if version.Downloads != nil {
 		if version.Downloads.XLS != nil {
-			if version.Downloads.XLS.URL == "" {
+			if version.Downloads.XLS.HRef == "" {
 				missingFields = append(missingFields, "Downloads.XLS.URL")
 			}
 			if version.Downloads.XLS.Size == "" {
@@ -333,7 +333,7 @@ func ValidateVersion(version *Version) error {
 		}
 
 		if version.Downloads.CSV != nil {
-			if version.Downloads.CSV.URL == "" {
+			if version.Downloads.CSV.HRef == "" {
 				missingFields = append(missingFields, "Downloads.CSV.URL")
 			}
 			if version.Downloads.CSV.Size == "" {

--- a/models/dataset_test.go
+++ b/models/dataset_test.go
@@ -192,22 +192,22 @@ func TestValidateVersion(t *testing.T) {
 		Convey("when version downloads are invalid", func() {
 			v := &Version{ReleaseDate: "Today", State: EditionConfirmedState}
 
-			v.Downloads = &DownloadList{XLS: &DownloadObject{URL: "", Size: "2"}}
+			v.Downloads = &DownloadList{XLS: &DownloadObject{HRef: "", Size: "2"}}
 			assertVersionDownloadError(fmt.Errorf("missing mandatory fields: %v", []string{"Downloads.XLS.URL"}), v)
 
-			v.Downloads = &DownloadList{CSV: &DownloadObject{URL: "", Size: "2"}}
+			v.Downloads = &DownloadList{CSV: &DownloadObject{HRef: "", Size: "2"}}
 			assertVersionDownloadError(fmt.Errorf("missing mandatory fields: %v", []string{"Downloads.CSV.URL"}), v)
 
-			v.Downloads = &DownloadList{XLS: &DownloadObject{URL: "/", Size: ""}}
+			v.Downloads = &DownloadList{XLS: &DownloadObject{HRef: "/", Size: ""}}
 			assertVersionDownloadError(fmt.Errorf("missing mandatory fields: %v", []string{"Downloads.XLS.Size"}), v)
 
-			v.Downloads = &DownloadList{CSV: &DownloadObject{URL: "/", Size: ""}}
+			v.Downloads = &DownloadList{CSV: &DownloadObject{HRef: "/", Size: ""}}
 			assertVersionDownloadError(fmt.Errorf("missing mandatory fields: %v", []string{"Downloads.CSV.Size"}), v)
 
-			v.Downloads = &DownloadList{XLS: &DownloadObject{URL: "/", Size: "bob"}}
+			v.Downloads = &DownloadList{XLS: &DownloadObject{HRef: "/", Size: "bob"}}
 			assertVersionDownloadError(fmt.Errorf("invalid fields: %v", []string{"Downloads.XLS.Size not a number"}), v)
 
-			v.Downloads = &DownloadList{CSV: &DownloadObject{URL: "/", Size: "bob"}}
+			v.Downloads = &DownloadList{CSV: &DownloadObject{HRef: "/", Size: "bob"}}
 			assertVersionDownloadError(fmt.Errorf("invalid fields: %v", []string{"Downloads.CSV.Size not a number"}), v)
 		})
 	})
@@ -231,7 +231,7 @@ func TestCreateDownloadList(t *testing.T) {
 		expected := &DownloadList{
 			XLS: &DownloadObject{
 				Size: "1",
-				URL:  "2",
+				HRef: "2",
 			},
 		}
 

--- a/models/metadata.go
+++ b/models/metadata.go
@@ -109,11 +109,11 @@ func getDistribution(downloads *DownloadList) []string {
 	distribution := []string{"json"}
 
 	if downloads != nil {
-		if downloads.CSV != nil && downloads.CSV.URL != "" {
+		if downloads.CSV != nil && downloads.CSV.HRef != "" {
 			distribution = append(distribution, "csv")
 		}
 
-		if downloads.XLS != nil && downloads.XLS.URL != "" {
+		if downloads.XLS != nil && downloads.XLS.HRef != "" {
 			distribution = append(distribution, "xls")
 		}
 	}

--- a/models/test_data.go
+++ b/models/test_data.go
@@ -124,11 +124,11 @@ var dimension = CodeList{
 
 var downloads = DownloadList{
 	CSV: &DownloadObject{
-		URL:  "https://www.aws/123",
+		HRef: "https://www.aws/123",
 		Size: "25",
 	},
 	XLS: &DownloadObject{
-		URL:  "https://www.aws/1234",
+		HRef: "https://www.aws/1234",
 		Size: "45",
 	},
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1506,7 +1506,7 @@ definitions:
     description: "Object containing information of a downloadable file"
     type: object
     properties:
-      url:
+      href:
         type: string
         description: "The URL to the generated file"
       size:


### PR DESCRIPTION
### What

- Allow the dataset api to update published versions with public links

### How to review

- Run dp-dataset-exporter on `feature/write-to-public-private`
- Import an instance
- Publish the instance
- Verify that the mongo document for the instance is correctly updated with public links

### Who can review

Anyone