### PR TITLE
Ignore case sensitivity with observation query parameters

### DIFF
--- a/api/observation.go
+++ b/api/observation.go
@@ -182,9 +182,10 @@ func extractQueryParameters(urlQuery url.Values, validDimensions []string) (map[
 	for dimension, option := range urlQuery {
 		queryParamExists := false
 		for _, validDimension := range validDimensions {
-			if dimension == validDimension {
+			// Ignore case sensitivity
+			if strings.ToLower(dimension) == strings.ToLower(validDimension) {
 				queryParamExists = true
-				queryParameters[dimension] = option[0]
+				queryParameters[validDimension] = option[0]
 				if len(option) != 1 {
 					multivaluedQueryParameters = append(multivaluedQueryParameters, dimension)
 				}
@@ -232,7 +233,7 @@ func (api *DatasetAPI) getObservationList(versionDoc *models.Version, queryParam
 				return nil, errs.ErrTooManyWildcards
 			}
 
-			wildcardParameter = dimension
+			wildcardParameter = strings.ToLower(dimension)
 			continue
 		}
 
@@ -309,9 +310,9 @@ func (api *DatasetAPI) getObservationList(versionDoc *models.Version, queryParam
 
 				if strings.ToLower(headerRowArray[i]) == wildcardParameter {
 					for _, versionDimension := range versionDoc.Dimensions {
-						if versionDimension.Name == wildcardParameter {
+						if strings.ToLower(versionDimension.Name) == wildcardParameter {
 
-							dimensions[headerRowArray[i]] = &models.DimensionObject{
+							dimensions[strings.ToLower(headerRowArray[i])] = &models.DimensionObject{
 								ID:    observationRowArray[i-1],
 								HRef:  versionDimension.HRef + "/codes/" + observationRowArray[i-1],
 								Label: observationRowArray[i],

--- a/models/observation.go
+++ b/models/observation.go
@@ -1,5 +1,7 @@
 package models
 
+import "strings"
+
 const wildcard = "*"
 
 // ObservationsDoc represents information (observations) relevant to a version
@@ -72,14 +74,15 @@ func CreateObservationsDoc(rawQuery string, versionDoc *Version, datasetDoc *Dat
 	for paramKey, paramValue := range queryParameters {
 		for _, dimension := range versionDoc.Dimensions {
 			var linkObjects []*LinkObject
-			if dimension.Name == paramKey && paramValue != wildcard {
+			// Ignore case sensitivity
+			if strings.ToLower(dimension.Name) == strings.ToLower(paramKey) && paramValue != wildcard {
 
 				linkObject := &LinkObject{
 					HRef: dimension.HRef + "/codes/" + paramValue,
 					ID:   paramValue,
 				}
 				linkObjects = append(linkObjects, linkObject)
-				dimensions[paramKey] = Option{
+				dimensions[strings.ToLower(paramKey)] = Option{
 					LinkObject: linkObject,
 				}
 				break


### PR DESCRIPTION
### What

Lower case all variable values relevated to a dimension in observation
endpoint. These variables can be found in `query_paramaters`,
`dimensions` or `headers`. The reason for doing this is so we can
compare request query parameters with data in mongo and neo4j without
failing to find expected data.

More specifically, the `headers` in a version document are stored in mongo
as defined by the original v4 file loaded into import process. Mean while the
`dimension.names` field stored against a version document are not
necessarily the same, as these get lower cased on input. These
`dimension.name` values are the ones our api users see and hence are
more likely to enter as query parameters. Also the neo4j dimension nodes
use the lower cased naming convention and hence querying the database
with sentenced cased dimension names leads to failure of finding 
dimensions stored in neo4j therefore resulting in no observations found 
where one would expect to find one or many.

### How to review

Check unit tests pass and logical changes make sense.

### Who can review

Team B
