### PR TITLE
Fix edition model to avoid immutable _id field and update queries

### DIFF
--- a/instance/instance.go
+++ b/instance/instance.go
@@ -275,6 +275,7 @@ func (s *Store) Update(w http.ResponseWriter, r *http.Request) {
 		// Only create edition if it doesn't already exist
 		editionDoc, err := s.getEdition(datasetID, edition, id)
 		if err != nil {
+			log.ErrorR(r, err, nil)
 			handleErrorType(err, w)
 			return
 		}

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -112,7 +112,7 @@ type ContactDetails struct {
 
 // EditionUpdate represents an evolving edition containing both the next and current edition
 type EditionUpdate struct {
-	ID      string   `bson:"_id,omitempty"         json:"id,omitempty"`
+	ID      string   `bson:"id,omitempty"         json:"id,omitempty"`
 	Current *Edition `bson:"current,omitempty"     json:"current,omitempty"`
 	Next    *Edition `bson:"next,omitempty"        json:"next,omitempty"`
 }

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -158,7 +158,7 @@ func buildEditionQuery(id, editionID, state string) bson.M {
 		selector = bson.M{
 			"current.links.dataset.id": id,
 			"current.edition":          editionID,
-			"current.state":			state,
+			"current.state":            state,
 		}
 	} else {
 		selector = bson.M{
@@ -458,11 +458,11 @@ func (m *Mongo) UpdateEdition(datasetID, edition string, version *models.Version
 			"next.links.latest_version.id":   version.Links.Version.ID,
 		},
 		"$setOnInsert": bson.M{
-			"last_updated": time.Now(),
+			"next.last_updated": time.Now(),
 		},
 	}
 
-	err = s.DB(m.Database).C(editionsCollection).Update(bson.M{"links.dataset.id": datasetID, "edition": edition}, update)
+	err = s.DB(m.Database).C(editionsCollection).Update(bson.M{"next.links.dataset.id": datasetID, "next.edition": edition}, update)
 	return
 }
 
@@ -628,7 +628,7 @@ func (m *Mongo) CheckEditionExists(id, editionID, state string) error {
 		query = bson.M{
 			"current.links.dataset.id": id,
 			"current.edition":          editionID,
-			"current.state":    state,
+			"current.state":            state,
 		}
 	}
 


### PR DESCRIPTION
### What

Fix edition model to avoid writing _id field
Fix queries to use next document for selectors

### How to review

This should resolve issues around being able to update editions which existed before the schema change

### Who can review

@nshumoogum 