### PR TITLE
fixed always auth'd bug on metadata endpoint

### DIFF
--- a/api/metadata.go
+++ b/api/metadata.go
@@ -31,8 +31,12 @@ func (api *DatasetAPI) getMetadata(w http.ResponseWriter, r *http.Request) {
 
 		versionDoc, err := api.dataStore.Backend.GetVersion(datasetID, edition, version, "")
 		if err != nil {
-			log.ErrorCtx(ctx, errors.WithMessage(err, "getMetadata endpoint: failed to find version for dataset edition"), logData)
-			return nil, errs.ErrMetadataVersionNotFound
+			if err == errs.ErrVersionNotFound {
+				log.ErrorCtx(ctx, errors.WithMessage(err, "getMetadata endpoint: failed to find version for dataset edition"), logData)
+				return nil, errs.ErrMetadataVersionNotFound
+			}
+			log.ErrorCtx(ctx, errors.WithMessage(err, "getMetadata endpoint: get datastore.getVersion returned an error"), logData)
+			return nil, err
 		}
 
 		datasetDoc, err := api.dataStore.Backend.GetDataset(datasetID)

--- a/api/metadata.go
+++ b/api/metadata.go
@@ -28,6 +28,13 @@ func (api *DatasetAPI) getMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 
 	b, err := func() ([]byte, error) {
+
+		versionDoc, err := api.dataStore.Backend.GetVersion(datasetID, edition, version, "")
+		if err != nil {
+			log.ErrorCtx(ctx, errors.WithMessage(err, "getMetadata endpoint: failed to find version for dataset edition"), logData)
+			return nil, errs.ErrMetadataVersionNotFound
+		}
+
 		datasetDoc, err := api.dataStore.Backend.GetDataset(datasetID)
 		if err != nil {
 			log.ErrorCtx(ctx, errors.WithMessage(err, "getMetadata endpoint: get datastore.getDataset returned an error"), logData)
@@ -35,9 +42,15 @@ func (api *DatasetAPI) getMetadata(w http.ResponseWriter, r *http.Request) {
 		}
 
 		authorised, logData := api.authenticate(r, logData)
-		var state string
+		state := versionDoc.State
 
-		// if request is authenticated then access resources of state other than published
+		// if the requested version is not yet published and the user is unauthorised, return a 404
+		if !authorised && versionDoc.State != models.PublishedState {
+			log.ErrorCtx(ctx, errors.WithMessage(errs.ErrUnauthorised, "getMetadata endpoint: unauthorised user requested unpublished version, returning 404"), logData)
+			return nil, errs.ErrUnauthorised
+		}
+
+		// if request is not authenticated but the version is published, restrict dataset access to only published resources
 		if !authorised {
 			// Check for current sub document
 			if datasetDoc.Current == nil || datasetDoc.Current.State != models.PublishedState {
@@ -49,15 +62,9 @@ func (api *DatasetAPI) getMetadata(w http.ResponseWriter, r *http.Request) {
 			state = datasetDoc.Current.State
 		}
 
-		if err = api.dataStore.Backend.CheckEditionExists(datasetID, edition, state); err != nil {
+		if err = api.dataStore.Backend.CheckEditionExists(datasetID, edition, ""); err != nil {
 			log.ErrorCtx(ctx, errors.WithMessage(err, "getMetadata endpoint: failed to find edition for dataset"), logData)
 			return nil, err
-		}
-
-		versionDoc, err := api.dataStore.Backend.GetVersion(datasetID, edition, version, state)
-		if err != nil {
-			log.ErrorCtx(ctx, errors.WithMessage(err, "getMetadata endpoint: failed to find version for dataset edition"), logData)
-			return nil, errs.ErrMetadataVersionNotFound
 		}
 
 		if err = models.CheckState("version", versionDoc.State); err != nil {
@@ -108,6 +115,8 @@ func handleMetadataErr(w http.ResponseWriter, err error) {
 	var responseStatus int
 
 	switch {
+	case err == errs.ErrUnauthorised:
+		responseStatus = http.StatusNotFound
 	case err == errs.ErrEditionNotFound:
 		responseStatus = http.StatusNotFound
 	case err == errs.ErrMetadataVersionNotFound:


### PR DESCRIPTION
### What

The metadata endpoint currently uses resources from the `dataset.Current` documents for queries with a state of `Published`, and the `dataset.Next` document for queries with all other states.

The issues is/was that the state defaults to blank "" and was only changed to `Published` for queries that don't have auth. As the calls are being made by the dataset-exporter service (which always has auth) the state was always the default blank state and the .Next document is/was always being used.

This PR - I've tweaked the /metadata endpoint to use a default state equal to that of the version requested in the has-auth scenario rather than blank. That way if you (for example) query metadata from web for a published version, it's state of `Published` will pass through and the dataset.Current document will be returned as intended.

### How to review

Sanity Check.

### Who can review

Anyone.
