### PR TITLE
Always Create graph DB client and healthcheck

### DIFF
--- a/initialise/initialise.go
+++ b/initialise/initialise.go
@@ -59,12 +59,7 @@ func (e *ExternalServiceList) GetProducer(ctx context.Context, kafkaBrokers []st
 }
 
 // GetGraphDB returns a graphDB
-func (e *ExternalServiceList) GetGraphDB(ctx context.Context, enableObservationEndpoint bool) (*graph.DB, error) {
-
-	// the graph DB is only used for the observation endpoint
-	if !enableObservationEndpoint {
-		return nil, nil
-	}
+func (e *ExternalServiceList) GetGraphDB(ctx context.Context) (*graph.DB, error) {
 
 	graphDB, err := graph.New(ctx, graph.Subsets{Observation: true, Instance: true})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func run(ctx context.Context) error {
 	}
 
 	// Get graphdb connection for observation store
-	graphDB, err := serviceList.GetGraphDB(ctx, cfg.EnableObservationEndpoint)
+	graphDB, err := serviceList.GetGraphDB(ctx)
 	if err != nil {
 		log.Event(ctx, "failed to initialise graph driver", log.FATAL, log.Error(err))
 		return err
@@ -150,8 +150,7 @@ func run(ctx context.Context) error {
 		graphDB,
 		mongoClient,
 		zebedeeClient,
-		cfg.EnablePrivateEnpoints,
-		cfg.EnableObservationEndpoint); err != nil {
+		cfg.EnablePrivateEnpoints); err != nil {
 		return err
 	}
 
@@ -276,7 +275,7 @@ func registerCheckers(ctx context.Context,
 	graphDB *graph.DB,
 	mongoClient *mongoHealth.Client,
 	zebedeeClient *zebedee.Client,
-	enablePrivateEnpoints, enableObservationEndpoint bool) (err error) {
+	enablePrivateEnpoints bool) (err error) {
 
 	hasErrors := false
 
@@ -306,12 +305,10 @@ func registerCheckers(ctx context.Context,
 		log.Event(ctx, "error adding check for mongo db", log.ERROR, log.Error(err))
 	}
 
-	if enableObservationEndpoint {
-		log.Event(ctx, "adding graph db health check as the observations endpoint is enabled", log.INFO)
-		if err = hc.AddCheck("Graph DB", graphDB.Driver.Checker); err != nil {
-			hasErrors = true
-			log.Event(ctx, "error adding check for graph db", log.ERROR, log.Error(err))
-		}
+	log.Event(ctx, "adding graph db health check as the observations endpoint is enabled", log.INFO)
+	if err = hc.AddCheck("Graph DB", graphDB.Driver.Checker); err != nil {
+		hasErrors = true
+		log.Event(ctx, "error adding check for graph db", log.ERROR, log.Error(err))
 	}
 
 	if hasErrors {


### PR DESCRIPTION
### What

- Initialiser always creates the graph DB client, regardless of observation endpoint being enabled or disabled
- Graph checker is always added to healthcheck

### How to review

- Make sure code changes make sense
- You can try to disable the observation endpoint, and verify that the /health returns the graph DB check:
```
export ENABLE_OBSERVATION_ENDPOINT=false
make debug
curl  GET 'http://localhost:22000/health'
```

### Who can review

Anyone