### PR TITLE
Release/beta 1.15.0

### DIFF
--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -1218,6 +1218,9 @@ func TestDeleteDatasetReturnsSuccessfully(t *testing.T) {
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 				return &models.DatasetUpdate{Next: &models.Dataset{State: models.CreatedState}}, nil
 			},
+			GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+				return &models.EditionUpdateResults{}, nil
+			},
 			DeleteDatasetFunc: func(string) error {
 				return nil
 			},
@@ -1229,6 +1232,45 @@ func TestDeleteDatasetReturnsSuccessfully(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusNoContent)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 1)
+
+		auditMock.AssertRecordCalls(
+			auditortest.Expected{Action: deleteDatasetAction, Result: audit.Attempted, Params: common.Params{"caller_identity": "someone@ons.gov.uk", "dataset_id": "123"}},
+			auditortest.Expected{Action: deleteDatasetAction, Result: audit.Successful, Params: common.Params{"dataset_id": "123"}},
+		)
+	})
+
+	Convey("A successful request to delete dataset with editions returns 200 OK response", t, func() {
+		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{State: models.CreatedState}}, nil
+			},
+			GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+				var items []*models.EditionUpdate
+				items = append(items, &models.EditionUpdate{})
+				return &models.EditionUpdateResults{Items: items}, nil
+			},
+			DeleteEditionFunc: func(ID string) error {
+				return nil
+			},
+			DeleteDatasetFunc: func(string) error {
+				return nil
+			},
+		}
+
+		auditMock := auditortest.New()
+		api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditMock)
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusNoContent)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.DeleteEditionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 1)
 
 		auditMock.AssertRecordCalls(
@@ -1249,6 +1291,9 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 				return &models.DatasetUpdate{Current: &models.Dataset{State: models.PublishedState}}, nil
 			},
+			GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+				return &models.EditionUpdateResults{}, nil
+			},
 			DeleteDatasetFunc: func(string) error {
 				return nil
 			},
@@ -1260,6 +1305,8 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.DeleteEditionCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 0)
 
 		auditMock.AssertRecordCalls(
@@ -1278,6 +1325,9 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 				return &models.DatasetUpdate{Next: &models.Dataset{State: models.CreatedState}}, nil
 			},
+			GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+				return &models.EditionUpdateResults{}, nil
+			},
 			DeleteDatasetFunc: func(string) error {
 				return errs.ErrInternalServer
 			},
@@ -1289,6 +1339,8 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 
 		assertInternalServerErr(w)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.DeleteEditionCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 1)
 
 		auditMock.AssertRecordCalls(
@@ -1307,6 +1359,9 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 				return nil, errs.ErrDatasetNotFound
 			},
+			GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+				return &models.EditionUpdateResults{}, nil
+			},
 			DeleteDatasetFunc: func(string) error {
 				return nil
 			},
@@ -1318,6 +1373,8 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusNoContent)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.DeleteEditionCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 0)
 
 		auditMock.AssertRecordCalls(
@@ -1336,6 +1393,9 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 				return nil, errors.New("database is broken")
 			},
+			GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+				return &models.EditionUpdateResults{}, nil
+			},
 			DeleteDatasetFunc: func(string) error {
 				return nil
 			},
@@ -1347,6 +1407,7 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 
 		assertInternalServerErr(w)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 0)
 
 		auditMock.AssertRecordCalls(
@@ -1370,6 +1431,8 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusUnauthorized)
 		So(w.Body.String(), ShouldResemble, "unauthenticated request\n")
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.DeleteEditionCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 0)
 
 		auditMock.AssertRecordCalls(
@@ -1377,6 +1440,7 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 			auditortest.Expected{Action: deleteDatasetAction, Result: audit.Unsuccessful, Params: common.Params{"dataset_id": "123"}},
 		)
 	})
+
 }
 
 func TestDeleteDatasetAuditActionAttemptedError(t *testing.T) {
@@ -1396,6 +1460,8 @@ func TestDeleteDatasetAuditActionAttemptedError(t *testing.T) {
 			Convey("then a 500 status is returned", func() {
 				So(w.Code, ShouldEqual, http.StatusInternalServerError)
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
+				So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
+				So(len(mockedDataStore.DeleteEditionCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 0)
 
 				auditMock.AssertRecordCalls(
@@ -1431,6 +1497,8 @@ func TestDeleteDatasetAuditauditUnsuccessfulError(t *testing.T) {
 			Convey("then a 204 status is returned", func() {
 				So(w.Code, ShouldEqual, http.StatusNoContent)
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
+				So(len(mockedDataStore.DeleteEditionCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 0)
 
 				auditMock.AssertRecordCalls(
@@ -1458,6 +1526,8 @@ func TestDeleteDatasetAuditauditUnsuccessfulError(t *testing.T) {
 			Convey("then a 500 status is returned", func() {
 				assertInternalServerErr(w)
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
+				So(len(mockedDataStore.DeleteEditionCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 0)
 
 				auditMock.AssertRecordCalls(
@@ -1485,6 +1555,45 @@ func TestDeleteDatasetAuditauditUnsuccessfulError(t *testing.T) {
 			Convey("then a 403 status is returned", func() {
 				So(w.Code, ShouldEqual, http.StatusForbidden)
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
+				So(len(mockedDataStore.DeleteEditionCalls()), ShouldEqual, 0)
+				So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 0)
+
+				auditMock.AssertRecordCalls(
+					auditortest.Expected{Action: deleteDatasetAction, Result: audit.Attempted, Params: common.Params{"caller_identity": "someone@ons.gov.uk", "dataset_id": "123"}},
+					auditortest.Expected{Action: deleteDatasetAction, Result: audit.Unsuccessful, Params: common.Params{"dataset_id": "123"}},
+				)
+			})
+		})
+
+		Convey("when dataStore.Backend.DeleteEdition returns an error", func() {
+			r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123", nil)
+			So(err, ShouldBeNil)
+
+			w := httptest.NewRecorder()
+			mockedDataStore := &storetest.StorerMock{
+				GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
+					return &models.DatasetUpdate{Next: &models.Dataset{State: models.CompletedState}}, nil
+				},
+				GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+					var items []*models.EditionUpdate
+					items = append(items, &models.EditionUpdate{})
+					return &models.EditionUpdateResults{Items: items}, nil
+				},
+				DeleteEditionFunc: func(ID string) error {
+					return errors.New("DeleteEditionFunc error")
+				},
+			}
+
+			auditMock = auditortest.NewErroring(deleteDatasetAction, audit.Unsuccessful)
+			api := GetAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditMock)
+			api.Router.ServeHTTP(w, r)
+
+			Convey("then a 500 status is returned", func() {
+				assertInternalServerErr(w)
+				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.DeleteEditionCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 0)
 
 				auditMock.AssertRecordCalls(
@@ -1503,6 +1612,9 @@ func TestDeleteDatasetAuditauditUnsuccessfulError(t *testing.T) {
 				GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 					return &models.DatasetUpdate{Next: &models.Dataset{State: models.CompletedState}}, nil
 				},
+				GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+					return &models.EditionUpdateResults{}, nil
+				},
 				DeleteDatasetFunc: func(ID string) error {
 					return errors.New("DeleteDatasetFunc error")
 				},
@@ -1515,6 +1627,8 @@ func TestDeleteDatasetAuditauditUnsuccessfulError(t *testing.T) {
 			Convey("then a 500 status is returned", func() {
 				assertInternalServerErr(w)
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.DeleteEditionCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 1)
 
 				auditMock.AssertRecordCalls(
@@ -1536,6 +1650,9 @@ func TestDeleteDatasetAuditActionSuccessfulError(t *testing.T) {
 			GetDatasetFunc: func(string) (*models.DatasetUpdate, error) {
 				return &models.DatasetUpdate{Next: &models.Dataset{State: models.CreatedState}}, nil
 			},
+			GetEditionsFunc: func(ID string, state string) (*models.EditionUpdateResults, error) {
+				return &models.EditionUpdateResults{}, nil
+			},
 			DeleteDatasetFunc: func(string) error {
 				return nil
 			},
@@ -1550,6 +1667,8 @@ func TestDeleteDatasetAuditActionSuccessfulError(t *testing.T) {
 			Convey("then a 204 status is returned", func() {
 				So(w.Code, ShouldEqual, http.StatusNoContent)
 				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.DeleteEditionCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 1)
 
 				auditMock.AssertRecordCalls(

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
-
-	"io"
 
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/config"
@@ -2596,6 +2597,460 @@ func TestCreateNewVersionDoc(t *testing.T) {
 		So(version.Links, ShouldNotBeNil)
 		So(version.Links.Spatial, ShouldBeNil)
 	})
+}
+
+func TestDetachVersionReturnOK(t *testing.T) {
+
+	// TODO conditional test for feature flagged functionality. Will need tidying up eventually.
+	featureEnvString := os.Getenv("ENABLE_DETACH_DATASET")
+	featureOn, _ := strconv.ParseBool(featureEnvString)
+	if !featureOn {
+		return
+	}
+
+	auditParams := common.Params{"dataset_id": "123", "edition": "2017", "version": "1"}
+	auditParamsWithCallerIdentity := common.Params{"caller_identity": "someone@ons.gov.uk", "dataset_id": "123", "edition": "2017", "version": "1"}
+	t.Parallel()
+
+	Convey("A successful detach request against a version of a published dataset returns 200 OK response.", t, func() {
+		generatorMock := &mocks.DownloadsGeneratorMock{
+			GenerateFunc: func(string, string, string, string) error {
+				return nil
+			},
+		}
+
+		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetEditionFunc: func(datasetID, editionID, state string) (*models.EditionUpdate, error) {
+				return &models.EditionUpdate{
+					ID:      "test",
+					Current: &models.Edition{},
+					Next: &models.Edition{
+						Edition: "yep",
+						State:   models.EditionConfirmedState,
+						Links: &models.EditionUpdateLinks{
+							LatestVersion: &models.LinkObject{
+								ID: "1"}}}}, nil
+			},
+			GetVersionFunc: func(datasetID string, editionID string, version string, state string) (*models.Version, error) {
+				return &models.Version{}, nil
+			},
+			GetDatasetFunc: func(ID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Current: &models.Dataset{}}, nil
+			},
+			UpdateVersionFunc: func(ID string, version *models.Version) error {
+				return nil
+			},
+			UpsertEditionFunc: func(datasetID string, edition string, editionDoc *models.EditionUpdate) error {
+				return nil
+			},
+			UpsertDatasetFunc: func(ID string, datasetDoc *models.DatasetUpdate) error {
+				return nil
+			},
+		}
+
+		auditor := auditortest.New()
+		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock, auditor)
+
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusOK)
+
+		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpsertEditionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 1)
+		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
+
+		auditor.AssertRecordCalls(
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParamsWithCallerIdentity},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParams},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Successful, Params: auditParams},
+		)
+	})
+
+	Convey("A successful detach request against a version of a unpublished dataset returns 200 OK response.", t, func() {
+		generatorMock := &mocks.DownloadsGeneratorMock{
+			GenerateFunc: func(string, string, string, string) error {
+				return nil
+			},
+		}
+
+		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetEditionFunc: func(datasetID, editionID, state string) (*models.EditionUpdate, error) {
+				return &models.EditionUpdate{
+					ID:      "test",
+					Current: &models.Edition{},
+					Next: &models.Edition{
+						Edition: "yep",
+						State:   models.EditionConfirmedState,
+						Links: &models.EditionUpdateLinks{
+							LatestVersion: &models.LinkObject{
+								ID: "1"}}}}, nil
+			},
+			GetVersionFunc: func(datasetID string, editionID string, version string, state string) (*models.Version, error) {
+				return &models.Version{}, nil
+			},
+			GetDatasetFunc: func(ID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
+			},
+			UpdateVersionFunc: func(ID string, version *models.Version) error {
+				return nil
+			},
+			UpsertEditionFunc: func(datasetID string, edition string, editionDoc *models.EditionUpdate) error {
+				return nil
+			},
+			UpsertDatasetFunc: func(ID string, datasetDoc *models.DatasetUpdate) error {
+				return nil
+			},
+		}
+
+		auditor := auditortest.New()
+		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock, auditor)
+
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusOK)
+
+		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpsertEditionCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
+		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
+
+		auditor.AssertRecordCalls(
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParamsWithCallerIdentity},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParams},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Successful, Params: auditParams},
+		)
+	})
+}
+
+func TestDetachVersionReturnsError(t *testing.T) {
+
+	// TODO conditional test for feature flagged functionality. Will need tidying up eventually.
+	featureEnvString := os.Getenv("ENABLE_DETACH_DATASET")
+	featureOn, _ := strconv.ParseBool(featureEnvString)
+	if !featureOn {
+		return
+	}
+
+	auditParams := common.Params{"dataset_id": "123", "edition": "2017", "version": "1"}
+	auditParamsWithCallerIdentity := common.Params{"caller_identity": "someone@ons.gov.uk", "dataset_id": "123", "edition": "2017", "version": "1"}
+	t.Parallel()
+
+	Convey("When the api cannot connect to datastore return an internal server error.", t, func() {
+		generatorMock := &mocks.DownloadsGeneratorMock{
+			GenerateFunc: func(string, string, string, string) error {
+				return nil
+			},
+		}
+
+		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetEditionFunc: func(datasetID, editionID, state string) (*models.EditionUpdate, error) {
+				return nil, errs.ErrInternalServer
+			},
+		}
+
+		auditor := auditortest.New()
+		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock, auditor)
+
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
+
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
+		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
+
+		auditor.AssertRecordCalls(
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParamsWithCallerIdentity},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParams},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Unsuccessful, Params: auditParams},
+		)
+	})
+
+	Convey("When the provided edition cannot be found, return a 404 not found error.", t, func() {
+		generatorMock := &mocks.DownloadsGeneratorMock{
+			GenerateFunc: func(string, string, string, string) error {
+				return nil
+			},
+		}
+
+		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetEditionFunc: func(datasetID, editionID, state string) (*models.EditionUpdate, error) {
+				return nil, errs.ErrEditionNotFound
+			},
+		}
+
+		auditor := auditortest.New()
+		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock, auditor)
+
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldContainSubstring, errs.ErrEditionNotFound.Error())
+
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
+		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
+
+		auditor.AssertRecordCalls(
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParamsWithCallerIdentity},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParams},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Unsuccessful, Params: auditParams},
+		)
+	})
+
+	Convey("When detached is called against a version other than latest, return an internal server error", t, func() {
+		generatorMock := &mocks.DownloadsGeneratorMock{
+			GenerateFunc: func(string, string, string, string) error {
+				return nil
+			},
+		}
+
+		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetEditionFunc: func(datasetID, editionID, state string) (*models.EditionUpdate, error) {
+				return &models.EditionUpdate{
+					Next: &models.Edition{
+						State: models.EditionConfirmedState,
+						Links: &models.EditionUpdateLinks{LatestVersion: &models.LinkObject{ID: "2"}}}}, nil
+			},
+		}
+
+		auditor := auditortest.New()
+		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock, auditor)
+
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
+
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
+		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
+
+		auditor.AssertRecordCalls(
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParamsWithCallerIdentity},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParams},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Unsuccessful, Params: auditParams},
+		)
+	})
+
+	Convey("When state is neither edition-confirmed or associated, return an internal server error", t, func() {
+		generatorMock := &mocks.DownloadsGeneratorMock{
+			GenerateFunc: func(string, string, string, string) error {
+				return nil
+			},
+		}
+
+		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetEditionFunc: func(datasetID, editionID, state string) (*models.EditionUpdate, error) {
+				return &models.EditionUpdate{
+					Next: &models.Edition{
+						State: models.PublishedState,
+						Links: &models.EditionUpdateLinks{LatestVersion: &models.LinkObject{ID: "1"}}}}, nil
+			},
+			GetVersionFunc: func(datasetID, editionID, version, state string) (*models.Version, error) {
+				return &models.Version{}, nil
+			},
+		}
+
+		auditor := auditortest.New()
+		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock, auditor)
+
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
+
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
+		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
+
+		auditor.AssertRecordCalls(
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParamsWithCallerIdentity},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParams},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Unsuccessful, Params: auditParams},
+		)
+	})
+
+	Convey("When the requested version cannot be found, return a not found error", t, func() {
+		generatorMock := &mocks.DownloadsGeneratorMock{
+			GenerateFunc: func(string, string, string, string) error {
+				return nil
+			},
+		}
+
+		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetEditionFunc: func(datasetID, editionID, state string) (*models.EditionUpdate, error) {
+				return &models.EditionUpdate{
+					Next: &models.Edition{
+						State: models.EditionConfirmedState,
+						Links: &models.EditionUpdateLinks{LatestVersion: &models.LinkObject{ID: "1"}}}}, nil
+			},
+			GetVersionFunc: func(datasetID, editionID, version, state string) (*models.Version, error) {
+				return nil, errs.ErrVersionNotFound
+			},
+		}
+
+		auditor := auditortest.New()
+		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock, auditor)
+
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldContainSubstring, errs.ErrVersionNotFound.Error())
+
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
+		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
+
+		auditor.AssertRecordCalls(
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParamsWithCallerIdentity},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParams},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Unsuccessful, Params: auditParams},
+		)
+	})
+
+	Convey("When updating the version fails, return an internal server error", t, func() {
+		generatorMock := &mocks.DownloadsGeneratorMock{
+			GenerateFunc: func(string, string, string, string) error {
+				return nil
+			},
+		}
+
+		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetEditionFunc: func(datasetID, editionID, state string) (*models.EditionUpdate, error) {
+				return &models.EditionUpdate{
+					Next: &models.Edition{
+						State: models.EditionConfirmedState,
+						Links: &models.EditionUpdateLinks{LatestVersion: &models.LinkObject{ID: "1"}}}}, nil
+			},
+
+			GetDatasetFunc: func(ID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
+			},
+
+			GetVersionFunc: func(datasetID, editionID, version, state string) (*models.Version, error) {
+				return &models.Version{}, nil
+			},
+			UpdateVersionFunc: func(ID string, version *models.Version) error {
+				return errs.ErrInternalServer
+			},
+		}
+
+		auditor := auditortest.New()
+		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock, auditor)
+
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
+
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 1)
+		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
+
+		auditor.AssertRecordCalls(
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParamsWithCallerIdentity},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParams},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Unsuccessful, Params: auditParams},
+		)
+	})
+
+	Convey("When edition update fails whilst rolling back the edition, return an internal server error", t, func() {
+		generatorMock := &mocks.DownloadsGeneratorMock{
+			GenerateFunc: func(string, string, string, string) error {
+				return nil
+			},
+		}
+
+		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetEditionFunc: func(datasetID, editionID, state string) (*models.EditionUpdate, error) {
+				return &models.EditionUpdate{
+					Next: &models.Edition{
+						State: models.EditionConfirmedState,
+						Links: &models.EditionUpdateLinks{LatestVersion: &models.LinkObject{ID: "1"}}}}, nil
+			},
+			GetVersionFunc: func(datasetID, editionID, version, state string) (*models.Version, error) {
+				return &models.Version{}, nil
+			},
+
+			GetDatasetFunc: func(ID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Current: &models.Dataset{}}, nil
+			},
+
+			UpdateVersionFunc: func(ID string, version *models.Version) error {
+				return nil
+			},
+			UpsertEditionFunc: func(datasetID string, edition string, editionDoc *models.EditionUpdate) error {
+				return errs.ErrInternalServer
+			},
+		}
+
+		auditor := auditortest.New()
+		api := GetAPIWithMockedDatastore(mockedDataStore, generatorMock, auditor)
+
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
+
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpsertEditionCalls()), ShouldEqual, 1)
+		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
+
+		auditor.AssertRecordCalls(
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParamsWithCallerIdentity},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Attempted, Params: auditParams},
+			auditortest.Expected{Action: detachVersionAction, Result: audit.Unsuccessful, Params: auditParams},
+		)
+	})
+
 }
 
 func assertInternalServerErr(w *httptest.ResponseRecorder) {

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -18,6 +18,8 @@ var (
 	ErrDimensionOptionNotFound           = errors.New("dimension option not found")
 	ErrDimensionsNotFound                = errors.New("dimensions not found")
 	ErrEditionNotFound                   = errors.New("edition not found")
+	ErrEditionsNotFound                  = errors.New("no editions were found")
+	ErrIncorrectStateToDetach            = errors.New("only versions with a state of edition-confirmed or associated can be detached")
 	ErrIndexOutOfRange                   = errors.New("index out of range")
 	ErrInstanceNotFound                  = errors.New("instance not found")
 	ErrInternalServer                    = errors.New("internal error")
@@ -36,6 +38,7 @@ var (
 	ErrUnauthorised                      = errors.New("unauthorised access to API")
 	ErrVersionMissingState               = errors.New("missing state from version")
 	ErrVersionNotFound                   = errors.New("version not found")
+	ErrVersionAlreadyExists              = errors.New("an unpublished version of this dataset already exists")
 	ErrNotFound                          = errors.New("not found")
 
 	ErrExpectedResourceStateOfCreated          = errors.New("unable to update resource, expected resource to have a state of created")

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Configuration struct {
 	GracefulShutdownTimeout  time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval      time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	EnablePrivateEnpoints    bool          `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
+	EnableDetachDataset      bool          `envconfig:"ENABLE_DETACH_DATASET"`
 	MongoConfig              MongoConfig
 }
 
@@ -54,6 +55,7 @@ func Get() (*Configuration, error) {
 		GracefulShutdownTimeout:  5 * time.Second,
 		HealthCheckInterval:      30 * time.Second,
 		EnablePrivateEnpoints:    false,
+		EnableDetachDataset:      false,
 		MongoConfig: MongoConfig{
 			BindAddr:   "localhost:27017",
 			Collection: "datasets",

--- a/instance/editions.go
+++ b/instance/editions.go
@@ -38,8 +38,19 @@ func (s *Store) confirmEdition(ctx context.Context, datasetID, edition, instance
 			editionDoc = models.CreateEdition(s.Host, datasetID, edition)
 			log.Debug("created new edition", logData)
 		} else {
-			log.Debug("edition found, updating", logData)
+
 			action = UpdateEditionAction
+
+			// TODO - feature flag. Will need removing eventually.
+			if s.EnableDetachDataset {
+				// Abort if a new/next version is already in flight
+				if editionDoc.Current == nil || editionDoc.Current.Links.LatestVersion.ID != editionDoc.Next.Links.LatestVersion.ID {
+					log.InfoCtx(ctx, "there was an attempted skip of versioning sequence. Aborting edition update", logData)
+					return nil, action, errs.ErrVersionAlreadyExists
+				}
+			}
+
+			log.Debug("edition found, updating", logData)
 			if auditErr := s.Auditor.Record(ctx, action, audit.Attempted, auditParams); auditErr != nil {
 				return nil, action, auditErr
 			}

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -25,8 +25,9 @@ import (
 //Store provides a backend for instances
 type Store struct {
 	store.Storer
-	Host    string
-	Auditor audit.AuditorService
+	Host                string
+	Auditor             audit.AuditorService
+	EnableDetachDataset bool
 }
 
 type taskError struct {

--- a/instance/instance_editions_external_test.go
+++ b/instance/instance_editions_external_test.go
@@ -305,6 +305,19 @@ func Test_UpdateInstanceToEditionConfirmedReturnsError(t *testing.T) {
 					GetEditionFunc: func(datasetID string, edition string, state string) (*models.EditionUpdate, error) {
 						return &models.EditionUpdate{
 							Current: &models.Edition{
+								Links: &models.EditionUpdateLinks{
+									Dataset: &models.LinkObject{
+										HRef: "/dataset/test/href",
+										ID:   "cpih01",
+									},
+									LatestVersion: &models.LinkObject{
+										ID: "1",
+									},
+									Self: &models.LinkObject{
+										HRef: "/edition/test/href",
+										ID:   "test",
+									},
+								},
 								State: models.PublishedState,
 							},
 							Next: &models.Edition{
@@ -314,7 +327,7 @@ func Test_UpdateInstanceToEditionConfirmedReturnsError(t *testing.T) {
 										ID:   "cpih01",
 									},
 									LatestVersion: &models.LinkObject{
-										ID: "2",
+										ID: "1",
 									},
 									Self: &models.LinkObject{
 										HRef: "/edition/test/href",
@@ -329,7 +342,7 @@ func Test_UpdateInstanceToEditionConfirmedReturnsError(t *testing.T) {
 						return nil
 					},
 					GetNextVersionFunc: func(string, string) (int, error) {
-						return 1, nil
+						return 2, nil
 					},
 					UpdateInstanceFunc: func(ctx context.Context, id string, i *models.Instance) error {
 						return errs.ErrInternalServer
@@ -412,7 +425,7 @@ func Test_UpdateInstanceToEditionConfirmedReturnsError(t *testing.T) {
 										ID:   "cpih01",
 									},
 									LatestVersion: &models.LinkObject{
-										ID: "2",
+										ID: "1",
 									},
 									Self: &models.LinkObject{
 										HRef: "/edition/test/href",

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -320,7 +320,7 @@ func CreateEdition(host, datasetID, edition string) *EditionUpdate {
 
 //UpdateLinks in the editions.next document, ensuring links can't regress once published to current
 func (ed *EditionUpdate) UpdateLinks(host string) error {
-	if ed.Next == nil || ed.Next.Links == nil || ed.Next.Links.LatestVersion == nil {
+	if ed.Next == nil || ed.Next.Links == nil || ed.Next.Links.LatestVersion == nil || ed.Next.Links.LatestVersion.ID == "" {
 		return ErrEditionLinksInvalid
 	}
 

--- a/models/state.go
+++ b/models/state.go
@@ -14,6 +14,7 @@ const (
 	EditionConfirmedState = "edition-confirmed"
 	AssociatedState       = "associated"
 	PublishedState        = "published"
+	DetachedState         = "detached"
 )
 
 var validVersionStates = map[string]int{

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -49,6 +49,7 @@ type Storer interface {
 	UpsertEdition(datasetID, edition string, editionDoc *models.EditionUpdate) error
 	UpsertVersion(ID string, versionDoc *models.Version) error
 	DeleteDataset(ID string) error
+	DeleteEdition(ID string) error
 
 	AddVersionDetailsToInstance(ctx context.Context, instanceID string, datasetID string, edition string, version int) error
 	SetInstanceIsPublished(ctx context.Context, instanceID string) error

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -19,6 +19,7 @@ var (
 	lockStorerMockCheckDatasetExists                sync.RWMutex
 	lockStorerMockCheckEditionExists                sync.RWMutex
 	lockStorerMockDeleteDataset                     sync.RWMutex
+	lockStorerMockDeleteEdition                     sync.RWMutex
 	lockStorerMockGetDataset                        sync.RWMutex
 	lockStorerMockGetDatasets                       sync.RWMutex
 	lockStorerMockGetDimensionOptions               sync.RWMutex
@@ -75,6 +76,9 @@ var (
 //             },
 //             DeleteDatasetFunc: func(ID string) error {
 // 	               panic("TODO: mock out the DeleteDataset method")
+//             },
+//             DeleteEditionFunc: func(ID string) error {
+// 	               panic("TODO: mock out the DeleteEdition method")
 //             },
 //             GetDatasetFunc: func(ID string) (*models.DatasetUpdate, error) {
 // 	               panic("TODO: mock out the GetDataset method")
@@ -187,6 +191,9 @@ type StorerMock struct {
 
 	// DeleteDatasetFunc mocks the DeleteDataset method.
 	DeleteDatasetFunc func(ID string) error
+
+	// DeleteEditionFunc mocks the DeleteEdition method.
+	DeleteEditionFunc func(ID string) error
 
 	// GetDatasetFunc mocks the GetDataset method.
 	GetDatasetFunc func(ID string) (*models.DatasetUpdate, error)
@@ -322,6 +329,11 @@ type StorerMock struct {
 		}
 		// DeleteDataset holds details about calls to the DeleteDataset method.
 		DeleteDataset []struct {
+			// ID is the ID argument value.
+			ID string
+		}
+		// DeleteEdition holds details about calls to the DeleteEdition method.
+		DeleteEdition []struct {
 			// ID is the ID argument value.
 			ID string
 		}
@@ -780,6 +792,37 @@ func (mock *StorerMock) DeleteDatasetCalls() []struct {
 	lockStorerMockDeleteDataset.RLock()
 	calls = mock.calls.DeleteDataset
 	lockStorerMockDeleteDataset.RUnlock()
+	return calls
+}
+
+// DeleteEdition calls DeleteEditionFunc.
+func (mock *StorerMock) DeleteEdition(ID string) error {
+	if mock.DeleteEditionFunc == nil {
+		panic("StorerMock.DeleteEditionFunc: method is nil but Storer.DeleteEdition was just called")
+	}
+	callInfo := struct {
+		ID string
+	}{
+		ID: ID,
+	}
+	lockStorerMockDeleteEdition.Lock()
+	mock.calls.DeleteEdition = append(mock.calls.DeleteEdition, callInfo)
+	lockStorerMockDeleteEdition.Unlock()
+	return mock.DeleteEditionFunc(ID)
+}
+
+// DeleteEditionCalls gets all the calls that were made to DeleteEdition.
+// Check the length with:
+//     len(mockedStorer.DeleteEditionCalls())
+func (mock *StorerMock) DeleteEditionCalls() []struct {
+	ID string
+} {
+	var calls []struct {
+		ID string
+	}
+	lockStorerMockDeleteEdition.RLock()
+	calls = mock.calls.DeleteEdition
+	lockStorerMockDeleteEdition.RUnlock()
 	return calls
 }
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -367,6 +367,33 @@ paths:
           description: "No version was found for an edition of a dataset using the id, edition and version provided"
         500:
           $ref: '#/responses/InternalError'
+    delete:
+      tags:
+      - "Private"
+      summary: "Delete a version"
+      description: "detaches a version from a collection. Effectively a soft delete."
+      parameters:
+      - $ref: '#/parameters/edition'
+      - $ref: '#/parameters/id'
+      - $ref: '#/parameters/version'
+      security:
+            - InternalAPIKey: []
+      responses:
+        200:
+          description: "A json object containing the edition and version of a dataset"
+          schema:
+            $ref: '#/definitions/Version'
+        400:
+          description: |
+            Invalid request, reasons can be one of the following:
+              * dataset id was incorrect
+              * edition was incorrect
+              * version state was incorrect
+              * not the most recent unpublished version
+        404:
+          description: "No version was found for an edition of a dataset using the id, edition and version provided"
+        500:
+          $ref: '#/responses/InternalError'
   /datasets/{id}/editions/{edition}/versions/{version}/dimensions:
     get:
       tags:

--- a/vendor/github.com/ONSdigital/go-ns/common/collection.go
+++ b/vendor/github.com/ONSdigital/go-ns/common/collection.go
@@ -1,0 +1,4 @@
+package common
+
+const CollectionIDHeaderKey = "Collection-Id"
+const CollectionIDCookieKey = "collection"

--- a/vendor/github.com/ONSdigital/go-ns/handlers/collectionID/handler.go
+++ b/vendor/github.com/ONSdigital/go-ns/handlers/collectionID/handler.go
@@ -1,0 +1,44 @@
+package collectionID
+
+import (
+	"context"
+	"net/http"
+	"errors"
+
+	"github.com/ONSdigital/go-ns/common"
+	"github.com/ONSdigital/go-ns/log"
+)
+
+// CheckHeader is a wrapper which adds a CollectionID from the request header to context if one does not yet exist
+func CheckHeader(h http.Handler) http.Handler {
+
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+		collectionID := req.Header.Get(common.CollectionIDHeaderKey)
+
+		if collectionID != "" {
+			req = req.WithContext(context.WithValue(req.Context(), common.CollectionIDHeaderKey, collectionID))
+		}
+
+		h.ServeHTTP(w, req)
+	})
+}
+
+// CheckCookie is a wrapper which adds a CollectionID from the cookie to context if one does not yet exist
+func CheckCookie(h http.Handler) http.Handler {
+
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+		collectionIDCookie, err := req.Cookie(common.CollectionIDCookieKey)
+		if err == nil {
+			collectionID := collectionIDCookie.String()
+			req = req.WithContext(context.WithValue(req.Context(), common.CollectionIDHeaderKey, collectionID))
+		} else {
+			if err != http.ErrNoCookie {
+				log.ErrorCtx(req.Context(), errors.New("unexpected error while extracting collection ID from cookie"), nil)
+			}
+		}
+
+		h.ServeHTTP(w, req)
+	})
+}

--- a/vendor/github.com/jtolds/gls/stack_tags.go
+++ b/vendor/github.com/jtolds/gls/stack_tags.go
@@ -51,22 +51,56 @@ func addStackTag(tag uint, context_call func()) {
 
 // these private methods are named this horrendous name so gopherjs support
 // is easier. it shouldn't add any runtime cost in non-js builds.
+
+//go:noinline
 func github_com_jtolds_gls_markS(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark0(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark1(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark2(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark3(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark4(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark5(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark6(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark7(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark8(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark9(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markA(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markB(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markC(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markD(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markE(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markF(tag uint, cb func()) { _m(tag, cb) }
 
 func _m(tag_remainder uint, cb func()) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -117,10 +117,16 @@
 			"revisionTime": "2018-07-12T08:51:53Z"
 		},
 		{
-			"checksumSHA1": "WIzknz1rbQWUgVG7KwwElO7DajY=",
+			"checksumSHA1": "hlr8fdPLJMYY6YkPuiBkI8Jm9Mc=",
 			"path": "github.com/ONSdigital/go-ns/common",
-			"revision": "81b393bfc6e80674df603b7fde2f31a35e81b9dd",
-			"revisionTime": "2019-03-01T13:55:03Z"
+			"revision": "caee21dda39f1143056a5ec0b3031036e14c7c42",
+			"revisionTime": "2019-05-20T09:08:57Z"
+		},
+		{
+			"checksumSHA1": "vTOAgsj69LFRQVsg/Of0O8B/eaY=",
+			"path": "github.com/ONSdigital/go-ns/handlers/collectionID",
+			"revision": "caee21dda39f1143056a5ec0b3031036e14c7c42",
+			"revisionTime": "2019-05-20T09:08:57Z"
 		},
 		{
 			"checksumSHA1": "Vjyl/gfY0qx2lW9te3Ieb5HV3/s=",
@@ -365,10 +371,10 @@
 			"revisionTime": "2016-12-20T21:52:15Z"
 		},
 		{
-			"checksumSHA1": "Js/yx9fZ3+wH1wZpHNIxSTMIaCg=",
+			"checksumSHA1": "cIiyvAduLLFvu+tg1Qr5Jw3jeWo=",
 			"path": "github.com/jtolds/gls",
-			"revision": "77f18212c9c7edc9bd6a33d383a7b545ce62f064",
-			"revisionTime": "2017-05-03T22:40:06Z"
+			"revision": "b4936e06046bbecbb94cae9c18127ebe510a2cb9",
+			"revisionTime": "2018-11-10T20:28:10Z"
 		},
 		{
 			"checksumSHA1": "OBvAHqWjdI4NQVAqTkcQAdTuCFY=",


### PR DESCRIPTION
### What

Merge develop into master for release
* QMI data is now deletable in the CMS
* New tests added and old tests updated
* Block multiple in-flight versions
* Feature flags now consistent
* dataset deletions now include editions
* godocs added
* CollectionID handler to server middleware added
* fixed always auth'd bug on metadata endpoint

### How to review

Checkout branch ensure everything works

### Who can review

Anyone except me, but would be best for Dave or Mike to review.