### PR TITLE
Feature/fix unkeyed fields

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -185,31 +185,6 @@ func Routes(cfg config.Configuration, router *mux.Router, dataStore store.DataSt
 	return &api
 }
 
-func handleErrorType(docType string, err error, w http.ResponseWriter) {
-	log.Error(err, nil)
-
-	switch docType {
-	default:
-		if err == errs.ErrEditionNotFound || err == errs.ErrVersionNotFound || err == errs.ErrDimensionNodeNotFound || err == errs.ErrInstanceNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	case "dimension":
-		if err == errs.ErrDatasetNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else if err == errs.ErrEditionNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else if err == errs.ErrVersionNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else if err == errs.ErrDimensionsNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	}
-}
-
 // Check wraps a HTTP handle. Checks that the state is not published
 func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/api.go
+++ b/api/api.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"time"
 
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
@@ -51,7 +52,11 @@ const (
 
 	auditError     = "error while attempting to record audit event, failing request"
 	auditActionErr = "failed to audit action"
+
+	hasDownloads = "has_downloads"
 )
+
+var trueStringified = strconv.FormatBool(true)
 
 // PublishCheck Checks if an version has been published
 type PublishCheck struct {
@@ -285,7 +290,7 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request), ac
 
 							// Set variable `has_downloads` to true to prevent request
 							// triggering version from being republished
-							vars["has_downloads"] = "true"
+							vars[hasDownloads] = trueStringified
 							r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
 							handle(w, r)
 							return

--- a/api/api.go
+++ b/api/api.go
@@ -274,13 +274,14 @@ func (d *PublishCheck) Check(handle func(http.ResponseWriter, *http.Request)) ht
 							}
 						}
 						if newVersion != nil {
-							b, err := json.Marshal(newVersion)
+							var b []byte
+							b, err = json.Marshal(newVersion)
 							if err != nil {
 								http.Error(w, err.Error(), http.StatusForbidden)
 								return
 							}
 
-							if err := r.Body.Close(); err != nil {
+							if err = r.Body.Close(); err != nil {
 								log.ErrorC("could not close response body", err, nil)
 							}
 							r.Body = ioutil.NopCloser(bytes.NewBuffer(b))

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -44,7 +44,7 @@ var (
 
 	urlBuilder                    = url.NewBuilder("localhost:20000")
 	genericMockedObservationStore = &mocks.ObservationStoreMock{}
-	auditParams                   = common.Params{"dataset_id": "123-456"}
+	genericAuditParams            = common.Params{"dataset_id": "123-456"}
 )
 
 // GetAPIWithMockedDatastore also used in other tests, so exported
@@ -86,8 +86,8 @@ func TestGetDatasetsReturnsOK(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetDatasetsCalls()), ShouldEqual, 1)
 		mockAuditor.AssertRecordCalls(
-			audit_mock.Expected{getDatasetsAction, audit.Attempted, nil},
-			audit_mock.Expected{getDatasetsAction, audit.Successful, nil},
+			audit_mock.Expected{Action: getDatasetsAction, Result: audit.Attempted, Params: nil},
+			audit_mock.Expected{Action: getDatasetsAction, Result: audit.Successful, Params: nil},
 		)
 	})
 }
@@ -113,7 +113,7 @@ func TestGetDatasetsReturnsErrorIfAuditAttemptFails(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 
 		assertInternalServerErr(w)
-		auditMock.AssertRecordCalls(audit_mock.Expected{getDatasetsAction, audit.Attempted, nil})
+		auditMock.AssertRecordCalls(audit_mock.Expected{Action: getDatasetsAction, Result: audit.Attempted, Params: nil})
 		So(len(mockedDataStore.GetDatasetsCalls()), ShouldEqual, 0)
 	})
 
@@ -142,8 +142,8 @@ func TestGetDatasetsReturnsErrorIfAuditAttemptFails(t *testing.T) {
 		So(strings.TrimSpace(w.Body.String()), ShouldEqual, errInternal.Error())
 		So(len(mockedDataStore.GetDatasetsCalls()), ShouldEqual, 1)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getDatasetsAction, audit.Attempted, nil},
-			audit_mock.Expected{getDatasetsAction, audit.Unsuccessful, nil},
+			audit_mock.Expected{Action: getDatasetsAction, Result: audit.Attempted, Params: nil},
+			audit_mock.Expected{Action: getDatasetsAction, Result: audit.Unsuccessful, Params: nil},
 		)
 	})
 }
@@ -167,8 +167,8 @@ func TestGetDatasetsReturnsError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(len(mockedDataStore.GetDatasetsCalls()), ShouldEqual, 1)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getDatasetsAction, audit.Attempted, nil},
-			audit_mock.Expected{getDatasetsAction, audit.Unsuccessful, nil},
+			audit_mock.Expected{Action: getDatasetsAction, Result: audit.Attempted, Params: nil},
+			audit_mock.Expected{Action: getDatasetsAction, Result: audit.Unsuccessful, Params: nil},
 		)
 
 	})
@@ -192,8 +192,8 @@ func TestGetDatasetsAuditSuccessfulError(t *testing.T) {
 
 		So(len(mockedDataStore.GetDatasetsCalls()), ShouldEqual, 1)
 		mockAuditor.AssertRecordCalls(
-			audit_mock.Expected{getDatasetsAction, audit.Attempted, nil},
-			audit_mock.Expected{getDatasetsAction, audit.Successful, nil},
+			audit_mock.Expected{Action: getDatasetsAction, Result: audit.Attempted, Params: nil},
+			audit_mock.Expected{Action: getDatasetsAction, Result: audit.Successful, Params: nil},
 		)
 		assertInternalServerErr(w)
 	})
@@ -216,8 +216,8 @@ func TestGetDatasetReturnsOK(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getDatasetAction, audit.Attempted, auditParams},
-			audit_mock.Expected{getDatasetAction, audit.Successful, auditParams},
+			audit_mock.Expected{Action: getDatasetAction, Result: audit.Attempted, Params: genericAuditParams},
+			audit_mock.Expected{Action: getDatasetAction, Result: audit.Successful, Params: genericAuditParams},
 		)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -243,8 +243,8 @@ func TestGetDatasetReturnsOK(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getDatasetAction, audit.Attempted, auditParams},
-			audit_mock.Expected{getDatasetAction, audit.Successful, auditParams},
+			audit_mock.Expected{Action: getDatasetAction, Result: audit.Attempted, Params: genericAuditParams},
+			audit_mock.Expected{Action: getDatasetAction, Result: audit.Successful, Params: genericAuditParams},
 		)
 	})
 }
@@ -268,8 +268,8 @@ func TestGetDatasetReturnsError(t *testing.T) {
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getDatasetAction, audit.Attempted, auditParams},
-			audit_mock.Expected{getDatasetAction, audit.Unsuccessful, auditParams},
+			audit_mock.Expected{Action: getDatasetAction, Result: audit.Attempted, Params: genericAuditParams},
+			audit_mock.Expected{Action: getDatasetAction, Result: audit.Unsuccessful, Params: genericAuditParams},
 		)
 	})
 
@@ -309,8 +309,8 @@ func TestGetDatasetReturnsError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getDatasetAction, audit.Attempted, auditParams},
-			audit_mock.Expected{getDatasetAction, audit.Unsuccessful, auditParams},
+			audit_mock.Expected{Action: getDatasetAction, Result: audit.Attempted, Params: genericAuditParams},
+			audit_mock.Expected{Action: getDatasetAction, Result: audit.Unsuccessful, Params: genericAuditParams},
 		)
 	})
 }
@@ -335,7 +335,7 @@ func TestGetDatasetAuditingErrors(t *testing.T) {
 				assertInternalServerErr(w)
 				So(len(mockDatastore.GetDatasetCalls()), ShouldEqual, 0)
 				auditMock.AssertRecordCalls(
-					audit_mock.Expected{getDatasetAction, audit.Attempted, auditParams},
+					audit_mock.Expected{Action: getDatasetAction, Result: audit.Attempted, Params: genericAuditParams},
 				)
 			})
 		})
@@ -367,8 +367,8 @@ func TestGetDatasetAuditingErrors(t *testing.T) {
 				So(len(mockDatastore.GetDatasetCalls()), ShouldEqual, 1)
 				assertInternalServerErr(w)
 				auditMock.AssertRecordCalls(
-					audit_mock.Expected{getDatasetAction, audit.Attempted, auditParams},
-					audit_mock.Expected{getDatasetAction, audit.Successful, auditParams},
+					audit_mock.Expected{Action: getDatasetAction, Result: audit.Attempted, Params: genericAuditParams},
+					audit_mock.Expected{Action: getDatasetAction, Result: audit.Successful, Params: genericAuditParams},
 				)
 			})
 		})
@@ -400,8 +400,8 @@ func TestGetDatasetAuditingErrors(t *testing.T) {
 				assertInternalServerErr(w)
 				So(len(mockDatastore.GetDatasetCalls()), ShouldEqual, 1)
 				auditMock.AssertRecordCalls(
-					audit_mock.Expected{getDatasetAction, audit.Attempted, auditParams},
-					audit_mock.Expected{getDatasetAction, audit.Unsuccessful, auditParams},
+					audit_mock.Expected{Action: getDatasetAction, Result: audit.Attempted, Params: genericAuditParams},
+					audit_mock.Expected{Action: getDatasetAction, Result: audit.Unsuccessful, Params: genericAuditParams},
 				)
 
 			})
@@ -567,7 +567,7 @@ func TestPostDatasetAuditErrors(t *testing.T) {
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{addDatasetAction, audit.Attempted, ap},
+					audit_mock.Expected{Action: addDatasetAction, Result: audit.Attempted, Params: ap},
 				)
 			})
 		})
@@ -594,8 +594,8 @@ func TestPostDatasetAuditErrors(t *testing.T) {
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{addDatasetAction, audit.Attempted, ap},
-					audit_mock.Expected{addDatasetAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: addDatasetAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: addDatasetAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -620,8 +620,8 @@ func TestPostDatasetAuditErrors(t *testing.T) {
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{addDatasetAction, audit.Attempted, ap},
-					audit_mock.Expected{addDatasetAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: addDatasetAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: addDatasetAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -648,8 +648,8 @@ func TestPostDatasetAuditErrors(t *testing.T) {
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 1)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{addDatasetAction, audit.Attempted, ap},
-					audit_mock.Expected{addDatasetAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: addDatasetAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: addDatasetAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -679,8 +679,8 @@ func TestPostDatasetAuditErrors(t *testing.T) {
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 1)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{addDatasetAction, audit.Attempted, ap},
-					audit_mock.Expected{addDatasetAction, audit.Successful, ap},
+					audit_mock.Expected{Action: addDatasetAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: addDatasetAction, Result: audit.Successful, Params: ap},
 				)
 			})
 		})
@@ -719,15 +719,15 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 2)
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{putDatasetAction, audit.Attempted, common.Params{"dataset_id": "123"}},
-			audit_mock.Expected{putDatasetAction, audit.Successful, common.Params{"dataset_id": "123"}},
+			audit_mock.Expected{Action: putDatasetAction, Result: audit.Attempted, Params: common.Params{"dataset_id": "123"}},
+			audit_mock.Expected{Action: putDatasetAction, Result: audit.Successful, Params: common.Params{"dataset_id": "123"}},
 		)
 	})
 }
 
 func TestPutDatasetReturnsError(t *testing.T) {
-	auditParams := common.Params{"dataset_id": "123"}
 	t.Parallel()
+	ap := common.Params{"dataset_id": "123"}
 	Convey("When the request contain malformed json a bad request status is returned", t, func() {
 		var b string
 		b = "{"
@@ -756,8 +756,8 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 0)
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{putDatasetAction, audit.Attempted, auditParams},
-			audit_mock.Expected{putDatasetAction, audit.Unsuccessful, auditParams},
+			audit_mock.Expected{Action: putDatasetAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: putDatasetAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 
@@ -793,8 +793,8 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 2)
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{putDatasetAction, audit.Attempted, auditParams},
-			audit_mock.Expected{putDatasetAction, audit.Unsuccessful, auditParams},
+			audit_mock.Expected{Action: putDatasetAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: putDatasetAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 
@@ -825,8 +825,8 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 0)
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{putDatasetAction, audit.Attempted, auditParams},
-			audit_mock.Expected{putDatasetAction, audit.Unsuccessful, auditParams},
+			audit_mock.Expected{Action: putDatasetAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: putDatasetAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 
@@ -888,7 +888,7 @@ func TestPutDatasetAuditErrors(t *testing.T) {
 				So(w.Code, ShouldEqual, http.StatusInternalServerError)
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 0)
-				auditor.AssertRecordCalls(audit_mock.Expected{putDatasetAction, audit.Attempted, ap})
+				auditor.AssertRecordCalls(audit_mock.Expected{Action: putDatasetAction, Result: audit.Attempted, Params: ap})
 			})
 		})
 	})
@@ -918,8 +918,8 @@ func TestPutDatasetAuditErrors(t *testing.T) {
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 1)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{putDatasetAction, audit.Attempted, ap},
-					audit_mock.Expected{putDatasetAction, audit.Successful, ap},
+					audit_mock.Expected{Action: putDatasetAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: putDatasetAction, Result: audit.Successful, Params: ap},
 				)
 			})
 		})
@@ -950,8 +950,8 @@ func TestPutDatasetAuditErrors(t *testing.T) {
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 0)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{putDatasetAction, audit.Attempted, ap},
-					audit_mock.Expected{putDatasetAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: putDatasetAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: putDatasetAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -975,8 +975,8 @@ func TestPutDatasetAuditErrors(t *testing.T) {
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 0)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{putDatasetAction, audit.Attempted, ap},
-					audit_mock.Expected{putDatasetAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: putDatasetAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: putDatasetAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -1009,8 +1009,8 @@ func TestPutDatasetAuditErrors(t *testing.T) {
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 1)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{putDatasetAction, audit.Attempted, ap},
-					audit_mock.Expected{putDatasetAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: putDatasetAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: putDatasetAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -1037,8 +1037,8 @@ func TestPutDatasetAuditErrors(t *testing.T) {
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 1)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{putDatasetAction, audit.Attempted, ap},
-					audit_mock.Expected{putDatasetAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: putDatasetAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: putDatasetAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -1071,8 +1071,8 @@ func TestDeleteDatasetReturnsSuccessfully(t *testing.T) {
 		So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 1)
 		ap := common.Params{"dataset_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{deleteDatasetAction, audit.Attempted, ap},
-			audit_mock.Expected{deleteDatasetAction, audit.Successful, ap},
+			audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Successful, Params: ap},
 		)
 	})
 }
@@ -1103,8 +1103,8 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 		So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 0)
 		ap := common.Params{"dataset_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{deleteDatasetAction, audit.Attempted, ap},
-			audit_mock.Expected{deleteDatasetAction, audit.Unsuccessful, ap},
+			audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 
@@ -1134,8 +1134,8 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 		So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 1)
 		ap := common.Params{"dataset_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{deleteDatasetAction, audit.Attempted, ap},
-			audit_mock.Expected{deleteDatasetAction, audit.Unsuccessful, ap},
+			audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 
@@ -1165,8 +1165,8 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 
 		ap := common.Params{"dataset_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{deleteDatasetAction, audit.Attempted, ap},
-			audit_mock.Expected{deleteDatasetAction, audit.Unsuccessful, ap},
+			audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 
@@ -1196,8 +1196,8 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 
 		ap := common.Params{"dataset_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{deleteDatasetAction, audit.Attempted, ap},
-			audit_mock.Expected{deleteDatasetAction, audit.Unsuccessful, ap},
+			audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 
@@ -1244,7 +1244,7 @@ func TestDeleteDatasetAuditActionAttemptedError(t *testing.T) {
 
 				ap := common.Params{"dataset_id": "123"}
 				auditorMock.AssertRecordCalls(
-					audit_mock.Expected{deleteDatasetAction, audit.Attempted, ap},
+					audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Attempted, Params: ap},
 				)
 			})
 		})
@@ -1277,8 +1277,8 @@ func TestDeleteDatasetAuditauditUnsuccessfulError(t *testing.T) {
 
 				ap := common.Params{"dataset_id": "123"}
 				auditorMock.AssertRecordCalls(
-					audit_mock.Expected{deleteDatasetAction, audit.Attempted, ap},
-					audit_mock.Expected{deleteDatasetAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -1306,8 +1306,8 @@ func TestDeleteDatasetAuditauditUnsuccessfulError(t *testing.T) {
 
 				ap := common.Params{"dataset_id": "123"}
 				auditorMock.AssertRecordCalls(
-					audit_mock.Expected{deleteDatasetAction, audit.Attempted, ap},
-					audit_mock.Expected{deleteDatasetAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -1335,8 +1335,8 @@ func TestDeleteDatasetAuditauditUnsuccessfulError(t *testing.T) {
 
 				ap := common.Params{"dataset_id": "123"}
 				auditorMock.AssertRecordCalls(
-					audit_mock.Expected{deleteDatasetAction, audit.Attempted, ap},
-					audit_mock.Expected{deleteDatasetAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -1367,8 +1367,8 @@ func TestDeleteDatasetAuditauditUnsuccessfulError(t *testing.T) {
 
 				ap := common.Params{"dataset_id": "123"}
 				auditorMock.AssertRecordCalls(
-					audit_mock.Expected{deleteDatasetAction, audit.Attempted, ap},
-					audit_mock.Expected{deleteDatasetAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -1403,8 +1403,8 @@ func TestDeleteDatasetAuditActionSuccessfulError(t *testing.T) {
 
 				ap := common.Params{"dataset_id": "123"}
 				auditorMock.AssertRecordCalls(
-					audit_mock.Expected{deleteDatasetAction, audit.Attempted, ap},
-					audit_mock.Expected{deleteDatasetAction, audit.Successful, ap},
+					audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: deleteDatasetAction, Result: audit.Successful, Params: ap},
 				)
 			})
 		})

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -13,14 +13,13 @@ import (
 	"time"
 
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
-	"github.com/ONSdigital/go-ns/audit/audit_mock"
-
 	"github.com/ONSdigital/dp-dataset-api/mocks"
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store"
-	"github.com/ONSdigital/dp-dataset-api/store/datastoretest"
+	storetest "github.com/ONSdigital/dp-dataset-api/store/datastoretest"
 	"github.com/ONSdigital/dp-dataset-api/url"
 	"github.com/ONSdigital/go-ns/audit"
+	"github.com/ONSdigital/go-ns/audit/audit_mock"
 	"github.com/ONSdigital/go-ns/common"
 	"github.com/gorilla/mux"
 

--- a/api/dimensions.go
+++ b/api/dimensions.go
@@ -26,8 +26,7 @@ func (api *DatasetAPI) getDimensions(w http.ResponseWriter, r *http.Request) {
 	auditParams := common.Params{"dataset_id": datasetID, "edition": edition, "version": version}
 
 	if err := api.auditor.Record(ctx, getDimensionsAction, audit.Attempted, auditParams); err != nil {
-		auditActionFailure(ctx, getDimensionsAction, audit.Attempted, err, logData)
-		handleDimensionsErr(ctx, w, err)
+		handleDimensionsErr(ctx, w, err, logData)
 		return
 	}
 
@@ -41,25 +40,25 @@ func (api *DatasetAPI) getDimensions(w http.ResponseWriter, r *http.Request) {
 
 		versionDoc, err := api.dataStore.Backend.GetVersion(datasetID, edition, version, state)
 		if err != nil {
-			logError(ctx, errors.WithMessage(err, "getDimensions endpoint: datastore.getversion returned an error"), logData)
+			log.ErrorCtx(ctx, errors.WithMessage(err, "getDimensions endpoint: datastore.getversion returned an error"), logData)
 			return nil, err
 		}
 
 		if err = models.CheckState("version", versionDoc.State); err != nil {
 			logData["state"] = versionDoc.State
-			logError(ctx, errors.WithMessage(err, "getDimensions endpoint: unpublished version has an invalid state"), logData)
+			log.ErrorCtx(ctx, errors.WithMessage(err, "getDimensions endpoint: unpublished version has an invalid state"), logData)
 			return nil, err
 		}
 
 		dimensions, err := api.dataStore.Backend.GetDimensions(datasetID, versionDoc.ID)
 		if err != nil {
-			logError(ctx, errors.WithMessage(err, "getDimensions endpoint: failed to get version dimensions"), logData)
+			log.ErrorCtx(ctx, errors.WithMessage(err, "getDimensions endpoint: failed to get version dimensions"), logData)
 			return nil, err
 		}
 
 		results, err := api.createListOfDimensions(versionDoc, dimensions)
 		if err != nil {
-			logError(ctx, errors.WithMessage(err, "getDimensions endpoint: failed to convert bson to dimension"), logData)
+			log.ErrorCtx(ctx, errors.WithMessage(err, "getDimensions endpoint: failed to convert bson to dimension"), logData)
 			return nil, err
 		}
 
@@ -67,7 +66,7 @@ func (api *DatasetAPI) getDimensions(w http.ResponseWriter, r *http.Request) {
 
 		b, err := json.Marshal(listOfDimensions)
 		if err != nil {
-			logError(ctx, errors.WithMessage(err, "getDimensions endpoint: failed to marshal list of dimension resources into bytes"), logData)
+			log.ErrorCtx(ctx, errors.WithMessage(err, "getDimensions endpoint: failed to marshal list of dimension resources into bytes"), logData)
 			return nil, err
 		}
 		return b, nil
@@ -75,25 +74,25 @@ func (api *DatasetAPI) getDimensions(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		if auditErr := api.auditor.Record(ctx, getDimensionsAction, audit.Unsuccessful, auditParams); auditErr != nil {
-			auditActionFailure(ctx, getDimensionsAction, audit.Unsuccessful, auditErr, logData)
+			err = auditErr
 		}
-		handleDimensionsErr(ctx, w, err)
+		handleDimensionsErr(ctx, w, err, logData)
 		return
 	}
 
 	if auditErr := api.auditor.Record(ctx, getDimensionsAction, audit.Successful, auditParams); auditErr != nil {
-		auditActionFailure(ctx, getDimensionsAction, audit.Successful, auditErr, logData)
-		handleDimensionsErr(ctx, w, auditErr)
+		handleDimensionsErr(ctx, w, auditErr, logData)
 		return
 	}
 
 	setJSONContentType(w)
 	_, err = w.Write(b)
 	if err != nil {
-		logError(ctx, errors.WithMessage(err, "getDimensions endpoint: error writing bytes to response"), logData)
+		log.ErrorCtx(ctx, errors.WithMessage(err, "getDimensions endpoint: error writing bytes to response"), logData)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
-	logInfo(ctx, "getDimensions endpoint: request successful", logData)
+
+	log.InfoCtx(ctx, "getDimensions endpoint: request successful", logData)
 }
 
 func (api *DatasetAPI) createListOfDimensions(versionDoc *models.Version, dimensions []bson.M) ([]models.Dimension, error) {
@@ -162,7 +161,7 @@ func (api *DatasetAPI) getDimensionOptions(w http.ResponseWriter, r *http.Reques
 	version, err := api.dataStore.Backend.GetVersion(datasetID, editionID, versionID, state)
 	if err != nil {
 		log.ErrorC("failed to get version", err, logData)
-		handleDimensionsErr(ctx, w, err)
+		handleDimensionsErr(ctx, w, err, logData)
 		return
 	}
 
@@ -175,7 +174,7 @@ func (api *DatasetAPI) getDimensionOptions(w http.ResponseWriter, r *http.Reques
 	results, err := api.dataStore.Backend.GetDimensionOptions(version, dimension)
 	if err != nil {
 		log.ErrorC("failed to get a list of dimension options", err, logData)
-		handleDimensionsErr(ctx, w, err)
+		handleDimensionsErr(ctx, w, err, logData)
 		return
 	}
 
@@ -201,9 +200,12 @@ func (api *DatasetAPI) getDimensionOptions(w http.ResponseWriter, r *http.Reques
 	log.Debug("get dimension options", logData)
 }
 
-func handleDimensionsErr(ctx context.Context, w http.ResponseWriter, err error) {
-	var responseStatus int
+func handleDimensionsErr(ctx context.Context, w http.ResponseWriter, err error, data log.Data) {
+	if data == nil {
+		data = log.Data{}
+	}
 
+	var responseStatus int
 	switch {
 	case errs.NotFoundMap[err]:
 		responseStatus = http.StatusNotFound
@@ -211,6 +213,7 @@ func handleDimensionsErr(ctx context.Context, w http.ResponseWriter, err error) 
 		responseStatus = http.StatusInternalServerError
 	}
 
-	logError(ctx, errors.WithMessage(err, "request unsuccessful"), log.Data{"responseStatus": responseStatus})
+	data["responseStatus"] = responseStatus
+	log.ErrorCtx(ctx, errors.WithMessage(err, "request unsuccessful"), data)
 	http.Error(w, err.Error(), responseStatus)
 }

--- a/api/dimensions_test.go
+++ b/api/dimensions_test.go
@@ -230,7 +230,7 @@ func TestGetDimensionsAuditingErrors(t *testing.T) {
 			api.Router.ServeHTTP(w, r)
 
 			Convey("then a 500 status is returned", func() {
-				So(w.Code, ShouldEqual, http.StatusNotFound)
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
 				So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.GetDimensionsCalls()), ShouldEqual, 0)
 
@@ -280,7 +280,7 @@ func TestGetDimensionsAuditingErrors(t *testing.T) {
 			api.Router.ServeHTTP(w, r)
 
 			Convey("then a 500 status is returned", func() {
-				So(w.Code, ShouldEqual, http.StatusNotFound)
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
 				So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.GetDimensionsCalls()), ShouldEqual, 1)
 				auditor.AssertRecordCalls(

--- a/api/dimensions_test.go
+++ b/api/dimensions_test.go
@@ -44,8 +44,8 @@ func TestGetDimensionsReturnsOk(t *testing.T) {
 			"version":    "1",
 		}
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{getDimensionsAction, audit.Attempted, ap},
-			audit_mock.Expected{getDimensionsAction, audit.Successful, ap},
+			audit_mock.Expected{Action: getDimensionsAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: getDimensionsAction, Result: audit.Successful, Params: ap},
 		)
 	})
 }
@@ -77,8 +77,8 @@ func TestGetDimensionsReturnsErrors(t *testing.T) {
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetDimensionsCalls()), ShouldEqual, 0)
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{getDimensionsAction, audit.Attempted, ap},
-			audit_mock.Expected{getDimensionsAction, audit.Unsuccessful, ap},
+			audit_mock.Expected{Action: getDimensionsAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: getDimensionsAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 
@@ -101,8 +101,8 @@ func TestGetDimensionsReturnsErrors(t *testing.T) {
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetDimensionsCalls()), ShouldEqual, 0)
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{getDimensionsAction, audit.Attempted, ap},
-			audit_mock.Expected{getDimensionsAction, audit.Unsuccessful, ap},
+			audit_mock.Expected{Action: getDimensionsAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: getDimensionsAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 
@@ -128,8 +128,8 @@ func TestGetDimensionsReturnsErrors(t *testing.T) {
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetDimensionsCalls()), ShouldEqual, 1)
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{getDimensionsAction, audit.Attempted, ap},
-			audit_mock.Expected{getDimensionsAction, audit.Unsuccessful, ap},
+			audit_mock.Expected{Action: getDimensionsAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: getDimensionsAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 
@@ -152,8 +152,8 @@ func TestGetDimensionsReturnsErrors(t *testing.T) {
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetDimensionsCalls()), ShouldEqual, 0)
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{getDimensionsAction, audit.Attempted, ap},
-			audit_mock.Expected{getDimensionsAction, audit.Unsuccessful, ap},
+			audit_mock.Expected{Action: getDimensionsAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: getDimensionsAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 }
@@ -178,7 +178,7 @@ func TestGetDimensionsAuditingErrors(t *testing.T) {
 				So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.GetDimensionsCalls()), ShouldEqual, 0)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getDimensionsAction, audit.Attempted, ap},
+					audit_mock.Expected{Action: getDimensionsAction, Result: audit.Attempted, Params: ap},
 				)
 			})
 		})
@@ -207,8 +207,8 @@ func TestGetDimensionsAuditingErrors(t *testing.T) {
 				So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.GetDimensionsCalls()), ShouldEqual, 1)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getDimensionsAction, audit.Attempted, ap},
-					audit_mock.Expected{getDimensionsAction, audit.Successful, ap},
+					audit_mock.Expected{Action: getDimensionsAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getDimensionsAction, Result: audit.Successful, Params: ap},
 				)
 			})
 		})
@@ -235,8 +235,8 @@ func TestGetDimensionsAuditingErrors(t *testing.T) {
 				So(len(mockedDataStore.GetDimensionsCalls()), ShouldEqual, 0)
 
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getDimensionsAction, audit.Attempted, ap},
-					audit_mock.Expected{getDimensionsAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: getDimensionsAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getDimensionsAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -258,8 +258,8 @@ func TestGetDimensionsAuditingErrors(t *testing.T) {
 				So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.GetDimensionsCalls()), ShouldEqual, 0)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getDimensionsAction, audit.Attempted, ap},
-					audit_mock.Expected{getDimensionsAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: getDimensionsAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getDimensionsAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -284,8 +284,8 @@ func TestGetDimensionsAuditingErrors(t *testing.T) {
 				So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.GetDimensionsCalls()), ShouldEqual, 1)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getDimensionsAction, audit.Attempted, ap},
-					audit_mock.Expected{getDimensionsAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: getDimensionsAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getDimensionsAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})

--- a/api/editions_test.go
+++ b/api/editions_test.go
@@ -43,8 +43,8 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusOK)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionsAction, audit.Attempted, auditParams},
-			audit_mock.Expected{getEditionsAction, audit.Successful, auditParams},
+			audit_mock.Expected{Action: getEditionsAction, Result: audit.Attempted, Params: genericAuditParams},
+			audit_mock.Expected{Action: getEditionsAction, Result: audit.Successful, Params: genericAuditParams},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -75,7 +75,7 @@ func TestGetEditionsAuditingError(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 
 		assertInternalServerErr(w)
-		auditMock.AssertRecordCalls(audit_mock.Expected{getEditionsAction, audit.Attempted, auditParams})
+		auditMock.AssertRecordCalls(audit_mock.Expected{Action: getEditionsAction, Result: audit.Attempted, Params: genericAuditParams})
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
 	})
@@ -99,8 +99,8 @@ func TestGetEditionsAuditingError(t *testing.T) {
 
 		assertInternalServerErr(w)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionsAction, audit.Attempted, auditParams},
-			audit_mock.Expected{getEditionsAction, audit.Successful, auditParams},
+			audit_mock.Expected{Action: getEditionsAction, Result: audit.Attempted, Params: genericAuditParams},
+			audit_mock.Expected{Action: getEditionsAction, Result: audit.Successful, Params: genericAuditParams},
 		)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 1)
@@ -123,8 +123,8 @@ func TestGetEditionsAuditingError(t *testing.T) {
 
 		assertInternalServerErr(w)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionsAction, audit.Attempted, auditParams},
-			audit_mock.Expected{getEditionsAction, audit.Unsuccessful, auditParams},
+			audit_mock.Expected{Action: getEditionsAction, Result: audit.Attempted, Params: genericAuditParams},
+			audit_mock.Expected{Action: getEditionsAction, Result: audit.Unsuccessful, Params: genericAuditParams},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -150,8 +150,8 @@ func TestGetEditionsAuditingError(t *testing.T) {
 
 		assertInternalServerErr(w)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionsAction, audit.Attempted, auditParams},
-			audit_mock.Expected{getEditionsAction, audit.Unsuccessful, auditParams},
+			audit_mock.Expected{Action: getEditionsAction, Result: audit.Attempted, Params: genericAuditParams},
+			audit_mock.Expected{Action: getEditionsAction, Result: audit.Unsuccessful, Params: genericAuditParams},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -179,8 +179,8 @@ func TestGetEditionsReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldResemble, "internal error\n")
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionsAction, audit.Attempted, auditParams},
-			audit_mock.Expected{getEditionsAction, audit.Unsuccessful, auditParams},
+			audit_mock.Expected{Action: getEditionsAction, Result: audit.Attempted, Params: genericAuditParams},
+			audit_mock.Expected{Action: getEditionsAction, Result: audit.Unsuccessful, Params: genericAuditParams},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -206,8 +206,8 @@ func TestGetEditionsReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldResemble, "Dataset not found\n")
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionsAction, audit.Attempted, auditParams},
-			audit_mock.Expected{getEditionsAction, audit.Unsuccessful, auditParams},
+			audit_mock.Expected{Action: getEditionsAction, Result: audit.Attempted, Params: genericAuditParams},
+			audit_mock.Expected{Action: getEditionsAction, Result: audit.Unsuccessful, Params: genericAuditParams},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -236,8 +236,8 @@ func TestGetEditionsReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldResemble, "Edition not found\n")
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionsAction, audit.Attempted, auditParams},
-			audit_mock.Expected{getEditionsAction, audit.Unsuccessful, auditParams},
+			audit_mock.Expected{Action: getEditionsAction, Result: audit.Attempted, Params: genericAuditParams},
+			audit_mock.Expected{Action: getEditionsAction, Result: audit.Unsuccessful, Params: genericAuditParams},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -289,8 +289,8 @@ func TestGetEditionReturnsOK(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusOK)
 		p := common.Params{"dataset_id": "123-456", "edition": "678"}
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionAction, audit.Attempted, p},
-			audit_mock.Expected{getEditionAction, audit.Successful, p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Successful, Params: p},
 		)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
@@ -318,8 +318,8 @@ func TestGetEditionReturnsError(t *testing.T) {
 
 		p := common.Params{"dataset_id": "123-456", "edition": "678"}
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionAction, audit.Attempted, p},
-			audit_mock.Expected{getEditionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -346,8 +346,8 @@ func TestGetEditionReturnsError(t *testing.T) {
 
 		p := common.Params{"dataset_id": "123-456", "edition": "678"}
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionAction, audit.Attempted, p},
-			audit_mock.Expected{getEditionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -377,8 +377,8 @@ func TestGetEditionReturnsError(t *testing.T) {
 
 		p := common.Params{"dataset_id": "123-456", "edition": "678"}
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionAction, audit.Attempted, p},
-			audit_mock.Expected{getEditionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -407,8 +407,8 @@ func TestGetEditionReturnsError(t *testing.T) {
 
 		p := common.Params{"dataset_id": "123-456", "edition": "678"}
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionAction, audit.Attempted, p},
-			audit_mock.Expected{getEditionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Unsuccessful, Params: p},
 		)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
@@ -429,7 +429,7 @@ func TestGetEditionAuditErrors(t *testing.T) {
 
 		assertInternalServerErr(w)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionAction, audit.Attempted, common.Params{"dataset_id": "123-456", "edition": "678"}},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Attempted, Params: common.Params{"dataset_id": "123-456", "edition": "678"}},
 		)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 0)
@@ -452,8 +452,8 @@ func TestGetEditionAuditErrors(t *testing.T) {
 		assertInternalServerErr(w)
 		p := common.Params{"dataset_id": "123-456", "edition": "678"}
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionAction, audit.Attempted, p},
-			audit_mock.Expected{getEditionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -481,8 +481,8 @@ func TestGetEditionAuditErrors(t *testing.T) {
 		assertInternalServerErr(w)
 		p := common.Params{"dataset_id": "123-456", "edition": "678"}
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionAction, audit.Attempted, p},
-			audit_mock.Expected{getEditionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Unsuccessful, Params: p},
 		)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
@@ -508,8 +508,8 @@ func TestGetEditionAuditErrors(t *testing.T) {
 		assertInternalServerErr(w)
 		p := common.Params{"dataset_id": "123-456", "edition": "678"}
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getEditionAction, audit.Attempted, p},
-			audit_mock.Expected{getEditionAction, audit.Successful, p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getEditionAction, Result: audit.Successful, Params: p},
 		)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)

--- a/api/metadata_test.go
+++ b/api/metadata_test.go
@@ -51,8 +51,8 @@ func TestGetMetadataReturnsOk(t *testing.T) {
 
 		ap := common.Params{"dataset_id": "123", "edition": "2017", "version": "1"}
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{getMetadataAction, audit.Attempted, ap},
-			audit_mock.Expected{getMetadataAction, audit.Successful, ap},
+			audit_mock.Expected{Action: getMetadataAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: getMetadataAction, Result: audit.Successful, Params: ap},
 		)
 
 		bytes, err := ioutil.ReadAll(w.Body)
@@ -114,8 +114,8 @@ func TestGetMetadataReturnsOk(t *testing.T) {
 
 		ap := common.Params{"dataset_id": "123", "edition": "2017", "version": "1"}
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{getMetadataAction, audit.Attempted, ap},
-			audit_mock.Expected{getMetadataAction, audit.Successful, ap},
+			audit_mock.Expected{Action: getMetadataAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: getMetadataAction, Result: audit.Successful, Params: ap},
 		)
 
 		bytes, err := ioutil.ReadAll(w.Body)
@@ -318,7 +318,7 @@ func TestGetMetadataAuditingErrors(t *testing.T) {
 			Convey("then a 500 status is returned", func() {
 				So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-				auditor.AssertRecordCalls(audit_mock.Expected{getMetadataAction, audit.Attempted, ap})
+				auditor.AssertRecordCalls(audit_mock.Expected{Action: getMetadataAction, Result: audit.Attempted, Params: ap})
 
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 0)
@@ -346,8 +346,8 @@ func TestGetMetadataAuditingErrors(t *testing.T) {
 			Convey("then a 500 status is returned", func() {
 				assertInternalServerErr(w)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getMetadataAction, audit.Attempted, ap},
-					audit_mock.Expected{getMetadataAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: getMetadataAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getMetadataAction, Result: audit.Unsuccessful, Params: ap},
 				)
 
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -372,8 +372,8 @@ func TestGetMetadataAuditingErrors(t *testing.T) {
 			Convey("then a 500 status is returned", func() {
 				assertInternalServerErr(w)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getMetadataAction, audit.Attempted, ap},
-					audit_mock.Expected{getMetadataAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: getMetadataAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getMetadataAction, Result: audit.Unsuccessful, Params: ap},
 				)
 
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -401,8 +401,8 @@ func TestGetMetadataAuditingErrors(t *testing.T) {
 			Convey("then a 500 status is returned", func() {
 				assertInternalServerErr(w)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getMetadataAction, audit.Attempted, ap},
-					audit_mock.Expected{getMetadataAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: getMetadataAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getMetadataAction, Result: audit.Unsuccessful, Params: ap},
 				)
 
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -433,8 +433,8 @@ func TestGetMetadataAuditingErrors(t *testing.T) {
 			Convey("then a 500 status is returned", func() {
 				assertInternalServerErr(w)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getMetadataAction, audit.Attempted, ap},
-					audit_mock.Expected{getMetadataAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: getMetadataAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getMetadataAction, Result: audit.Unsuccessful, Params: ap},
 				)
 
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -467,8 +467,8 @@ func TestGetMetadataAuditingErrors(t *testing.T) {
 			Convey("then a 500 status is returned", func() {
 				assertInternalServerErr(w)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getMetadataAction, audit.Attempted, ap},
-					audit_mock.Expected{getMetadataAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: getMetadataAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getMetadataAction, Result: audit.Unsuccessful, Params: ap},
 				)
 
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -504,8 +504,8 @@ func TestGetMetadataAuditingErrors(t *testing.T) {
 				So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getMetadataAction, audit.Attempted, ap},
-					audit_mock.Expected{getMetadataAction, audit.Successful, ap},
+					audit_mock.Expected{Action: getMetadataAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getMetadataAction, Result: audit.Successful, Params: ap},
 				)
 
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)

--- a/api/observation_test.go
+++ b/api/observation_test.go
@@ -113,8 +113,8 @@ func TestGetObservationsReturnsOK(t *testing.T) {
 
 			ap := common.Params{"dataset_id": "cpih012", "edition": "2017", "version": "1"}
 			auditor.AssertRecordCalls(
-				audit_mock.Expected{getObservationsAction, audit.Attempted, ap},
-				audit_mock.Expected{getObservationsAction, audit.Successful, ap},
+				audit_mock.Expected{Action: getObservationsAction, Result: audit.Attempted, Params: ap},
+				audit_mock.Expected{Action: getObservationsAction, Result: audit.Successful, Params: ap},
 			)
 		})
 
@@ -134,8 +134,8 @@ func TestGetObservationsReturnsOK(t *testing.T) {
 
 			ap := common.Params{"dataset_id": "cpih012", "edition": "2017", "version": "1"}
 			auditor.AssertRecordCalls(
-				audit_mock.Expected{getObservationsAction, audit.Attempted, ap},
-				audit_mock.Expected{getObservationsAction, audit.Successful, ap},
+				audit_mock.Expected{Action: getObservationsAction, Result: audit.Attempted, Params: ap},
+				audit_mock.Expected{Action: getObservationsAction, Result: audit.Successful, Params: ap},
 			)
 		})
 	})
@@ -823,7 +823,7 @@ func TestGetObservationAuditAttemptedError(t *testing.T) {
 			Convey("then a 500 response status is returned", func() {
 				assertInternalServerErr(w)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getObservationsAction, audit.Attempted, common.Params{"dataset_id": "cpih012", "edition": "2017", "version": "1"}},
+					audit_mock.Expected{Action: getObservationsAction, Result: audit.Attempted, Params: common.Params{"dataset_id": "cpih012", "edition": "2017", "version": "1"}},
 				)
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 0)
@@ -857,8 +857,8 @@ func TestGetObservationAuditUnsuccessfulError(t *testing.T) {
 			Convey("then a 500 response status is returned", func() {
 				assertInternalServerErr(w)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getObservationsAction, audit.Attempted, ap},
-					audit_mock.Expected{getObservationsAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: getObservationsAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getObservationsAction, Result: audit.Unsuccessful, Params: ap},
 				)
 
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -890,8 +890,8 @@ func TestGetObservationAuditUnsuccessfulError(t *testing.T) {
 			Convey("then a 500 response status is returned", func() {
 				assertInternalServerErr(w)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getObservationsAction, audit.Attempted, ap},
-					audit_mock.Expected{getObservationsAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: getObservationsAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getObservationsAction, Result: audit.Unsuccessful, Params: ap},
 				)
 
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -926,8 +926,8 @@ func TestGetObservationAuditUnsuccessfulError(t *testing.T) {
 			Convey("then a 500 response status is returned", func() {
 				assertInternalServerErr(w)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getObservationsAction, audit.Attempted, ap},
-					audit_mock.Expected{getObservationsAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: getObservationsAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getObservationsAction, Result: audit.Unsuccessful, Params: ap},
 				)
 
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -962,8 +962,8 @@ func TestGetObservationAuditUnsuccessfulError(t *testing.T) {
 			Convey("then a 500 response status is returned", func() {
 				assertInternalServerErr(w)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getObservationsAction, audit.Attempted, ap},
-					audit_mock.Expected{getObservationsAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: getObservationsAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getObservationsAction, Result: audit.Unsuccessful, Params: ap},
 				)
 
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
@@ -1053,8 +1053,8 @@ func TestGetObservationAuditSuccessfulError(t *testing.T) {
 
 				assertInternalServerErr(w)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{getObservationsAction, audit.Attempted, ap},
-					audit_mock.Expected{getObservationsAction, audit.Successful, ap},
+					audit_mock.Expected{Action: getObservationsAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: getObservationsAction, Result: audit.Successful, Params: ap},
 				)
 
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)

--- a/api/versions.go
+++ b/api/versions.go
@@ -38,13 +38,14 @@ var (
 	}
 )
 
-type versionDetails struct {
+// VersionDetails contains the details that uniquely identify a version resource
+type VersionDetails struct {
 	datasetID string
 	edition   string
 	version   string
 }
 
-func (v versionDetails) baseAuditParams() common.Params {
+func (v VersionDetails) baseAuditParams() common.Params {
 	return common.Params{"dataset_id": v.datasetID, "edition": v.edition, "version": v.version}
 }
 
@@ -236,7 +237,7 @@ func (api *DatasetAPI) getVersion(w http.ResponseWriter, r *http.Request) {
 func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	vars := mux.Vars(r)
-	versionDetails := versionDetails{
+	versionDetails := VersionDetails{
 		datasetID: vars["id"],
 		edition:   vars["edition"],
 		version:   vars["version"],
@@ -272,7 +273,7 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 	audit.LogInfo(ctx, "putVersion endpoint: request successful", data)
 }
 
-func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, versionDetails versionDetails) (*models.DatasetUpdate, *models.Version, *models.Version, error) {
+func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, versionDetails VersionDetails) (*models.DatasetUpdate, *models.Version, *models.Version, error) {
 	ap := versionDetails.baseAuditParams()
 	data := audit.ToLogData(ap)
 
@@ -340,7 +341,7 @@ func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, ve
 	return currentDataset, currentVersion, versionUpdate, nil
 }
 
-func (api *DatasetAPI) publishVersion(ctx context.Context, currentDataset *models.DatasetUpdate, currentVersion *models.Version, versionDoc *models.Version, versionDetails versionDetails) error {
+func (api *DatasetAPI) publishVersion(ctx context.Context, currentDataset *models.DatasetUpdate, currentVersion *models.Version, versionDoc *models.Version, versionDetails VersionDetails) error {
 	ap := versionDetails.baseAuditParams()
 	data := audit.ToLogData(ap)
 
@@ -400,7 +401,7 @@ func (api *DatasetAPI) publishVersion(ctx context.Context, currentDataset *model
 	return nil
 }
 
-func (api *DatasetAPI) associateVersion(ctx context.Context, currentVersion *models.Version, versionDoc *models.Version, versionDetails versionDetails) error {
+func (api *DatasetAPI) associateVersion(ctx context.Context, currentVersion *models.Version, versionDoc *models.Version, versionDetails VersionDetails) error {
 	ap := versionDetails.baseAuditParams()
 	data := audit.ToLogData(ap)
 

--- a/api/versions.go
+++ b/api/versions.go
@@ -255,7 +255,7 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If update was to add downloads do not try to publish/associate version
-	if vars["has_downloads"] != "true" {
+	if vars[hasDownloads] != trueStringified {
 		if versionDoc.State == models.PublishedState {
 			if err := api.publishVersion(ctx, currentDataset, currentVersion, versionDoc, versionDetails); err != nil {
 				handleVersionAPIErr(ctx, err, w, data)

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -759,9 +759,9 @@ func TestGetVersionAuditErrors(t *testing.T) {
 			audit_mock.Expected{Action: getVersionAction, Result: audit.Unsuccessful, Params: p},
 		)
 
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 0)
 	})
 
 	Convey("When version does not exist for an edition of a dataset and auditing errors then a 500 status", t, func() {
@@ -791,9 +791,9 @@ func TestGetVersionAuditErrors(t *testing.T) {
 			audit_mock.Expected{Action: getVersionAction, Result: audit.Unsuccessful, Params: p},
 		)
 
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 	})
 
 	Convey("When version does not exist for an edition of a dataset and auditing errors then a 500 status", t, func() {
@@ -829,9 +829,9 @@ func TestGetVersionAuditErrors(t *testing.T) {
 			audit_mock.Expected{Action: getVersionAction, Result: audit.Unsuccessful, Params: p},
 		)
 
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 	})
 
 	Convey("when auditing a successful request to get a version errors then return a 500 status", t, func() {
@@ -869,9 +869,9 @@ func TestGetVersionAuditErrors(t *testing.T) {
 			audit_mock.Expected{Action: getVersionAction, Result: audit.Successful, Params: p},
 		)
 
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 	})
 }
 
@@ -926,8 +926,6 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 				return nil
 			},
 		}
-		mockedDataStore.GetVersion("123", "2017", "1", "")
-		mockedDataStore.UpdateVersion("a1b2c3", &models.Version{})
 
 		auditor := audit_mock.New()
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditor, genericMockedObservationStore)
@@ -935,10 +933,10 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 3)
-		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 2)
+		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpdateEditionCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.UpdateDatasetWithAssociationCalls()), ShouldEqual, 0)
@@ -983,9 +981,6 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 				return nil
 			},
 		}
-		mockedDataStore.GetVersion("123", "2017", "1", "")
-		mockedDataStore.UpdateVersion("a1b2c3", &models.Version{})
-		mockedDataStore.UpdateDatasetWithAssociation("123", models.AssociatedState, &models.Version{})
 
 		auditor := audit_mock.New()
 		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditor, genericMockedObservationStore)
@@ -993,11 +988,11 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 3)
-		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 2)
-		So(len(mockedDataStore.UpdateDatasetWithAssociationCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpdateDatasetWithAssociationCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.UpdateEditionCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
@@ -1060,10 +1055,10 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		}
 
 		So(w.Code, ShouldEqual, http.StatusOK)
+		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
-		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpdateDatasetWithAssociationCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpdateEditionCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
@@ -1155,24 +1150,18 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 			},
 		}
 
-		mockedDataStore.GetVersion("789", "2017", "1", "")
-		mockedDataStore.GetEdition("123", "2017", "")
-		mockedDataStore.UpdateVersion("a1b2c3", &models.Version{})
-		mockedDataStore.GetDataset("123")
-		mockedDataStore.UpsertDataset("123", &models.DatasetUpdate{Next: &models.Dataset{}})
-
 		auditor := audit_mock.New()
 		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock, auditor, genericMockedObservationStore)
 
 		api.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 3)
-		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 2)
+		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpsertEditionCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 2)
-		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 2)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpdateDatasetWithAssociationCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 1)
 
@@ -1183,6 +1172,115 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 			audit_mock.Expected{Action: publishVersionAction, Result: audit.Successful, Params: ap},
 		)
 	})
+
+	Convey("When version is already published and update includes downloads object only", t, func() {
+		Convey("And downloads object contains only a csv object", func() {
+			var b string
+			b = `{"downloads": { "csv": { "public": "http://cmd-dev/test-site/cpih01", "size": "12", "href": "http://localhost:8080/cpih01"}}}`
+			r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
+			So(err, ShouldBeNil)
+
+			updateVersionDownloadTest(r, ap)
+		})
+
+		Convey("And downloads object contains only a xls object", func() {
+			var b string
+			b = `{"downloads": { "xls": { "public": "http://cmd-dev/test-site/cpih01", "size": "12", "href": "http://localhost:8080/cpih01"}}}`
+			r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
+			So(err, ShouldBeNil)
+
+			updateVersionDownloadTest(r, ap)
+		})
+	})
+}
+
+func updateVersionDownloadTest(r *http.Request, ap common.Params) {
+	w := httptest.NewRecorder()
+
+	generatorMock := &mocks.DownloadsGeneratorMock{
+		GenerateFunc: func(string, string, string, string) error {
+			return nil
+		},
+	}
+
+	mockedDataStore := &storetest.StorerMock{
+		GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
+			return &models.DatasetUpdate{
+				ID:      "123",
+				Next:    &models.Dataset{Links: &models.DatasetLinks{}},
+				Current: &models.Dataset{Links: &models.DatasetLinks{}},
+			}, nil
+		},
+		CheckEditionExistsFunc: func(string, string, string) error {
+			return nil
+		},
+		GetVersionFunc: func(string, string, string, string) (*models.Version, error) {
+			return &models.Version{
+				ID: "789",
+				Links: &models.VersionLinks{
+					Dataset: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123",
+						ID:   "123",
+					},
+					Dimensions: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123/editions/2017/versions/1/dimensions",
+					},
+					Edition: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123/editions/2017",
+						ID:   "2017",
+					},
+					Self: &models.LinkObject{
+						HRef: "http://localhost:22000/instances/765",
+					},
+					Version: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123/editions/2017/versions/1",
+					},
+				},
+				ReleaseDate: "2017-12-12",
+				Downloads: &models.DownloadList{
+					CSV: &models.DownloadObject{
+						Private: "s3://csv-exported/myfile.csv",
+						HRef:    "http://localhost:23600/datasets/123/editions/2017/versions/1.csv",
+						Size:    "1234",
+					},
+				},
+				State: models.PublishedState,
+			}, nil
+		},
+		UpdateVersionFunc: func(string, *models.Version) error {
+			return nil
+		},
+		GetEditionFunc: func(string, string, string) (*models.EditionUpdate, error) {
+			return &models.EditionUpdate{
+				ID: "123",
+				Next: &models.Edition{
+					State: models.PublishedState,
+				},
+				Current: &models.Edition{},
+			}, nil
+		},
+	}
+
+	auditor := audit_mock.New()
+	api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock, auditor, genericMockedObservationStore)
+
+	api.Router.ServeHTTP(w, r)
+
+	So(w.Code, ShouldEqual, http.StatusOK)
+	So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+	So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
+	So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
+	So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 1)
+	// Check updates to edition and dataset resources were not called
+	So(len(mockedDataStore.UpsertEditionCalls()), ShouldEqual, 0)
+	So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
+	So(len(mockedDataStore.UpdateDatasetWithAssociationCalls()), ShouldEqual, 0)
+	So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
+
+	auditor.AssertRecordCalls(
+		audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+		audit_mock.Expected{Action: updateVersionAction, Result: audit.Successful, Params: ap},
+	)
 }
 
 func TestPutVersionGenerateDownloadsError(t *testing.T) {
@@ -1388,11 +1486,35 @@ func TestPutEmptyVersion(t *testing.T) {
 func TestUpdateVersionAuditErrors(t *testing.T) {
 	ap := common.Params{"dataset_id": "123", "edition": "2017", "version": "1"}
 
-	versionDetails := VersionDetails{
-		datasetID: "123",
-		edition:   "2017",
-		version:   "1",
-	}
+	t.Parallel()
+	Convey("given audit action attempted returns an error", t, func() {
+		auditor := audit_mock.NewErroring(updateVersionAction, audit.Attempted)
+
+		Convey("when updateVersion is called with a valid request", func() {
+			r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(versionPayload))
+			So(err, ShouldBeNil)
+
+			w := httptest.NewRecorder()
+
+			store := &storetest.StorerMock{}
+			api := GetAPIWithMockedDatastore(store, nil, auditor, nil)
+
+			api.Router.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+			So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
+
+			Convey("then an error is returned and updateVersion fails", func() {
+				// Check no calls have been made to the datastore
+				So(len(store.GetDatasetCalls()), ShouldEqual, 0)
+				So(len(store.CheckEditionExistsCalls()), ShouldEqual, 0)
+				So(len(store.GetVersionCalls()), ShouldEqual, 0)
+				So(len(store.UpdateVersionCalls()), ShouldEqual, 0)
+				auditor.AssertRecordCalls(
+					audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+				)
+			})
+		})
+	})
 
 	currentVersion := &models.Version{
 		ID: "789",
@@ -1415,36 +1537,6 @@ func TestUpdateVersionAuditErrors(t *testing.T) {
 		ReleaseDate: "2017",
 		State:       models.EditionConfirmedState,
 	}
-
-	t.Parallel()
-
-	Convey("given audit action attempted returns an error", t, func() {
-		auditor := audit_mock.NewErroring(updateVersionAction, audit.Attempted)
-
-		Convey("when updateVersion is called with a valid request", func() {
-			r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(versionPayload))
-			So(err, ShouldBeNil)
-
-			store := &storetest.StorerMock{}
-			api := GetAPIWithMockedDatastore(store, nil, auditor, nil)
-
-			currentDataset, cVersion, updateVersion, err := api.updateVersion(r.Context(), r.Body, versionDetails)
-
-			Convey("then an error is returned and updateVersion fails", func() {
-				So(err, ShouldNotBeNil)
-				So(currentDataset, ShouldBeNil)
-				So(cVersion, ShouldBeNil)
-				So(updateVersion, ShouldBeNil)
-				So(len(store.GetDatasetCalls()), ShouldEqual, 0)
-				So(len(store.CheckEditionExistsCalls()), ShouldEqual, 0)
-				So(len(store.GetVersionCalls()), ShouldEqual, 0)
-				So(len(store.UpdateVersionCalls()), ShouldEqual, 0)
-				auditor.AssertRecordCalls(
-					audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
-				)
-			})
-		})
-	})
 
 	Convey("given audit action successful returns an error", t, func() {
 		auditor := audit_mock.NewErroring(updateVersionAction, audit.Successful)
@@ -1474,20 +1566,20 @@ func TestUpdateVersionAuditErrors(t *testing.T) {
 			expectedUpdateVersion.ID = currentVersion.ID
 			expectedUpdateVersion.State = models.EditionConfirmedState
 
+			w := httptest.NewRecorder()
+
 			r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(versionPayload))
 			So(err, ShouldBeNil)
-			api := GetAPIWithMockedDatastore(store, nil, auditor, nil)
 
-			actualCurrentDataset, actualCurrentVersion, actualUpdateVersion, err := api.updateVersion(r.Context(), r.Body, versionDetails)
+			api := GetAPIWithMockedDatastore(store, nil, auditor, nil)
+			api.Router.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, http.StatusOK)
 
 			Convey("then the expected audit events are recorded and the expected error is returned", func() {
-				So(err, ShouldBeNil)
-				So(actualCurrentDataset, ShouldResemble, &models.DatasetUpdate{})
-				So(actualCurrentVersion, ShouldResemble, currentVersion)
-				So(actualUpdateVersion, ShouldResemble, &expectedUpdateVersion)
+
 				So(len(store.GetDatasetCalls()), ShouldEqual, 1)
 				So(len(store.CheckEditionExistsCalls()), ShouldEqual, 1)
-				So(len(store.GetVersionCalls()), ShouldEqual, 1)
+				So(len(store.GetVersionCalls()), ShouldEqual, 2)
 				So(len(store.UpdateVersionCalls()), ShouldEqual, 1)
 				auditor.AssertRecordCalls(
 					audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
@@ -1502,24 +1594,27 @@ func TestUpdateVersionAuditErrors(t *testing.T) {
 
 		Convey("when update version is unsuccessful", func() {
 			store := &storetest.StorerMock{
+				GetVersionFunc: func(string, string, string, string) (*models.Version, error) {
+					return nil, errs.ErrVersionNotFound
+				},
 				GetDatasetFunc: func(datasetID string) (*models.DatasetUpdate, error) {
 					return nil, errs.ErrDatasetNotFound
 				},
 			}
 			r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(versionPayload))
 			So(err, ShouldBeNil)
-			api := GetAPIWithMockedDatastore(store, nil, auditor, nil)
 
-			actualCurrentDataset, actualCurrentVersion, actualUpdateVersion, err := api.updateVersion(r.Context(), r.Body, versionDetails)
+			w := httptest.NewRecorder()
+
+			api := GetAPIWithMockedDatastore(store, nil, auditor, nil)
+			api.Router.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, http.StatusNotFound)
+			So(w.Body.String(), ShouldContainSubstring, errs.ErrDatasetNotFound.Error())
 
 			Convey("then the expected audit events are recorded and the expected error is returned", func() {
-				So(err, ShouldEqual, errs.ErrDatasetNotFound)
-				So(actualCurrentDataset, ShouldBeNil)
-				So(actualCurrentVersion, ShouldBeNil)
-				So(actualUpdateVersion, ShouldBeNil)
+				So(len(store.GetVersionCalls()), ShouldEqual, 1)
 				So(len(store.GetDatasetCalls()), ShouldEqual, 1)
 				So(len(store.CheckEditionExistsCalls()), ShouldEqual, 0)
-				So(len(store.GetVersionCalls()), ShouldEqual, 0)
 				So(len(store.UpdateVersionCalls()), ShouldEqual, 0)
 				auditor.AssertRecordCalls(
 					audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
@@ -1876,7 +1971,11 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
-		So(len(auditor.RecordCalls()), ShouldEqual, 0)
+		So(len(auditor.RecordCalls()), ShouldEqual, 2)
+		auditor.AssertRecordCalls(
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Unsuccessful, Params: ap},
+		)
 	})
 
 	Convey("When the dataset document cannot be found for version return status not found", t, func() {
@@ -2074,7 +2173,11 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
-		So(len(auditor.RecordCalls()), ShouldEqual, 0)
+		So(len(auditor.RecordCalls()), ShouldEqual, 2)
+		auditor.AssertRecordCalls(
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Unsuccessful, Params: ap},
+		)
 	})
 
 	Convey("When the request body is invalid return status bad request", t, func() {

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -55,8 +55,8 @@ func TestGetVersionsReturnsOK(t *testing.T) {
 
 		p := common.Params{"dataset_id": "123-456", "edition": "678"}
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionsAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionsAction, audit.Successful, p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Successful, Params: p},
 		)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -86,8 +86,8 @@ func TestGetVersionsReturnsError(t *testing.T) {
 
 		assertInternalServerErr(w)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionsAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Unsuccessful, Params: p},
 		)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 0)
@@ -110,8 +110,8 @@ func TestGetVersionsReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldResemble, "Dataset not found\n")
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionsAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -140,8 +140,8 @@ func TestGetVersionsReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldResemble, "Edition not found\n")
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionsAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -174,8 +174,8 @@ func TestGetVersionsReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldResemble, "Version not found\n")
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionsAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -207,8 +207,8 @@ func TestGetVersionsReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldResemble, "Version not found\n")
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionsAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -243,8 +243,8 @@ func TestGetVersionsReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldEqual, "Incorrect resource state\n")
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionsAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -272,7 +272,7 @@ func TestGetVersionsAuditError(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionsAction, audit.Attempted, p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Attempted, Params: p},
 		)
 		assertInternalServerErr(w)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 0)
@@ -301,8 +301,8 @@ func TestGetVersionsAuditError(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionsAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Unsuccessful, Params: p},
 		)
 		assertInternalServerErr(w)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -334,8 +334,8 @@ func TestGetVersionsAuditError(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionsAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Unsuccessful, Params: p},
 		)
 		assertInternalServerErr(w)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -364,8 +364,8 @@ func TestGetVersionsAuditError(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionsAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Unsuccessful, Params: p},
 		)
 		assertInternalServerErr(w)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -402,8 +402,8 @@ func TestGetVersionsAuditError(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionsAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Unsuccessful, Params: p},
 		)
 		assertInternalServerErr(w)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -439,8 +439,8 @@ func TestGetVersionsAuditError(t *testing.T) {
 
 		p := common.Params{"dataset_id": "123-456", "edition": "678"}
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionsAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionsAction, audit.Successful, p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionsAction, Result: audit.Successful, Params: p},
 		)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -483,8 +483,8 @@ func TestGetVersionReturnsOK(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusOK)
 		p := common.Params{"dataset_id": "123-456", "edition": "678", "version": "1"}
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionAction, audit.Successful, p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Successful, Params: p},
 		)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
@@ -510,8 +510,8 @@ func TestGetVersionReturnsError(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 		assertInternalServerErr(w)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Unsuccessful, Params: p},
 		)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 	})
@@ -534,8 +534,8 @@ func TestGetVersionReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldResemble, "Dataset not found\n")
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Unsuccessful, Params: p},
 		)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 0)
@@ -563,8 +563,8 @@ func TestGetVersionReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldResemble, "Edition not found\n")
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Unsuccessful, Params: p},
 		)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
@@ -595,8 +595,8 @@ func TestGetVersionReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldResemble, "Version not found\n")
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -627,8 +627,8 @@ func TestGetVersionReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldResemble, "Version not found\n")
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -669,8 +669,8 @@ func TestGetVersionReturnsError(t *testing.T) {
 		So(w.Body.String(), ShouldResemble, "Incorrect resource state\n")
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -704,7 +704,7 @@ func TestGetVersionAuditErrors(t *testing.T) {
 		assertInternalServerErr(w)
 
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionAction, audit.Attempted, p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Attempted, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 0)
@@ -726,8 +726,8 @@ func TestGetVersionAuditErrors(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 		assertInternalServerErr(w)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -755,8 +755,8 @@ func TestGetVersionAuditErrors(t *testing.T) {
 
 		assertInternalServerErr(w)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -787,8 +787,8 @@ func TestGetVersionAuditErrors(t *testing.T) {
 
 		assertInternalServerErr(w)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -825,8 +825,8 @@ func TestGetVersionAuditErrors(t *testing.T) {
 
 		assertInternalServerErr(w)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionAction, audit.Unsuccessful, p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Unsuccessful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -865,8 +865,8 @@ func TestGetVersionAuditErrors(t *testing.T) {
 
 		assertInternalServerErr(w)
 		auditMock.AssertRecordCalls(
-			audit_mock.Expected{getVersionAction, audit.Attempted, p},
-			audit_mock.Expected{getVersionAction, audit.Successful, p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Attempted, Params: p},
+			audit_mock.Expected{Action: getVersionAction, Result: audit.Successful, Params: p},
 		)
 
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
@@ -945,8 +945,8 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
-			audit_mock.Expected{updateVersionAction, audit.Successful, ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Successful, Params: ap},
 		)
 	})
 
@@ -1003,8 +1003,8 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
-			audit_mock.Expected{updateVersionAction, audit.Successful, ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Successful, Params: ap},
 		)
 	})
 
@@ -1070,10 +1070,10 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 1)
 
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
-			audit_mock.Expected{updateVersionAction, audit.Successful, ap},
-			audit_mock.Expected{associateVersionAction, audit.Attempted, ap},
-			audit_mock.Expected{associateVersionAction, audit.Successful, ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Successful, Params: ap},
+			audit_mock.Expected{Action: associateVersionAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: associateVersionAction, Result: audit.Successful, Params: ap},
 		)
 	})
 
@@ -1177,10 +1177,10 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 1)
 
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
-			audit_mock.Expected{updateVersionAction, audit.Successful, ap},
-			audit_mock.Expected{publishVersionAction, audit.Attempted, ap},
-			audit_mock.Expected{publishVersionAction, audit.Successful, ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Successful, Params: ap},
+			audit_mock.Expected{Action: publishVersionAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: publishVersionAction, Result: audit.Successful, Params: ap},
 		)
 	})
 }
@@ -1258,10 +1258,10 @@ func TestPutVersionGenerateDownloadsError(t *testing.T) {
 				So(genCalls[0].Version, ShouldEqual, "1")
 
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
-					audit_mock.Expected{updateVersionAction, audit.Successful, ap},
-					audit_mock.Expected{associateVersionAction, audit.Attempted, ap},
-					audit_mock.Expected{associateVersionAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: updateVersionAction, Result: audit.Successful, Params: ap},
+					audit_mock.Expected{Action: associateVersionAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: associateVersionAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -1312,8 +1312,8 @@ func TestPutEmptyVersion(t *testing.T) {
 				So(mockedDataStore.UpdateVersionCalls()[0].Version.Downloads, ShouldBeNil)
 
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
-					audit_mock.Expected{updateVersionAction, audit.Successful, ap},
+					audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: updateVersionAction, Result: audit.Successful, Params: ap},
 				)
 			})
 		})
@@ -1377,8 +1377,8 @@ func TestPutEmptyVersion(t *testing.T) {
 				So(len(mockDownloadGenerator.GenerateCalls()), ShouldEqual, 0)
 
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
-					audit_mock.Expected{updateVersionAction, audit.Successful, ap},
+					audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: updateVersionAction, Result: audit.Successful, Params: ap},
 				)
 			})
 		})
@@ -1388,7 +1388,7 @@ func TestPutEmptyVersion(t *testing.T) {
 func TestUpdateVersionAuditErrors(t *testing.T) {
 	ap := common.Params{"dataset_id": "123", "edition": "2017", "version": "1"}
 
-	versionDetails := versionDetails{
+	versionDetails := VersionDetails{
 		datasetID: "123",
 		edition:   "2017",
 		version:   "1",
@@ -1428,19 +1428,19 @@ func TestUpdateVersionAuditErrors(t *testing.T) {
 			store := &storetest.StorerMock{}
 			api := GetAPIWithMockedDatastore(store, nil, auditor, nil)
 
-			currentDataset, currentVersion, updateVersion, err := api.updateVersion(r.Context(), r.Body, versionDetails)
+			currentDataset, cVersion, updateVersion, err := api.updateVersion(r.Context(), r.Body, versionDetails)
 
 			Convey("then an error is returned and updateVersion fails", func() {
 				So(err, ShouldNotBeNil)
 				So(currentDataset, ShouldBeNil)
-				So(currentVersion, ShouldBeNil)
+				So(cVersion, ShouldBeNil)
 				So(updateVersion, ShouldBeNil)
 				So(len(store.GetDatasetCalls()), ShouldEqual, 0)
 				So(len(store.CheckEditionExistsCalls()), ShouldEqual, 0)
 				So(len(store.GetVersionCalls()), ShouldEqual, 0)
 				So(len(store.UpdateVersionCalls()), ShouldEqual, 0)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
+					audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
 				)
 			})
 		})
@@ -1490,8 +1490,8 @@ func TestUpdateVersionAuditErrors(t *testing.T) {
 				So(len(store.GetVersionCalls()), ShouldEqual, 1)
 				So(len(store.UpdateVersionCalls()), ShouldEqual, 1)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
-					audit_mock.Expected{updateVersionAction, audit.Successful, ap},
+					audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: updateVersionAction, Result: audit.Successful, Params: ap},
 				)
 			})
 		})
@@ -1522,8 +1522,8 @@ func TestUpdateVersionAuditErrors(t *testing.T) {
 				So(len(store.GetVersionCalls()), ShouldEqual, 0)
 				So(len(store.UpdateVersionCalls()), ShouldEqual, 0)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
-					audit_mock.Expected{updateVersionAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: updateVersionAction, Result: audit.Unsuccessful, Params: ap},
 				)
 			})
 		})
@@ -1532,7 +1532,7 @@ func TestUpdateVersionAuditErrors(t *testing.T) {
 
 func TestPublishVersionAuditErrors(t *testing.T) {
 	ap := common.Params{"dataset_id": "123", "edition": "2017", "version": "1"}
-	versionDetails := versionDetails{
+	versionDetails := VersionDetails{
 		datasetID: "123",
 		edition:   "2017",
 		version:   "1",
@@ -1549,7 +1549,7 @@ func TestPublishVersionAuditErrors(t *testing.T) {
 
 			Convey("then the expected audit events are recorded and an error is returned", func() {
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{publishVersionAction, audit.Attempted, ap},
+					audit_mock.Expected{Action: publishVersionAction, Result: audit.Attempted, Params: ap},
 				)
 				So(err, ShouldNotBeNil)
 			})
@@ -1572,8 +1572,8 @@ func TestPublishVersionAuditErrors(t *testing.T) {
 			Convey("then the expected audit events are recorded and the expected error is returned", func() {
 				So(len(store.GetEditionCalls()), ShouldEqual, 1)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{publishVersionAction, audit.Attempted, ap},
-					audit_mock.Expected{publishVersionAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: publishVersionAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: publishVersionAction, Result: audit.Unsuccessful, Params: ap},
 				)
 				So(err, ShouldNotBeNil)
 			})
@@ -1645,8 +1645,8 @@ func TestPublishVersionAuditErrors(t *testing.T) {
 			Convey("then the expected audit events are recorded and the expected error is returned", func() {
 				So(len(store.GetEditionCalls()), ShouldEqual, 1)
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{publishVersionAction, audit.Attempted, ap},
-					audit_mock.Expected{publishVersionAction, audit.Successful, ap},
+					audit_mock.Expected{Action: publishVersionAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: publishVersionAction, Result: audit.Successful, Params: ap},
 				)
 				So(err, ShouldBeNil)
 			})
@@ -1684,7 +1684,7 @@ func TestAssociateVersionAuditErrors(t *testing.T) {
 	var versionDoc models.Version
 	json.Unmarshal([]byte(versionAssociatedPayload), &versionDoc)
 
-	v := versionDetails{
+	versionDetails := VersionDetails{
 		datasetID: "123",
 		edition:   "2018",
 		version:   "1",
@@ -1701,11 +1701,11 @@ func TestAssociateVersionAuditErrors(t *testing.T) {
 			gen := &mocks.DownloadsGeneratorMock{}
 			api := GetAPIWithMockedDatastore(store, gen, auditor, genericMockedObservationStore)
 
-			err := api.associateVersion(context.Background(), currentVersion, &versionDoc, v)
+			err := api.associateVersion(context.Background(), currentVersion, &versionDoc, versionDetails)
 
 			Convey("then the expected audit event is captured and the expected error is returned", func() {
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{associateVersionAction, audit.Attempted, ap},
+					audit_mock.Expected{Action: associateVersionAction, Result: audit.Attempted, Params: ap},
 				)
 
 				So(err, ShouldEqual, audit_mock.ErrAudit)
@@ -1728,12 +1728,12 @@ func TestAssociateVersionAuditErrors(t *testing.T) {
 			gen := &mocks.DownloadsGeneratorMock{}
 			api := GetAPIWithMockedDatastore(store, gen, auditor, genericMockedObservationStore)
 
-			err := api.associateVersion(context.Background(), currentVersion, &versionDoc, v)
+			err := api.associateVersion(context.Background(), currentVersion, &versionDoc, versionDetails)
 
 			Convey("then the expected audit event is captured and the expected error is returned", func() {
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{associateVersionAction, audit.Attempted, ap},
-					audit_mock.Expected{associateVersionAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: associateVersionAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: associateVersionAction, Result: audit.Unsuccessful, Params: ap},
 				)
 
 				So(err, ShouldEqual, expectedErr)
@@ -1755,12 +1755,12 @@ func TestAssociateVersionAuditErrors(t *testing.T) {
 			}
 			api := GetAPIWithMockedDatastore(store, gen, auditor, genericMockedObservationStore)
 
-			err := api.associateVersion(context.Background(), currentVersion, &versionDoc, v)
+			err := api.associateVersion(context.Background(), currentVersion, &versionDoc, versionDetails)
 
 			Convey("then the expected audit event is captured and the expected error is returned", func() {
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{associateVersionAction, audit.Attempted, ap},
-					audit_mock.Expected{associateVersionAction, audit.Unsuccessful, ap},
+					audit_mock.Expected{Action: associateVersionAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: associateVersionAction, Result: audit.Unsuccessful, Params: ap},
 				)
 
 				So(expectedErr.Error(), ShouldEqual, errors.Cause(err).Error())
@@ -1786,12 +1786,12 @@ func TestAssociateVersionAuditErrors(t *testing.T) {
 			}
 			api := GetAPIWithMockedDatastore(store, gen, auditor, genericMockedObservationStore)
 
-			err := api.associateVersion(context.Background(), currentVersion, &versionDoc, v)
+			err := api.associateVersion(context.Background(), currentVersion, &versionDoc, versionDetails)
 
 			Convey("then the expected audit event is captured and the expected error is returned", func() {
 				auditor.AssertRecordCalls(
-					audit_mock.Expected{associateVersionAction, audit.Attempted, ap},
-					audit_mock.Expected{associateVersionAction, audit.Successful, ap},
+					audit_mock.Expected{Action: associateVersionAction, Result: audit.Attempted, Params: ap},
+					audit_mock.Expected{Action: associateVersionAction, Result: audit.Successful, Params: ap},
 				)
 
 				So(err, ShouldBeNil)
@@ -1838,8 +1838,8 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
-			audit_mock.Expected{updateVersionAction, audit.Unsuccessful, ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 
@@ -1916,8 +1916,8 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
-			audit_mock.Expected{updateVersionAction, audit.Unsuccessful, ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 
@@ -1958,8 +1958,8 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
-			audit_mock.Expected{updateVersionAction, audit.Unsuccessful, ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 
@@ -2004,8 +2004,8 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
-			audit_mock.Expected{updateVersionAction, audit.Unsuccessful, ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 
@@ -2117,8 +2117,8 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 0)
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 		auditor.AssertRecordCalls(
-			audit_mock.Expected{updateVersionAction, audit.Attempted, ap},
-			audit_mock.Expected{updateVersionAction, audit.Unsuccessful, ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Attempted, Params: ap},
+			audit_mock.Expected{Action: updateVersionAction, Result: audit.Unsuccessful, Params: ap},
 		)
 	})
 }

--- a/api/webendpoints_test.go
+++ b/api/webendpoints_test.go
@@ -23,14 +23,12 @@ import (
 // published datasets are returned, even if the secret token is set.
 
 func TestWebSubnetDatasetsEndpoint(t *testing.T) {
-	t.Parallel()
-
-	current := &models.Dataset{ID: "1234", Title: "current"}
-	next := &models.Dataset{ID: "4321", Title: "next"}
-
 	Convey("When the API is started with private endpoints disabled", t, func() {
 		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets", nil)
 		So(err, ShouldBeNil)
+
+		current := &models.Dataset{ID: "1234", Title: "current"}
+		next := &models.Dataset{ID: "4321", Title: "next"}
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -59,14 +57,12 @@ func TestWebSubnetDatasetsEndpoint(t *testing.T) {
 }
 
 func TestWebSubnetDatasetEndpoint(t *testing.T) {
-	t.Parallel()
-
-	current := &models.Dataset{ID: "1234", Title: "current"}
-	next := &models.Dataset{ID: "1234", Title: "next"}
-
 	Convey("When the API is started with private endpoints disabled", t, func() {
 		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234", nil)
 		So(err, ShouldBeNil)
+
+		current := &models.Dataset{ID: "1234", Title: "current"}
+		next := &models.Dataset{ID: "1234", Title: "next"}
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -93,14 +89,12 @@ func TestWebSubnetDatasetEndpoint(t *testing.T) {
 }
 
 func TestWebSubnetEditionsEndpoint(t *testing.T) {
-	t.Parallel()
-
-	edition := &models.EditionUpdate{ID: "1234", Current: &models.Edition{State: models.PublishedState}}
-	var editionSearchState, datasetSearchState string
-
 	Convey("When the API is started with private endpoints disabled", t, func() {
 		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions", nil)
 		So(err, ShouldBeNil)
+
+		edition := &models.EditionUpdate{ID: "1234", Current: &models.Edition{State: models.PublishedState}}
+		var editionSearchState, datasetSearchState string
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -128,14 +122,12 @@ func TestWebSubnetEditionsEndpoint(t *testing.T) {
 }
 
 func TestWebSubnetEditionEndpoint(t *testing.T) {
-	t.Parallel()
-
-	edition := &models.EditionUpdate{ID: "1234", Current: &models.Edition{State: models.PublishedState}}
-	var editionSearchState, datasetSearchState string
-
 	Convey("When the API is started with private endpoints disabled", t, func() {
 		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234", nil)
 		So(err, ShouldBeNil)
+
+		edition := &models.EditionUpdate{ID: "1234", Current: &models.Edition{State: models.PublishedState}}
+		var editionSearchState, datasetSearchState string
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -161,14 +153,11 @@ func TestWebSubnetEditionEndpoint(t *testing.T) {
 }
 
 func TestWebSubnetVersionsEndpoint(t *testing.T) {
-	t.Parallel()
-
-	var versionSearchState, editionSearchState, datasetSearchState string
-
 	Convey("When the API is started with private endpoints disabled", t, func() {
 		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234/versions", nil)
 		So(err, ShouldBeNil)
 
+		var versionSearchState, editionSearchState, datasetSearchState string
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(ID, state string) error {
@@ -200,14 +189,11 @@ func TestWebSubnetVersionsEndpoint(t *testing.T) {
 }
 
 func TestWebSubnetVersionEndpoint(t *testing.T) {
-	t.Parallel()
-
-	var versionSearchState, editionSearchState, datasetSearchState string
-
 	Convey("When the API is started with private endpoints disabled", t, func() {
 		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234/versions/1234", nil)
 		So(err, ShouldBeNil)
 
+		var versionSearchState, editionSearchState, datasetSearchState string
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(ID, state string) error {
@@ -241,14 +227,11 @@ func TestWebSubnetVersionEndpoint(t *testing.T) {
 }
 
 func TestWebSubnetDimensionsEndpoint(t *testing.T) {
-	t.Parallel()
-
-	var versionSearchState string
-
 	Convey("When the API is started with private endpoints disabled", t, func() {
 		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234/versions/1234/dimensions", nil)
 		So(err, ShouldBeNil)
 
+		var versionSearchState string
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetVersionFunc: func(id string, editionID, version string, state string) (*models.Version, error) {
@@ -274,14 +257,11 @@ func TestWebSubnetDimensionsEndpoint(t *testing.T) {
 }
 
 func TestWebSubnetDimensionOptionsEndpoint(t *testing.T) {
-	t.Parallel()
-
-	var versionSearchState string
-
 	Convey("When the API is started with private endpoints disabled", t, func() {
 		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234/versions/1234/dimensions/t/options", nil)
 		So(err, ShouldBeNil)
 
+		var versionSearchState string
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetVersionFunc: func(id string, editionID, version string, state string) (*models.Version, error) {
@@ -308,7 +288,6 @@ func TestWebSubnetDimensionOptionsEndpoint(t *testing.T) {
 }
 
 func TestPublishedSubnetEndpointsAreDisabled(t *testing.T) {
-	t.Parallel()
 
 	type testEndpoint struct {
 		Method string

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -35,14 +35,13 @@ var (
 
 	NotFoundMap = map[error]bool{
 		ErrDatasetNotFound:         true,
+		ErrDimensionNotFound:       true,
+		ErrDimensionsNotFound:      true,
 		ErrDimensionNodeNotFound:   true,
 		ErrDimensionOptionNotFound: true,
 		ErrEditionNotFound:         true,
 		ErrInstanceNotFound:        true,
 		ErrVersionNotFound:         true,
-
-		ErrDimensionNodeNotFound: true,
-		ErrDimensionNotFound:     true,
 	}
 
 	BadRequestMap = map[error]bool{

--- a/dimension/dimension_test.go
+++ b/dimension/dimension_test.go
@@ -67,8 +67,16 @@ func TestAddNodeIDToDimensionReturnsOK(t *testing.T) {
 		So(len(mockedDataStore.UpdateDimensionNodeIDCalls()), ShouldEqual, 1)
 
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{dimension.PutNodeIDAction, audit.Attempted, common.Params{"instance_id": "123"}},
-			audit_mock.Expected{dimension.PutNodeIDAction, audit.Successful, common.Params{"dimension_name": "age", "instance_id": "123", "node_id": "11", "option": "55"}},
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Attempted,
+				Params: common.Params{"instance_id": "123"},
+			},
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Successful,
+				Params: common.Params{"dimension_name": "age", "instance_id": "123", "node_id": "11", "option": "55"},
+			},
 		)
 	})
 }
@@ -102,8 +110,16 @@ func TestAddNodeIDToDimensionReturnsBadRequest(t *testing.T) {
 		So(len(mockedDataStore.UpdateDimensionNodeIDCalls()), ShouldEqual, 1)
 
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{dimension.PutNodeIDAction, audit.Attempted, common.Params{"instance_id": "123"}},
-			audit_mock.Expected{dimension.PutNodeIDAction, audit.Unsuccessful, common.Params{"dimension_name": "age", "instance_id": "123", "node_id": "11", "option": "55"}},
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Attempted,
+				Params: common.Params{"instance_id": "123"},
+			},
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Unsuccessful,
+				Params: common.Params{"dimension_name": "age", "instance_id": "123", "node_id": "11", "option": "55"},
+			},
 		)
 	})
 }
@@ -133,8 +149,16 @@ func TestAddNodeIDToDimensionReturnsInternalError(t *testing.T) {
 
 		p := common.Params{"instance_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{dimension.PutNodeIDAction, audit.Attempted, p},
-			audit_mock.Expected{dimension.PutNodeIDAction, audit.Unsuccessful, p},
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Attempted,
+				Params: p,
+			},
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Unsuccessful,
+				Params: p,
+			},
 		)
 	})
 
@@ -162,8 +186,16 @@ func TestAddNodeIDToDimensionReturnsInternalError(t *testing.T) {
 		So(len(mockedDataStore.UpdateDimensionNodeIDCalls()), ShouldEqual, 0)
 
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{dimension.PutNodeIDAction, audit.Attempted, common.Params{"instance_id": "123"}},
-			audit_mock.Expected{dimension.PutNodeIDAction, audit.Unsuccessful, common.Params{"dimension_name": "age", "instance_id": "123", "node_id": "11", "option": "55"}},
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Attempted,
+				Params: common.Params{"instance_id": "123"},
+			},
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Unsuccessful,
+				Params: common.Params{"dimension_name": "age", "instance_id": "123", "node_id": "11", "option": "55"},
+			},
 		)
 	})
 }
@@ -196,8 +228,16 @@ func TestAddNodeIDToDimensionReturnsForbidden(t *testing.T) {
 
 		p := common.Params{"instance_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{dimension.PutNodeIDAction, audit.Attempted, p},
-			audit_mock.Expected{dimension.PutNodeIDAction, audit.Unsuccessful, p},
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Attempted,
+				Params: p,
+			},
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Unsuccessful,
+				Params: p,
+			},
 		)
 	})
 }
@@ -253,7 +293,12 @@ func TestAddNodeIDToDimensionAuditFailure(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
 		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 0)
-		auditorMock.AssertRecordCalls(audit_mock.Expected{dimension.PutNodeIDAction, audit.Attempted, common.Params{"instance_id": "123"}})
+		auditorMock.AssertRecordCalls(
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Attempted,
+				Params: common.Params{"instance_id": "123"},
+			})
 	})
 
 	Convey("When request to add node id to dimension is forbidden but audit fails returns an error of internal server error", t, func() {
@@ -285,8 +330,16 @@ func TestAddNodeIDToDimensionAuditFailure(t *testing.T) {
 		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
 		p := common.Params{"instance_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{dimension.PutNodeIDAction, audit.Attempted, p},
-			audit_mock.Expected{dimension.PutNodeIDAction, audit.Unsuccessful, p},
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Attempted,
+				Params: p,
+			},
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Unsuccessful,
+				Params: p,
+			},
 		)
 	})
 
@@ -324,8 +377,16 @@ func TestAddNodeIDToDimensionAuditFailure(t *testing.T) {
 		So(len(mockedDataStore.UpdateDimensionNodeIDCalls()), ShouldEqual, 1)
 
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{dimension.PutNodeIDAction, audit.Attempted, common.Params{"instance_id": "123"}},
-			audit_mock.Expected{dimension.PutNodeIDAction, audit.Successful, common.Params{"dimension_name": "age", "instance_id": "123", "node_id": "11", "option": "55"}},
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Attempted,
+				Params: common.Params{"instance_id": "123"},
+			},
+			audit_mock.Expected{
+				Action: dimension.PutNodeIDAction,
+				Result: audit.Successful,
+				Params: common.Params{"dimension_name": "age", "instance_id": "123", "node_id": "11", "option": "55"},
+			},
 		)
 	})
 }
@@ -363,8 +424,16 @@ func TestAddDimensionToInstanceReturnsOk(t *testing.T) {
 
 		p := common.Params{"instance_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{dimension.PostDimensionsAction, audit.Attempted, p},
-			audit_mock.Expected{dimension.PostDimensionsAction, audit.Successful, p},
+			audit_mock.Expected{
+				Action: dimension.PostDimensionsAction,
+				Result: audit.Attempted,
+				Params: p,
+			},
+			audit_mock.Expected{
+				Action: dimension.PostDimensionsAction,
+				Result: audit.Successful,
+				Params: p,
+			},
 		)
 	})
 }
@@ -401,8 +470,16 @@ func TestAddDimensionToInstanceReturnsNotFound(t *testing.T) {
 
 		p := common.Params{"instance_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{dimension.PostDimensionsAction, audit.Attempted, p},
-			audit_mock.Expected{dimension.PostDimensionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{
+				Action: dimension.PostDimensionsAction,
+				Result: audit.Attempted,
+				Params: p,
+			},
+			audit_mock.Expected{
+				Action: dimension.PostDimensionsAction,
+				Result: audit.Unsuccessful,
+				Params: p,
+			},
 		)
 	})
 }
@@ -437,8 +514,16 @@ func TestAddDimensionToInstanceReturnsForbidden(t *testing.T) {
 
 		p := common.Params{"instance_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{dimension.PostDimensionsAction, audit.Attempted, p},
-			audit_mock.Expected{dimension.PostDimensionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{
+				Action: dimension.PostDimensionsAction,
+				Result: audit.Attempted,
+				Params: p,
+			},
+			audit_mock.Expected{
+				Action: dimension.PostDimensionsAction,
+				Result: audit.Unsuccessful,
+				Params: p,
+			},
 		)
 	})
 }
@@ -503,8 +588,16 @@ func TestAddDimensionToInstanceReturnsInternalError(t *testing.T) {
 
 		p := common.Params{"instance_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{dimension.PostDimensionsAction, audit.Attempted, p},
-			audit_mock.Expected{dimension.PostDimensionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{
+				Action: dimension.PostDimensionsAction,
+				Result: audit.Attempted,
+				Params: p,
+			},
+			audit_mock.Expected{
+				Action: dimension.PostDimensionsAction,
+				Result: audit.Unsuccessful,
+				Params: p,
+			},
 		)
 	})
 
@@ -538,8 +631,16 @@ func TestAddDimensionToInstanceReturnsInternalError(t *testing.T) {
 
 		p := common.Params{"instance_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{dimension.PostDimensionsAction, audit.Attempted, p},
-			audit_mock.Expected{dimension.PostDimensionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{
+				Action: dimension.PostDimensionsAction,
+				Result: audit.Attempted,
+				Params: p,
+			},
+			audit_mock.Expected{
+				Action: dimension.PostDimensionsAction,
+				Result: audit.Unsuccessful,
+				Params: p,
+			},
 		)
 	})
 }
@@ -571,7 +672,11 @@ func TestAddDimensionAuditFailure(t *testing.T) {
 		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 0)
 
 		p := common.Params{"instance_id": "123"}
-		auditorMock.AssertRecordCalls(audit_mock.Expected{dimension.PostDimensionsAction, audit.Attempted, p})
+		auditorMock.AssertRecordCalls(audit_mock.Expected{
+			Action: dimension.PostDimensionsAction,
+			Result: audit.Attempted,
+			Params: p,
+		})
 	})
 
 	Convey("When request to add a dimension is forbidden but audit fails returns an error of internal server error", t, func() {
@@ -605,8 +710,16 @@ func TestAddDimensionAuditFailure(t *testing.T) {
 
 		p := common.Params{"instance_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{dimension.PostDimensionsAction, audit.Attempted, p},
-			audit_mock.Expected{dimension.PostDimensionsAction, audit.Unsuccessful, p},
+			audit_mock.Expected{
+				Action: dimension.PostDimensionsAction,
+				Result: audit.Attempted,
+				Params: p,
+			},
+			audit_mock.Expected{
+				Action: dimension.PostDimensionsAction,
+				Result: audit.Unsuccessful,
+				Params: p,
+			},
 		)
 	})
 
@@ -646,8 +759,16 @@ func TestAddDimensionAuditFailure(t *testing.T) {
 
 		p := common.Params{"instance_id": "123"}
 		auditorMock.AssertRecordCalls(
-			audit_mock.Expected{dimension.PostDimensionsAction, audit.Attempted, p},
-			audit_mock.Expected{dimension.PostDimensionsAction, audit.Successful, p},
+			audit_mock.Expected{
+				Action: dimension.PostDimensionsAction,
+				Result: audit.Attempted,
+				Params: p,
+			},
+			audit_mock.Expected{
+				Action: dimension.PostDimensionsAction,
+				Result: audit.Successful,
+				Params: p,
+			},
 		)
 	})
 }


### PR DESCRIPTION
### What

Initially to fix unkeyed fields but includes the following changes:
1) Fix composite literal uses of unkeyed fields - it is safer to explicitly pair up keys to values instead of relying on the ordering of a struct.
2) Remove parallelisation of web endpoint unit tests - to prevent intermittent failures
3) Remove deprecated functions, methods and variables from api package
4) Include audit process in api check function for put version endpoint
5) Use `log.ErrorCtx` and `log.InfoCtx` when logging in dimension package
6) Set variable `has_downloads` to true when updating a version with
 downloads occur and use this variable in the handler to prevent updates
 to the edition or dataset resource.
7) Update unit tests

### How to review

Check logical changes make sense and unit and acceptance tests pass.

### Who can review

Anyone
