### PR TITLE
Feature flag observations endpoint and graph DB connection / health check

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -198,18 +198,18 @@ func NewDatasetAPI(ctx context.Context, cfg config.Configuration, router *mux.Ro
 			Storer:  api.dataStore.Backend,
 		}
 
-		api.enablePrivateDatasetEndpoints()
+		api.enablePrivateDatasetEndpoints(ctx)
 		api.enablePrivateInstancesEndpoints(instanceAPI)
 		api.enablePrivateDimensionsEndpoints(dimensionAPI)
 	} else {
 		log.Event(ctx, "enabling only public endpoints for dataset api", log.INFO)
-		api.enablePublicEndpoints()
+		api.enablePublicEndpoints(ctx)
 	}
 	return api
 }
 
 // enablePublicEndpoints register only the public GET endpoints.
-func (api *DatasetAPI) enablePublicEndpoints() {
+func (api *DatasetAPI) enablePublicEndpoints(ctx context.Context) {
 	api.get("/datasets", api.getDatasets)
 	api.get("/datasets/{dataset_id}", api.getDataset)
 	api.get("/datasets/{dataset_id}/editions", api.getEditions)
@@ -221,13 +221,14 @@ func (api *DatasetAPI) enablePublicEndpoints() {
 	api.get("/datasets/{dataset_id}/editions/{edition}/versions/{version}/dimensions/{dimension}/options", api.getDimensionOptions)
 
 	if api.enableObservationEndpoint {
+		log.Event(ctx, "enabling observations endpoint", log.INFO)
 		api.get("/datasets/{dataset_id}/editions/{edition}/versions/{version}/observations", api.getObservations)
 	}
 }
 
 // enablePrivateDatasetEndpoints register the datasets endpoints with the appropriate authentication and authorisation
 // checks required when running the dataset API in publishing (private) mode.
-func (api *DatasetAPI) enablePrivateDatasetEndpoints() {
+func (api *DatasetAPI) enablePrivateDatasetEndpoints(ctx context.Context) {
 	api.get(
 		"/datasets",
 		api.isAuthorised(readPermission, api.getDatasets),
@@ -269,6 +270,7 @@ func (api *DatasetAPI) enablePrivateDatasetEndpoints() {
 	)
 
 	if api.enableObservationEndpoint {
+		log.Event(ctx, "enabling observations endpoint", log.INFO)
 		api.get(
 			"/datasets/{dataset_id}/editions/{edition}/versions/{version}/observations",
 			api.isAuthorisedForDatasets(readPermission,

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ type Configuration struct {
 	EnablePrivateEnpoints      bool          `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
 	EnableDetachDataset        bool          `envconfig:"ENABLE_DETACH_DATASET"`
 	EnablePermissionsAuth      bool          `envconfig:"ENABLE_PERMISSIONS_AUTH"`
+	EnableObservationEndpoint  bool          `envconfig:"ENABLE_OBSERVATION_ENDPOINT"`
 	MongoConfig                MongoConfig
 }
 
@@ -60,6 +61,7 @@ func Get() (*Configuration, error) {
 		EnablePrivateEnpoints:      false,
 		EnableDetachDataset:        false,
 		EnablePermissionsAuth:      false,
+		EnableObservationEndpoint:  true,
 		MongoConfig: MongoConfig{
 			BindAddr:   "localhost:27017",
 			Collection: "datasets",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,6 +36,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.EnablePermissionsAuth, ShouldBeFalse)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
+				So(cfg.EnableObservationEndpoint, ShouldEqual, true)
 			})
 		})
 	})

--- a/initialise/initialise.go
+++ b/initialise/initialise.go
@@ -59,7 +59,12 @@ func (e *ExternalServiceList) GetProducer(ctx context.Context, kafkaBrokers []st
 }
 
 // GetGraphDB returns a graphDB
-func (e *ExternalServiceList) GetGraphDB(ctx context.Context) (*graph.DB, error) {
+func (e *ExternalServiceList) GetGraphDB(ctx context.Context, enableObservationEndpoint bool) (*graph.DB, error) {
+
+	// the graph DB is only used for the observation endpoint
+	if !enableObservationEndpoint {
+		return nil, nil
+	}
 
 	graphDB, err := graph.New(ctx, graph.Subsets{Observation: true, Instance: true})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -307,6 +307,7 @@ func registerCheckers(ctx context.Context,
 	}
 
 	if enableObservationEndpoint {
+		log.Event(ctx, "adding graph db health check as the observations endpoint is enabled", log.INFO)
 		if err = hc.AddCheck("Graph DB", graphDB.Driver.Checker); err != nil {
 			hasErrors = true
 			log.Event(ctx, "error adding check for graph db", log.ERROR, log.Error(err))


### PR DESCRIPTION
### What

Feature flag observations endpoint and graph DB connection / health check

### How to review

- Review changes
- Check tests pass
- When the `ENABLE_OBSERVATION_ENDPOINT` flag is set to true or not set (using default value):
    - The observation endpoint should be enabled
    - the graph database should be health checked
- When the `ENABLE_OBSERVATION_ENDPOINT` flag is set to false:
    - The observation endpoint should **not** be enabled
    - the graph database should be **not** health checked

### Who can review

Anyone
