### PR TITLE
Feature/safe delete datasets and versions

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -24,12 +24,6 @@ var (
 		errs.ErrAddDatasetAlreadyExists:         true,
 	}
 
-	// errors that should return a 404 status
-	datasetsNotFound = map[error]bool{
-		errs.ErrDatasetNotFound: true,
-		errs.ErrEditionsNotFound: true,
-	}
-
 	// errors that should return a 204 status
 	datasetsNoContent = map[error]bool{
 		errs.ErrDeleteDatasetNotFound: true,
@@ -38,6 +32,12 @@ var (
 	// errors that should return a 400 status
 	datasetsBadRequest = map[error]bool{
 		errs.ErrAddUpdateDatasetBadRequest: true,
+	}
+
+	// errors that should return a 404 status
+	resourcesNotFound = map[error]bool{
+		errs.ErrDatasetNotFound: true,
+		errs.ErrEditionsNotFound: true,
 	}
 )
 
@@ -424,12 +424,12 @@ func handleDatasetAPIErr(ctx context.Context, err error, w http.ResponseWriter, 
 	switch {
 	case datasetsForbidden[err]:
 		status = http.StatusForbidden
-	case datasetsNotFound[err]:
-		status = http.StatusNotFound
 	case datasetsNoContent[err]:
 		status = http.StatusNoContent
 	case datasetsBadRequest[err]:
 		status = http.StatusBadRequest
+	case resourcesNotFound[err]:
+		status = http.StatusNotFound
 	default:
 		err = errs.ErrInternalServer
 		status = http.StatusInternalServerError

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -36,7 +36,7 @@ var (
 
 	// errors that should return a 404 status
 	resourcesNotFound = map[error]bool{
-		errs.ErrDatasetNotFound: true,
+		errs.ErrDatasetNotFound:  true,
 		errs.ErrEditionsNotFound: true,
 	}
 )
@@ -369,7 +369,7 @@ func (api *DatasetAPI) deleteDataset(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Find any editions associated with this dataset
-		editionDocs, err := api.dataStore.Backend.GetEditions(currentDataset.ID,"")
+		editionDocs, err := api.dataStore.Backend.GetEditions(currentDataset.ID, "")
 		if err != nil {
 			log.ErrorCtx(ctx, errors.WithMessage(errs.ErrEditionsNotFound, "delete dataset endpoint: unable to find the dataset editions"), logData)
 			return errs.ErrEditionsNotFound

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -27,6 +27,7 @@ var (
 	// errors that should return a 404 status
 	datasetsNotFound = map[error]bool{
 		errs.ErrDatasetNotFound: true,
+		errs.ErrEditionsNotFound: true,
 	}
 
 	// errors that should return a 204 status
@@ -353,25 +354,40 @@ func (api *DatasetAPI) deleteDataset(w http.ResponseWriter, r *http.Request) {
 		currentDataset, err := api.dataStore.Backend.GetDataset(datasetID)
 
 		if err == errs.ErrDatasetNotFound {
-			log.InfoCtx(ctx, "cannot delete dataset, it does not exist", logData)
+			log.InfoCtx(ctx, "delete dataset endpoint: cannot delete dataset, it does not exist", logData)
 			return errs.ErrDeleteDatasetNotFound
 		}
 
 		if err != nil {
-			log.ErrorCtx(ctx, errors.WithMessage(err, "failed to run query for existing dataset"), logData)
+			log.ErrorCtx(ctx, errors.WithMessage(err, "delete dataset endpoint: failed to run query for existing dataset"), logData)
 			return err
 		}
 
 		if currentDataset.Current != nil && currentDataset.Current.State == models.PublishedState {
-			log.ErrorCtx(ctx, errors.WithMessage(errs.ErrDeletePublishedDatasetForbidden, "unable to delete a published dataset"), logData)
+			log.ErrorCtx(ctx, errors.WithMessage(errs.ErrDeletePublishedDatasetForbidden, "delete dataset endpoint: unable to delete a published dataset"), logData)
 			return errs.ErrDeletePublishedDatasetForbidden
 		}
 
+		// Find any editions associated with this dataset
+		editionDocs, err := api.dataStore.Backend.GetEditions(currentDataset.ID,"")
+		if err != nil {
+			log.ErrorCtx(ctx, errors.WithMessage(errs.ErrEditionsNotFound, "delete dataset endpoint: unable to find the dataset editions"), logData)
+			return errs.ErrEditionsNotFound
+		}
+
+		// Then delete them
+		for i := range editionDocs.Items {
+			if api.dataStore.Backend.DeleteEdition(editionDocs.Items[i].ID); err != nil {
+				log.ErrorCtx(ctx, errors.WithMessage(err, "delete dataset endpoint: failed to delete edition"), logData)
+				return err
+			}
+		}
+
 		if err := api.dataStore.Backend.DeleteDataset(datasetID); err != nil {
-			log.ErrorCtx(ctx, errors.WithMessage(err, "failed to delete dataset"), logData)
+			log.ErrorCtx(ctx, errors.WithMessage(err, "delete dataset endpoint: failed to delete dataset"), logData)
 			return err
 		}
-		log.InfoCtx(ctx, "dataset deleted successfully", logData)
+		log.InfoCtx(ctx, "delete dataset endpoint: dataset deleted successfully", logData)
 		return nil
 	}()
 

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -377,7 +377,7 @@ func (api *DatasetAPI) deleteDataset(w http.ResponseWriter, r *http.Request) {
 
 		// Then delete them
 		for i := range editionDocs.Items {
-			if api.dataStore.Backend.DeleteEdition(editionDocs.Items[i].ID); err != nil {
+			if err := api.dataStore.Backend.DeleteEdition(editionDocs.Items[i].ID); err != nil {
 				log.ErrorCtx(ctx, errors.WithMessage(err, "delete dataset endpoint: failed to delete edition"), logData)
 				return err
 			}

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -1218,6 +1218,9 @@ func TestDeleteDatasetReturnsSuccessfully(t *testing.T) {
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 				return &models.DatasetUpdate{Next: &models.Dataset{State: models.CreatedState}}, nil
 			},
+			GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+				return &models.EditionUpdateResults{}, nil
+			},
 			DeleteDatasetFunc: func(string) error {
 				return nil
 			},
@@ -1249,6 +1252,9 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 				return &models.DatasetUpdate{Current: &models.Dataset{State: models.PublishedState}}, nil
 			},
+			GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+				return &models.EditionUpdateResults{}, nil
+			},
 			DeleteDatasetFunc: func(string) error {
 				return nil
 			},
@@ -1277,6 +1283,9 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 				return &models.DatasetUpdate{Next: &models.Dataset{State: models.CreatedState}}, nil
+			},
+			GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+				return &models.EditionUpdateResults{}, nil
 			},
 			DeleteDatasetFunc: func(string) error {
 				return errs.ErrInternalServer
@@ -1307,6 +1316,9 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 				return nil, errs.ErrDatasetNotFound
 			},
+			GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+				return &models.EditionUpdateResults{}, nil
+			},
 			DeleteDatasetFunc: func(string) error {
 				return nil
 			},
@@ -1335,6 +1347,9 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 				return nil, errors.New("database is broken")
+			},
+			GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+				return &models.EditionUpdateResults{}, nil
 			},
 			DeleteDatasetFunc: func(string) error {
 				return nil
@@ -1377,6 +1392,7 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 			auditortest.Expected{Action: deleteDatasetAction, Result: audit.Unsuccessful, Params: common.Params{"dataset_id": "123"}},
 		)
 	})
+
 }
 
 func TestDeleteDatasetAuditActionAttemptedError(t *testing.T) {
@@ -1503,6 +1519,9 @@ func TestDeleteDatasetAuditauditUnsuccessfulError(t *testing.T) {
 				GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 					return &models.DatasetUpdate{Next: &models.Dataset{State: models.CompletedState}}, nil
 				},
+				GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+					return &models.EditionUpdateResults{}, nil
+				},
 				DeleteDatasetFunc: func(ID string) error {
 					return errors.New("DeleteDatasetFunc error")
 				},
@@ -1535,6 +1554,9 @@ func TestDeleteDatasetAuditActionSuccessfulError(t *testing.T) {
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 				return &models.DatasetUpdate{Next: &models.Dataset{State: models.CreatedState}}, nil
+			},
+			GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+				return &models.EditionUpdateResults{}, nil
 			},
 			DeleteDatasetFunc: func(string) error {
 				return nil

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -1253,7 +1253,7 @@ func TestDeleteDatasetReturnsSuccessfully(t *testing.T) {
 			GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
 				var items []*models.EditionUpdate
 				items = append(items, &models.EditionUpdate{})
-				return &models.EditionUpdateResults{Items:items}, nil
+				return &models.EditionUpdateResults{Items: items}, nil
 			},
 			DeleteEditionFunc: func(ID string) error {
 				return nil
@@ -1578,7 +1578,7 @@ func TestDeleteDatasetAuditauditUnsuccessfulError(t *testing.T) {
 				GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
 					var items []*models.EditionUpdate
 					items = append(items, &models.EditionUpdate{})
-					return &models.EditionUpdateResults{Items:items}, nil
+					return &models.EditionUpdateResults{Items: items}, nil
 				},
 				DeleteEditionFunc: func(ID string) error {
 					return errors.New("DeleteEditionFunc error")

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -2626,14 +2626,14 @@ func TestDetachVersionReturnOK(t *testing.T) {
 		mockedDataStore := &storetest.StorerMock{
 			GetEditionFunc: func(datasetID, editionID, state string) (*models.EditionUpdate, error) {
 				return &models.EditionUpdate{
-					ID: "test",
+					ID:      "test",
 					Current: &models.Edition{},
 					Next: &models.Edition{
 						Edition: "yep",
-						State: models.EditionConfirmedState,
+						State:   models.EditionConfirmedState,
 						Links: &models.EditionUpdateLinks{
 							LatestVersion: &models.LinkObject{
-							ID: "1"}}}}, nil
+								ID: "1"}}}}, nil
 			},
 			GetVersionFunc: func(datasetID string, editionID string, version string, state string) (*models.Version, error) {
 				return &models.Version{}, nil
@@ -2688,11 +2688,11 @@ func TestDetachVersionReturnOK(t *testing.T) {
 		mockedDataStore := &storetest.StorerMock{
 			GetEditionFunc: func(datasetID, editionID, state string) (*models.EditionUpdate, error) {
 				return &models.EditionUpdate{
-					ID: "test",
+					ID:      "test",
 					Current: &models.Edition{},
 					Next: &models.Edition{
 						Edition: "yep",
-						State: models.EditionConfirmedState,
+						State:   models.EditionConfirmedState,
 						Links: &models.EditionUpdateLinks{
 							LatestVersion: &models.LinkObject{
 								ID: "1"}}}}, nil
@@ -2736,7 +2736,6 @@ func TestDetachVersionReturnOK(t *testing.T) {
 		)
 	})
 }
-
 
 func TestDetachVersionReturnsError(t *testing.T) {
 

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -18,6 +18,7 @@ var (
 	ErrDimensionOptionNotFound           = errors.New("dimension option not found")
 	ErrDimensionsNotFound                = errors.New("dimensions not found")
 	ErrEditionNotFound                   = errors.New("edition not found")
+	ErrEditionsNotFound                  = errors.New("no editions were found")
 	ErrIncorrectStateToDetach            = errors.New("only versions with a state of edition-confirmed or associated can be detached")
 	ErrIndexOutOfRange                   = errors.New("index out of range")
 	ErrInstanceNotFound                  = errors.New("instance not found")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,7 +19,6 @@ func TestSpec(t *testing.T) {
 
 			Convey("The values should be set to the expected defaults", func() {
 				So(cfg.BindAddr, ShouldEqual, ":22000")
-				So(cfg.EnableDetachDataset, ShouldEqual, false)
 				So(cfg.KafkaAddr, ShouldResemble, []string{"localhost:9092"})
 				So(cfg.AuditEventsTopic, ShouldEqual, "audit-events")
 				So(cfg.GenerateDownloadsTopic, ShouldEqual, "filter-job-submitted")

--- a/instance/editions_internal_test.go
+++ b/instance/editions_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/store/datastoretest"
 	"github.com/ONSdigital/go-ns/audit/auditortest"
 	. "github.com/smartystreets/goconvey/convey"
+	"context"
 )
 
 func Test_ConfirmEditionReturnsOK(t *testing.T) {
@@ -83,6 +84,7 @@ func Test_ConfirmEditionReturnsOK(t *testing.T) {
 						ID: "test",
 						Next: &models.Edition{
 							Edition: "unpublished-only",
+							State: models.EditionConfirmedState,
 							Links: &models.EditionUpdateLinks{
 								LatestVersion: &models.LinkObject{
 									ID: "1"}}},
@@ -96,6 +98,7 @@ func Test_ConfirmEditionReturnsOK(t *testing.T) {
 
 			host := "example.com"
 			s := Store{
+				EnableDetachDataset: true,
 				Storer:  mockedDataStore,
 				Host:    host,
 				Auditor: auditortest.New(),
@@ -106,7 +109,7 @@ func Test_ConfirmEditionReturnsOK(t *testing.T) {
 				editionName := "unpublished-only"
 				instanceID := "new-instance-1234"
 
-				_, err := s.confirmEdition(ctx, datasetID, editionName, instanceID)
+				_, err := s.confirmEdition(context.Background(), datasetID, editionName, instanceID)
 
 				Convey("then an internal server error is returned.", func() {
 					So(err, ShouldEqual, errs.ErrVersionAlreadyExists)

--- a/instance/editions_internal_test.go
+++ b/instance/editions_internal_test.go
@@ -84,7 +84,6 @@ func Test_ConfirmEditionReturnsOK(t *testing.T) {
 						ID: "test",
 						Next: &models.Edition{
 							Edition: "unpublished-only",
-							State:   models.EditionConfirmedState,
 							Links: &models.EditionUpdateLinks{
 								LatestVersion: &models.LinkObject{
 									ID: "1"}}},

--- a/instance/editions_internal_test.go
+++ b/instance/editions_internal_test.go
@@ -6,12 +6,12 @@ import (
 	"strconv"
 	"testing"
 
+	"context"
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store/datastoretest"
 	"github.com/ONSdigital/go-ns/audit/auditortest"
 	. "github.com/smartystreets/goconvey/convey"
-	"context"
 )
 
 func Test_ConfirmEditionReturnsOK(t *testing.T) {
@@ -84,7 +84,7 @@ func Test_ConfirmEditionReturnsOK(t *testing.T) {
 						ID: "test",
 						Next: &models.Edition{
 							Edition: "unpublished-only",
-							State: models.EditionConfirmedState,
+							State:   models.EditionConfirmedState,
 							Links: &models.EditionUpdateLinks{
 								LatestVersion: &models.LinkObject{
 									ID: "1"}}},
@@ -99,9 +99,9 @@ func Test_ConfirmEditionReturnsOK(t *testing.T) {
 			host := "example.com"
 			s := Store{
 				EnableDetachDataset: true,
-				Storer:  mockedDataStore,
-				Host:    host,
-				Auditor: auditortest.New(),
+				Storer:              mockedDataStore,
+				Host:                host,
+				Auditor:             auditortest.New(),
 			}
 
 			Convey("when confirmEdition is called again", func() {

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -689,3 +689,18 @@ func (m *Mongo) DeleteDataset(id string) (err error) {
 
 	return nil
 }
+
+// DeleteEdition deletes an existing edition document
+func (m *Mongo) DeleteEdition(id string) (err error) {
+	s := m.Session.Copy()
+	defer s.Close()
+
+	if err = s.DB(m.Database).C("editions").Remove(bson.D{{Name: "id", Value: id}}); err != nil {
+		if err == mgo.ErrNotFound {
+			return errs.ErrEditionNotFound
+		}
+		return err
+	}
+
+	return nil
+}

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -49,6 +49,7 @@ type Storer interface {
 	UpsertEdition(datasetID, edition string, editionDoc *models.EditionUpdate) error
 	UpsertVersion(ID string, versionDoc *models.Version) error
 	DeleteDataset(ID string) error
+	DeleteEdition(ID string) error
 
 	AddVersionDetailsToInstance(ctx context.Context, instanceID string, datasetID string, edition string, version int) error
 	SetInstanceIsPublished(ctx context.Context, instanceID string) error

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -19,6 +19,7 @@ var (
 	lockStorerMockCheckDatasetExists                sync.RWMutex
 	lockStorerMockCheckEditionExists                sync.RWMutex
 	lockStorerMockDeleteDataset                     sync.RWMutex
+	lockStorerMockDeleteEdition                     sync.RWMutex
 	lockStorerMockGetDataset                        sync.RWMutex
 	lockStorerMockGetDatasets                       sync.RWMutex
 	lockStorerMockGetDimensionOptions               sync.RWMutex
@@ -75,6 +76,9 @@ var (
 //             },
 //             DeleteDatasetFunc: func(ID string) error {
 // 	               panic("TODO: mock out the DeleteDataset method")
+//             },
+//             DeleteEditionFunc: func(ID string) error {
+// 	               panic("TODO: mock out the DeleteEdition method")
 //             },
 //             GetDatasetFunc: func(ID string) (*models.DatasetUpdate, error) {
 // 	               panic("TODO: mock out the GetDataset method")
@@ -187,6 +191,9 @@ type StorerMock struct {
 
 	// DeleteDatasetFunc mocks the DeleteDataset method.
 	DeleteDatasetFunc func(ID string) error
+
+	// DeleteEditionFunc mocks the DeleteEdition method.
+	DeleteEditionFunc func(ID string) error
 
 	// GetDatasetFunc mocks the GetDataset method.
 	GetDatasetFunc func(ID string) (*models.DatasetUpdate, error)
@@ -322,6 +329,11 @@ type StorerMock struct {
 		}
 		// DeleteDataset holds details about calls to the DeleteDataset method.
 		DeleteDataset []struct {
+			// ID is the ID argument value.
+			ID string
+		}
+		// DeleteEdition holds details about calls to the DeleteEdition method.
+		DeleteEdition []struct {
 			// ID is the ID argument value.
 			ID string
 		}
@@ -780,6 +792,37 @@ func (mock *StorerMock) DeleteDatasetCalls() []struct {
 	lockStorerMockDeleteDataset.RLock()
 	calls = mock.calls.DeleteDataset
 	lockStorerMockDeleteDataset.RUnlock()
+	return calls
+}
+
+// DeleteEdition calls DeleteEditionFunc.
+func (mock *StorerMock) DeleteEdition(ID string) error {
+	if mock.DeleteEditionFunc == nil {
+		panic("StorerMock.DeleteEditionFunc: method is nil but Storer.DeleteEdition was just called")
+	}
+	callInfo := struct {
+		ID string
+	}{
+		ID: ID,
+	}
+	lockStorerMockDeleteEdition.Lock()
+	mock.calls.DeleteEdition = append(mock.calls.DeleteEdition, callInfo)
+	lockStorerMockDeleteEdition.Unlock()
+	return mock.DeleteEditionFunc(ID)
+}
+
+// DeleteEditionCalls gets all the calls that were made to DeleteEdition.
+// Check the length with:
+//     len(mockedStorer.DeleteEditionCalls())
+func (mock *StorerMock) DeleteEditionCalls() []struct {
+	ID string
+} {
+	var calls []struct {
+		ID string
+	}
+	lockStorerMockDeleteEdition.RLock()
+	calls = mock.calls.DeleteEdition
+	lockStorerMockDeleteEdition.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
### What

Allow safe detach of unpublished versions, and deletion of unpublished dataset and edition documents, includes:

- updated DELETE to  /version to detach a version without the edition+dataset rollback, where the dataset has not been published.
- updated DELETE to /dataset to also delete the unpublished editions of an unpublished dataset.

### How to review

sanity check, and/or...

`export ENABLE_DETACH_DATASET=true`
load some data.

detach version:
DELETE to `/datasets/{dataset_id}/editions/{edition}/versions/{version}`

delete dataset+edition(should only work before first version is published).
DELETE to `/datasets/{dataset_id}`

### Who can review

Anyone.
