### PR TITLE
Feature/update editions audit

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -93,20 +93,6 @@ type DatasetAPI struct {
 	auditor              Auditor
 }
 
-type httpError struct {
-	//cause the original error
-	cause error
-	//status the http status code to write in the response.
-	status int
-}
-
-func (e *httpError) Error() string {
-	if e != nil {
-		return e.cause.Error()
-	}
-	return ""
-}
-
 func setJSONContentType(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 }
@@ -205,36 +191,6 @@ func handleErrorType(docType string, err error, w http.ResponseWriter) {
 	switch docType {
 	default:
 		if err == errs.ErrEditionNotFound || err == errs.ErrVersionNotFound || err == errs.ErrDimensionNodeNotFound || err == errs.ErrInstanceNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	case "dataset":
-		if err == errs.ErrDatasetNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else if err == errs.ErrDeleteDatasetNotFound {
-			http.Error(w, err.Error(), http.StatusNoContent)
-		} else if err == errs.ErrDeletePublishedDatasetForbidden || err == errs.ErrAddDatasetAlreadyExists {
-			http.Error(w, err.Error(), http.StatusForbidden)
-		} else if err == errs.ErrAddUpdateDatasetBadRequest {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	case "edition":
-		if err == errs.ErrDatasetNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else if err == errs.ErrEditionNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	case "version":
-		if err == errs.ErrDatasetNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else if err == errs.ErrEditionNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else if err == errs.ErrVersionNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/api/api.go
+++ b/api/api.go
@@ -93,6 +93,20 @@ type DatasetAPI struct {
 	auditor              Auditor
 }
 
+type httpError struct {
+	//cause the original error
+	cause error
+	//status the http status code to write in the response.
+	status int
+}
+
+func (e *httpError) Error() string {
+	if e != nil {
+		return e.cause.Error()
+	}
+	return ""
+}
+
 func setJSONContentType(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 }

--- a/api/editions.go
+++ b/api/editions.go
@@ -4,101 +4,98 @@ import (
 	"encoding/json"
 	"net/http"
 
+	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/go-ns/audit"
 	"github.com/ONSdigital/go-ns/common"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 )
 
 func (api *DatasetAPI) getEditions(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	vars := mux.Vars(r)
 	id := vars["id"]
 	logData := log.Data{"dataset_id": id}
 	auditParams := common.Params{"dataset_id": id}
 
 	if auditErr := api.auditor.Record(r.Context(), getEditionsAction, audit.Attempted, auditParams); auditErr != nil {
-		handleAuditingFailure(w, auditErr, logData)
+		http.Error(w, errs.ErrInternalServer.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	authorised, logData := api.authenticate(r, logData)
+	b, taskErr := func() ([]byte, *httpError) {
+		authorised, logData := api.authenticate(r, logData)
 
-	var state string
-	if !authorised {
-		state = models.PublishedState
-	}
-
-	logData["state"] = state
-	log.Info("about to check resources exist", logData)
-
-	if err := api.dataStore.Backend.CheckDatasetExists(id, state); err != nil {
-		log.ErrorC("unable to find dataset", err, logData)
-		if auditErr := api.auditor.Record(r.Context(), getEditionsAction, audit.Unsuccessful, auditParams); auditErr != nil {
-			handleAuditingFailure(w, auditErr, logData)
-			return
-
-		}
-		handleErrorType(editionDocType, err, w)
-		return
-	}
-
-	results, err := api.dataStore.Backend.GetEditions(id, state)
-	if err != nil {
-		log.ErrorC("unable to find editions for dataset", err, logData)
-
-		if auditErr := api.auditor.Record(r.Context(), getEditionsAction, audit.Unsuccessful, auditParams); auditErr != nil {
-			handleAuditingFailure(w, auditErr, logData)
-			return
+		var state string
+		if !authorised {
+			state = models.PublishedState
 		}
 
-		handleErrorType(editionDocType, err, w)
-		return
-	}
+		logData["state"] = state
+		log.Info("about to check resources exist", logData)
 
-	var logMessage string
-	var b []byte
+		if err := api.dataStore.Backend.CheckDatasetExists(id, state); err != nil {
+			audit.LogError(ctx, errors.WithMessage(err, "getEditions endpoint: unable to find dataset"), logData)
+			return nil, &httpError{errs.ErrDatasetNotFound, http.StatusNotFound}
+		}
 
-	if authorised {
-
-		// User has valid authentication to get raw edition document
-		b, err = json.Marshal(results)
+		results, err := api.dataStore.Backend.GetEditions(id, state)
 		if err != nil {
-			log.ErrorC("failed to marshal a list of edition resources into bytes", err, logData)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		logMessage = "get all editions with auth"
-
-	} else {
-
-		// User is not authenticated and hance has only access to current sub document
-		var publicResults []*models.Edition
-		for i := range results.Items {
-			publicResults = append(publicResults, results.Items[i].Current)
+			audit.LogError(ctx, errors.WithMessage(err, "getEditions endpoint: unable to find editions for dataset"), logData)
+			return nil, &httpError{errs.ErrEditionNotFound, http.StatusNotFound}
 		}
 
-		b, err = json.Marshal(&models.EditionResults{Items: publicResults})
-		if err != nil {
-			log.ErrorC("failed to marshal a list of public edition resources into bytes", err, logData)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+		var editionBytes []byte
+
+		if authorised {
+
+			// User has valid authentication to get raw edition document
+			editionBytes, err = json.Marshal(results)
+			if err != nil {
+				audit.LogError(ctx, errors.WithMessage(err, "getEditions endpoint: failed to marshal a list of edition resources into bytes"), logData)
+				return nil, &httpError{err, http.StatusInternalServerError}
+			}
+			audit.LogInfo(ctx, "getEditions endpoint: get all edition with auth", logData)
+
+		} else {
+			// User is not authenticated and hence has only access to current sub document
+			var publicResults []*models.Edition
+			for i := range results.Items {
+				publicResults = append(publicResults, results.Items[i].Current)
+			}
+
+			editionBytes, err = json.Marshal(&models.EditionResults{Items: publicResults})
+			if err != nil {
+				audit.LogError(ctx, errors.WithMessage(err, "getEditions endpoint: failed to marshal a list of edition resources into bytes"), logData)
+				return nil, &httpError{err, http.StatusInternalServerError}
+			}
+			audit.LogInfo(ctx, "getEditions endpoint: get all edition without auth", logData)
 		}
-		logMessage = "get all editions without auth"
+		return editionBytes, nil
+	}()
+
+	if taskErr != nil {
+		if auditErr := api.auditor.Record(ctx, getEditionsAction, audit.Unsuccessful, auditParams); auditErr != nil {
+			taskErr = &httpError{auditErr, http.StatusInternalServerError}
+		}
+		http.Error(w, taskErr.Error(), taskErr.status)
+		return
 	}
 
 	if auditErr := api.auditor.Record(r.Context(), getEditionsAction, audit.Successful, auditParams); auditErr != nil {
-		handleAuditingFailure(w, auditErr, logData)
+		http.Error(w, errs.ErrInternalServer.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	setJSONContentType(w)
-	_, err = w.Write(b)
+	_, err := w.Write(b)
 	if err != nil {
-		log.Error(err, logData)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		audit.LogError(ctx, errors.WithMessage(err, "getEditions endpoint: failed writing bytes to response"), logData)
+		http.Error(w, errs.ErrInternalServer.Error(), http.StatusInternalServerError)
 	}
-	log.Debug(logMessage, log.Data{"dataset_id": id})
+	audit.LogInfo(ctx, "getEditions endpoint: request successful", logData)
 }
 
 func (api *DatasetAPI) getEdition(w http.ResponseWriter, r *http.Request) {

--- a/api/editions_test.go
+++ b/api/editions_test.go
@@ -72,9 +72,7 @@ func TestGetEditionsAuditingError(t *testing.T) {
 
 		api.Router.ServeHTTP(w, r)
 
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		So(w.Body.String(), ShouldResemble, internalServerErr)
-
+		assertInternalServerErr(w)
 		recCalls := auditMock.RecordCalls()
 		So(len(recCalls), ShouldEqual, 1)
 		verifyAuditRecordCalls(recCalls[0], getEditionsAction, audit.Attempted, auditParams)
@@ -94,21 +92,12 @@ func TestGetEditionsAuditingError(t *testing.T) {
 			},
 		}
 
-		auditMock := getMockAuditor()
-		auditMock.RecordFunc = func(ctx context.Context, action string, result string, params common.Params) error {
-			if action == getEditionsAction && result == audit.Successful {
-				return errors.New("audit error")
-			}
-			return nil
-		}
-
+		auditMock := createAuditor(getEditionsAction, audit.Successful)
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditMock, genericMockedObservationStore)
 
 		api.Router.ServeHTTP(w, r)
 
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		So(w.Body.String(), ShouldResemble, internalServerErr)
-
+		assertInternalServerErr(w)
 		recCalls := auditMock.RecordCalls()
 		So(len(recCalls), ShouldEqual, 2)
 		verifyAuditRecordCalls(recCalls[0], getEditionsAction, audit.Attempted, auditParams)
@@ -127,20 +116,12 @@ func TestGetEditionsAuditingError(t *testing.T) {
 			},
 		}
 
-		auditMock := getMockAuditor()
-		auditMock.RecordFunc = func(ctx context.Context, action string, result string, params common.Params) error {
-			if action == getEditionsAction && result == audit.Unsuccessful {
-				return errors.New(auditError)
-			}
-			return nil
-		}
+		auditMock := createAuditor(getEditionsAction, audit.Unsuccessful)
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditMock, genericMockedObservationStore)
 
 		api.Router.ServeHTTP(w, r)
 
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		So(w.Body.String(), ShouldEqual, internalServerErr)
-
+		assertInternalServerErr(w)
 		recCalls := auditMock.RecordCalls()
 		So(len(recCalls), ShouldEqual, 2)
 		verifyAuditRecordCalls(recCalls[0], getEditionsAction, audit.Attempted, auditParams)
@@ -162,20 +143,12 @@ func TestGetEditionsAuditingError(t *testing.T) {
 			},
 		}
 
-		auditMock := getMockAuditor()
-		auditMock.RecordFunc = func(ctx context.Context, action string, result string, params common.Params) error {
-			if action == getEditionsAction && result == audit.Unsuccessful {
-				return errors.New(auditError)
-			}
-			return nil
-		}
+		auditMock := createAuditor(getEditionsAction, audit.Unsuccessful)
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditMock, genericMockedObservationStore)
 
 		api.Router.ServeHTTP(w, r)
 
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		So(w.Body.String(), ShouldResemble, internalServerErr)
-
+		assertInternalServerErr(w)
 		recCalls := auditMock.RecordCalls()
 		So(len(recCalls), ShouldEqual, 2)
 		verifyAuditRecordCalls(recCalls[0], getEditionsAction, audit.Attempted, auditParams)

--- a/api/editions_test.go
+++ b/api/editions_test.go
@@ -425,10 +425,7 @@ func TestGetEditionAuditErrors(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{}
 
-		auditMock := getMockAuditor()
-		auditMock.RecordFunc = func(ctx context.Context, action string, result string, params common.Params) error {
-			return errors.New("auditing error")
-		}
+		auditMock := createAuditor(getEditionAction, audit.Attempted)
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditMock, genericMockedObservationStore)
 
 		api.Router.ServeHTTP(w, r)
@@ -436,8 +433,7 @@ func TestGetEditionAuditErrors(t *testing.T) {
 		recCalls := auditMock.RecordCalls()
 		p := common.Params{"dataset_id": "123-456", "edition": "678"}
 
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		So(w.Body.String(), ShouldEqual, internalServerErr)
+		assertInternalServerErr(w)
 		So(len(recCalls), ShouldEqual, 1)
 		verifyAuditRecordCalls(recCalls[0], getEditionAction, audit.Attempted, p)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 0)
@@ -453,13 +449,7 @@ func TestGetEditionAuditErrors(t *testing.T) {
 			},
 		}
 
-		auditMock := getMockAuditor()
-		auditMock.RecordFunc = func(ctx context.Context, action string, result string, params common.Params) error {
-			if action == getEditionAction && result == audit.Unsuccessful {
-				return errors.New("auditing error")
-			}
-			return nil
-		}
+		auditMock := createAuditor(getEditionAction, audit.Unsuccessful)
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditMock, genericMockedObservationStore)
 
 		api.Router.ServeHTTP(w, r)
@@ -467,8 +457,7 @@ func TestGetEditionAuditErrors(t *testing.T) {
 		recCalls := auditMock.RecordCalls()
 		p := common.Params{"dataset_id": "123-456", "edition": "678"}
 
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		So(w.Body.String(), ShouldEqual, internalServerErr)
+		assertInternalServerErr(w)
 		So(len(recCalls), ShouldEqual, 2)
 		verifyAuditRecordCalls(recCalls[0], getEditionAction, audit.Attempted, p)
 		verifyAuditRecordCalls(recCalls[1], getEditionAction, audit.Unsuccessful, p)
@@ -489,13 +478,7 @@ func TestGetEditionAuditErrors(t *testing.T) {
 			},
 		}
 
-		auditMock := getMockAuditor()
-		auditMock.RecordFunc = func(ctx context.Context, action string, result string, params common.Params) error {
-			if action == getEditionAction && result == audit.Unsuccessful {
-				return errors.New("auditing error")
-			}
-			return nil
-		}
+		auditMock := createAuditor(getEditionAction, audit.Unsuccessful)
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditMock, genericMockedObservationStore)
 
 		api.Router.ServeHTTP(w, r)
@@ -503,8 +486,7 @@ func TestGetEditionAuditErrors(t *testing.T) {
 		recCalls := auditMock.RecordCalls()
 		p := common.Params{"dataset_id": "123-456", "edition": "678"}
 
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		So(w.Body.String(), ShouldEqual, internalServerErr)
+		assertInternalServerErr(w)
 		So(len(recCalls), ShouldEqual, 2)
 		verifyAuditRecordCalls(recCalls[0], getEditionAction, audit.Attempted, p)
 		verifyAuditRecordCalls(recCalls[1], getEditionAction, audit.Unsuccessful, p)
@@ -524,14 +506,7 @@ func TestGetEditionAuditErrors(t *testing.T) {
 			},
 		}
 
-		auditMock := getMockAuditor()
-		auditMock.RecordFunc = func(ctx context.Context, action string, result string, params common.Params) error {
-			if action == getEditionAction && result == audit.Successful {
-				return errors.New("error")
-			}
-			return nil
-		}
-
+		auditMock := createAuditor(getEditionAction, audit.Successful)
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditMock, genericMockedObservationStore)
 
 		api.Router.ServeHTTP(w, r)
@@ -539,8 +514,7 @@ func TestGetEditionAuditErrors(t *testing.T) {
 		recCalls := auditMock.RecordCalls()
 		p := common.Params{"dataset_id": "123-456", "edition": "678"}
 
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		So(w.Body.String(), ShouldEqual, internalServerErr)
+		assertInternalServerErr(w)
 		So(len(recCalls), ShouldEqual, 2)
 		verifyAuditRecordCalls(recCalls[0], getEditionAction, audit.Attempted, p)
 		verifyAuditRecordCalls(recCalls[1], getEditionAction, audit.Successful, p)


### PR DESCRIPTION
### What
Making the DatasetAPI great again.

Updated editions endpoints to use the latest changes from `go-ns/audit` package.

- `audit.Record()` now logs success or error internally so the caller no longer needs to do this.
- replaced log calls with `audit.LogError()` and `audit.LogInfo()` which will automatically add `user_identity`, `caller_identity` and `requestID/correlationID` to the log data making log output detailed and consistent.
### How to review
The API will function the same. Existing unit/integration tests should pass.

### Who can review
Team B