### PR TITLE
Fix QMI information not completely removable

### DIFF
--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -380,17 +380,9 @@ func createDatasetUpdateQuery(id string, dataset *models.Dataset, currentState s
 	}
 
 	if dataset.QMI != nil {
-		if dataset.QMI.Description != "" {
-			updates["next.qmi.description"] = dataset.QMI.Description
-		}
-
-		if dataset.QMI.HRef != "" {
-			updates["next.qmi.href"] = dataset.QMI.HRef
-		}
-
-		if dataset.QMI.Title != "" {
-			updates["next.qmi.title"] = dataset.QMI.Title
-		}
+		updates["next.qmi.description"] = dataset.QMI.Description
+		updates["next.qmi.href"] = dataset.QMI.HRef
+		updates["next.qmi.title"] = dataset.QMI.Title
 	}
 
 	if dataset.RelatedDatasets != nil {


### PR DESCRIPTION
### What

* Fix QMI information not completely removable 

### How to review

1. Checkout this branch
2. Run the dp-dataset-api and the publishing CMD stack
3. Create a version of an edition that has a QMI field entered in Florence
4. Save this
5. Now remove the whole text for QMI
6. Reload the page
7. Note the difference without this PR when you reloaded the page QMI would reappear, now it remains blank.

### Who can review

Anyone except me
