### PR TITLE
updated healthcheck endpoint to use latest middleware

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/store"
 	"github.com/ONSdigital/dp-dataset-api/url"
 	"github.com/ONSdigital/go-ns/audit"
+	"github.com/ONSdigital/go-ns/healthcheck"
 	"github.com/ONSdigital/go-ns/identity"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/ONSdigital/go-ns/server"
@@ -50,15 +51,17 @@ type DatasetAPI struct {
 // CreateDatasetAPI manages all the routes configured to API
 func CreateDatasetAPI(cfg config.Configuration, dataStore store.DataStore, urlBuilder *url.Builder, errorChan chan error, downloadsGenerator DownloadsGenerator, auditor Auditor) {
 	router := mux.NewRouter()
-	routes(cfg, router, dataStore, urlBuilder, downloadsGenerator, auditor)
+	api := routes(cfg, router, dataStore, urlBuilder, downloadsGenerator, auditor)
+
+	healthCheckHandler := healthcheck.NewMiddleware(api.healthCheck)
+	alice := alice.New(healthCheckHandler)
 
 	// Only add the identity middleware when running in publishing.
 	if cfg.EnablePrivateEnpoints {
-		alice := alice.New(identity.Handler(cfg.ZebedeeURL)).Then(router)
-		httpServer = server.New(cfg.BindAddr, alice)
-	} else {
-		httpServer = server.New(cfg.BindAddr, router)
+		alice = alice.Append(identity.Handler(cfg.ZebedeeURL))
 	}
+
+	httpServer = server.New(cfg.BindAddr, alice.Then(router))
 
 	// Disable this here to allow main to manage graceful shutdown of the entire app.
 	httpServer.HandleOSSignals = false
@@ -87,8 +90,6 @@ func routes(cfg config.Configuration, router *mux.Router, dataStore store.DataSt
 		healthCheckTimeout:   cfg.HealthCheckTimeout,
 		auditor:              auditor,
 	}
-
-	api.router.HandleFunc("/healthcheck", api.healthCheck).Methods("GET")
 
 	api.router.HandleFunc("/datasets", api.getDatasets).Methods("GET")
 	api.router.HandleFunc("/datasets/{id}", api.getDataset).Methods("GET")

--- a/api/healthcheck_test.go
+++ b/api/healthcheck_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/ONSdigital/dp-dataset-api/mocks"
 	storetest "github.com/ONSdigital/dp-dataset-api/store/datastoretest"
+	"github.com/ONSdigital/go-ns/healthcheck"
+	alice2 "github.com/justinas/alice"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -26,7 +28,11 @@ func TestHealthCheckReturnsOK(t *testing.T) {
 		}
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, getMockAuditor())
-		api.router.ServeHTTP(w, r)
+
+		healthCheck := healthcheck.NewMiddleware(api.healthCheck)
+		mainHandler := alice2.New(healthCheck).Then(api.router)
+
+		mainHandler.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		body := w.Body.String()
 		So(body, ShouldContainSubstring, `"status":"OK"`)
@@ -47,7 +53,11 @@ func TestHealthCheckReturnsError(t *testing.T) {
 		}
 
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, getMockAuditor())
-		api.router.ServeHTTP(w, r)
+		healthCheck := healthcheck.NewMiddleware(api.healthCheck)
+		mainHandler := alice2.New(healthCheck).Then(api.router)
+
+		mainHandler.ServeHTTP(w, r)
+
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		body := w.Body.String()
 		So(body, ShouldContainSubstring, `"status":"error"`)


### PR DESCRIPTION
Updated api healthcheck to use latest middleware.

API should work exactly the same as before except the healthcheck endpoint no longer requires an auth token.
