### PR TITLE
When alerts are sent to the api, it will replace them all

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -571,13 +571,6 @@ func (api *DatasetAPI) associateVersion(ctx context.Context, currentVersion *mod
 func populateNewVersionDoc(currentVersion *models.Version, version *models.Version) *models.Version {
 
 	var alerts []models.Alert
-	if currentVersion.Alerts != nil {
-
-		// loop through current alerts and add each alert to array
-		for _, currentAlert := range *currentVersion.Alerts {
-			alerts = append(alerts, currentAlert)
-		}
-	}
 
 	if version.Alerts != nil {
 		// loop through new alerts and add each alert to array


### PR DESCRIPTION
### What

This fixes the issue of duplicating all alerts and corrections when a user in Florence clicks save

### How to review

Check out branch, open florence create a filterable edition and a version for the edition. Add alerts and corrections then click save. Reload the page. User should still see the corrections and alerts. Add some more corrections and alerts and click save, then refresh the page. User should no longer see duplicate corrections and alerts.

### Who can review

Anyone except me