### PR TITLE
Log panic()'s during run time

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/store"
 	"github.com/ONSdigital/dp-dataset-api/url"
 	"github.com/ONSdigital/dp-graph/graph"
-	"github.com/ONSdigital/dp-rchttp"
+	rchttp "github.com/ONSdigital/dp-rchttp"
 	"github.com/ONSdigital/go-ns/audit"
 	"github.com/ONSdigital/go-ns/healthcheck"
 	"github.com/ONSdigital/go-ns/kafka"
@@ -60,6 +60,13 @@ func main() {
 		log.Error(err, nil)
 		os.Exit(1)
 	}
+
+	defer func() {
+		if x := recover(); x != nil {
+			// Capture run time panic's in the log ...
+			log.Error(errors.New(fmt.Sprintf("PANIC: %+v", x)), nil)
+		}
+	}()
 
 	log.Info("config on startup", log.Data{"config": cfg})
 


### PR DESCRIPTION
During 'production' run time, panic's are output to the terminal and maybe lost ...
Added logging them in a pertinent place.
Each go function has its own stack, so more could probably be added.
This mechanism comes in handy when calling out to 'external' health checks (see what i added in go-ns/healthcheck files.

You can test this code by creating a panic (such as a divide by zero) somewhere later in the main function.
and run the code with / without the capturing and logging of the panic's.