### PR TITLE
Remove collection ID from version when published

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -327,6 +327,10 @@ func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, ve
 			return nil, nil, nil, err
 		}
 
+                if versionUpdate.State == models.PublishedState {
+                        versionUpdate.CollectionID = “”
+                }
+
 		if err := api.dataStore.Backend.UpdateVersion(versionUpdate.ID, versionUpdate); err != nil {
 			log.ErrorCtx(ctx, errors.WithMessage(err, "putVersion endpoint: failed to update version document"), data)
 			return nil, nil, nil, err

--- a/api/versions.go
+++ b/api/versions.go
@@ -327,9 +327,9 @@ func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, ve
 			return nil, nil, nil, err
 		}
 
-                if versionUpdate.State == models.PublishedState {
-                        versionUpdate.CollectionID = “”
-                }
+		if versionUpdate.State == models.PublishedState {
+			versionUpdate.CollectionID = ""
+		}
 
 		if err := api.dataStore.Backend.UpdateVersion(versionUpdate.ID, versionUpdate); err != nil {
 			log.ErrorCtx(ctx, errors.WithMessage(err, "putVersion endpoint: failed to update version document"), data)


### PR DESCRIPTION
### What

Remove collection ID from version when published

### How to review

Check collection ID is no longer returned on newly published documents (this will not remove collection IDs which were previously available)

### Who can review

anyone