### PR TITLE
Upgrade dp-graph to 2.0.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.9.0
 	github.com/ONSdigital/dp-authorisation v0.0.0-20191018110224-d4543527d6cb
-	github.com/ONSdigital/dp-graph/v2 v2.0.3
+	github.com/ONSdigital/dp-graph/v2 v2.0.4
 	github.com/ONSdigital/dp-healthcheck v1.0.2
 	github.com/ONSdigital/dp-kafka v1.1.5
 	github.com/ONSdigital/dp-mongodb v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/ONSdigital/dp-api-clients-go v1.9.0/go.mod h1:SM0b/NXDWndJ9EulmAGdfDY
 github.com/ONSdigital/dp-authorisation v0.0.0-20191018110224-d4543527d6cb h1:k58Fs56RCIHAL3GToXYwO3IfKKyIN2JvvkQHANpIZ2Q=
 github.com/ONSdigital/dp-authorisation v0.0.0-20191018110224-d4543527d6cb/go.mod h1:0KlUytscZEmrm4+rI+VvRzbMqXRoqECwXGKivF0zWxI=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
-github.com/ONSdigital/dp-graph/v2 v2.0.3 h1:7wnZH6TTve84jQjTl/hqQOh0BeWiYKRL33OKjr/+QXw=
-github.com/ONSdigital/dp-graph/v2 v2.0.3/go.mod h1:jh7BsDGMG0VgNtSvc3hlA2wXs3H1cwdWCp84VGzMVB8=
+github.com/ONSdigital/dp-graph/v2 v2.0.4 h1:KwACJNL5r3P41yc3gZPF1fpSfWVSzCfd3DpL2qLgUZI=
+github.com/ONSdigital/dp-graph/v2 v2.0.4/go.mod h1:jh7BsDGMG0VgNtSvc3hlA2wXs3H1cwdWCp84VGzMVB8=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.0/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.2 h1:N8SzpYzdixVgJS9NMzTBA2RZ2bi3Am1wE5F8ROEpTYw=


### PR DESCRIPTION
### What
Upgrade dp-graph to 2.0.4
- allows usage of Neptune without a startup error

### How to review
Review changes

### Who can review
Anyone
