### PR TITLE
fixed typo enablePrivateEnpoints -> enablePrivateEndpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -116,7 +116,7 @@ func CreateAndInitialiseDatasetAPI(ctx context.Context, cfg config.Configuration
 	middleware = middleware.Append(oldHealthcheckHandler)
 
 	// Only add the identity middleware when running in publishing.
-	if cfg.EnablePrivateEnpoints {
+	if cfg.EnablePrivateEndpoints {
 		middleware = middleware.Append(identity.Handler(cfg.ZebedeeURL))
 	}
 
@@ -159,12 +159,12 @@ func NewDatasetAPI(ctx context.Context, cfg config.Configuration, router *mux.Ro
 		zebedeeURL:                cfg.ZebedeeURL,
 		serviceAuthToken:          cfg.ServiceAuthToken,
 		downloadServiceToken:      cfg.DownloadServiceSecretKey,
-		EnablePrePublishView:      cfg.EnablePrivateEnpoints,
+		EnablePrePublishView:      cfg.EnablePrivateEndpoints,
 		Router:                    router,
 		urlBuilder:                urlBuilder,
 		downloadGenerator:         downloadGenerator,
 		auditor:                   auditor,
-		enablePrivateEndpoints:    cfg.EnablePrivateEnpoints,
+		enablePrivateEndpoints:    cfg.EnablePrivateEndpoints,
 		enableDetachDataset:       cfg.EnableDetachDataset,
 		enableObservationEndpoint: cfg.EnableObservationEndpoint,
 		datasetPermissions:        datasetPermissions,

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -57,7 +57,7 @@ func GetAPIWithMocks(mockedDataStore store.Storer, mockedGeneratedDownloads Down
 	So(err, ShouldBeNil)
 	cfg.ServiceAuthToken = authToken
 	cfg.DatasetAPIURL = host
-	cfg.EnablePrivateEnpoints = true
+	cfg.EnablePrivateEndpoints = true
 
 	return NewDatasetAPI(testContext, *cfg, mux.NewRouter(), store.DataStore{Backend: mockedDataStore}, urlBuilder, mockedGeneratedDownloads, auditMock, datasetPermissions, permissions)
 }

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -1494,7 +1494,7 @@ func TestPutVersionGenerateDownloadsError(t *testing.T) {
 			w := httptest.NewRecorder()
 			cfg, err := config.Get()
 			So(err, ShouldBeNil)
-			cfg.EnablePrivateEnpoints = true
+			cfg.EnablePrivateEndpoints = true
 
 			datasetPermissions := getAuthorisationHandlerMock()
 			permissions := getAuthorisationHandlerMock()

--- a/api/webendpoints_test.go
+++ b/api/webendpoints_test.go
@@ -345,7 +345,7 @@ func GetWebAPIWithMocks(ctx context.Context, mockedDataStore store.Storer, mocke
 	So(err, ShouldBeNil)
 	cfg.ServiceAuthToken = authToken
 	cfg.DatasetAPIURL = host
-	cfg.EnablePrivateEnpoints = false
+	cfg.EnablePrivateEndpoints = false
 
 	return NewDatasetAPI(ctx, *cfg, mux.NewRouter(), store.DataStore{Backend: mockedDataStore}, urlBuilder, mockedGeneratedDownloads, auditor, datasetPermissions, permissions)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ type Configuration struct {
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
-	EnablePrivateEnpoints      bool          `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
+	EnablePrivateEndpoints     bool          `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
 	EnableDetachDataset        bool          `envconfig:"ENABLE_DETACH_DATASET"`
 	EnablePermissionsAuth      bool          `envconfig:"ENABLE_PERMISSIONS_AUTH"`
 	EnableObservationEndpoint  bool          `envconfig:"ENABLE_OBSERVATION_ENDPOINT"`
@@ -58,7 +58,7 @@ func Get() (*Configuration, error) {
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
-		EnablePrivateEnpoints:      false,
+		EnablePrivateEndpoints:     false,
 		EnableDetachDataset:        false,
 		EnablePermissionsAuth:      false,
 		EnableObservationEndpoint:  true,

--- a/dimension/dimension_test.go
+++ b/dimension/dimension_test.go
@@ -1327,7 +1327,7 @@ func getAPIWithMocks(ctx context.Context, mockedDataStore store.Storer, mockedGe
 	So(err, ShouldBeNil)
 	cfg.ServiceAuthToken = "dataset"
 	cfg.DatasetAPIURL = "http://localhost:22000"
-	cfg.EnablePrivateEnpoints = true
+	cfg.EnablePrivateEndpoints = true
 
 	datasetPermissions := getAuthorisationHandlerMock()
 	permissions := getAuthorisationHandlerMock()

--- a/initialise/initialise.go
+++ b/initialise/initialise.go
@@ -59,7 +59,17 @@ func (e *ExternalServiceList) GetProducer(ctx context.Context, kafkaBrokers []st
 }
 
 // GetGraphDB returns a graphDB
-func (e *ExternalServiceList) GetGraphDB(ctx context.Context) (*graph.DB, error) {
+func (e *ExternalServiceList) GetGraphDB(ctx context.Context, cfg *config.Configuration) (*graph.DB, error) {
+
+	// the graph DB is only used for the observation and private endpoint
+	if !cfg.EnableObservationEndpoint && !cfg.EnablePrivateEndpoints {
+		log.Event(ctx, "skipping graph DB client creation, because it is not required by the enabled endpoints", log.INFO, log.Data{
+			"EnableObservationEndpoint": cfg.EnableObservationEndpoint,
+			"EnablePrivateEndpoints":    cfg.EnablePrivateEndpoints,
+		})
+		return nil, nil
+	}
+
 	graphDB, err := graph.New(ctx, graph.Subsets{Observation: true, Instance: true})
 	if err != nil {
 		return nil, err

--- a/instance/instance_external_test.go
+++ b/instance/instance_external_test.go
@@ -244,31 +244,31 @@ func Test_GetInstancesReturnsError(t *testing.T) {
 			})
 		})
 
-			Convey("When the request contains an invalid state to filter on", func() {
-				Convey("Then return status bad request (400)", func() {
-					r, err := createRequestWithToken("GET", "http://localhost:21800/instances?state=foo", nil)
-					So(err, ShouldBeNil)
-					w := httptest.NewRecorder()
+		Convey("When the request contains an invalid state to filter on", func() {
+			Convey("Then return status bad request (400)", func() {
+				r, err := createRequestWithToken("GET", "http://localhost:21800/instances?state=foo", nil)
+				So(err, ShouldBeNil)
+				w := httptest.NewRecorder()
 
-					mockedDataStore := &storetest.StorerMock{}
+				mockedDataStore := &storetest.StorerMock{}
 
-					datasetPermissions := mocks.NewAuthHandlerMock()
-					permissions := mocks.NewAuthHandlerMock()
-					auditor := auditortest.New()
-					datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditor, datasetPermissions, permissions)
-					datasetAPI.Router.ServeHTTP(w, r)
+				datasetPermissions := mocks.NewAuthHandlerMock()
+				permissions := mocks.NewAuthHandlerMock()
+				auditor := auditortest.New()
+				datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditor, datasetPermissions, permissions)
+				datasetAPI.Router.ServeHTTP(w, r)
 
-					So(w.Code, ShouldEqual, http.StatusBadRequest)
-					So(w.Body.String(), ShouldContainSubstring, "bad request - invalid filter state values: [foo]")
-					So(datasetPermissions.Required.Calls, ShouldEqual, 0)
-					So(permissions.Required.Calls, ShouldEqual, 1)
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+				So(w.Body.String(), ShouldContainSubstring, "bad request - invalid filter state values: [foo]")
+				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
+				So(permissions.Required.Calls, ShouldEqual, 1)
 
-					auditor.AssertRecordCalls(
-						auditortest.NewExpectation(instance.GetInstancesAction, audit.Attempted, common.Params{"caller_identity": "someone@ons.gov.uk"}),
-						auditortest.NewExpectation(instance.GetInstancesAction, audit.Unsuccessful, common.Params{"state_query": "foo"}),
-					)
-				})
+				auditor.AssertRecordCalls(
+					auditortest.NewExpectation(instance.GetInstancesAction, audit.Attempted, common.Params{"caller_identity": "someone@ons.gov.uk"}),
+					auditortest.NewExpectation(instance.GetInstancesAction, audit.Unsuccessful, common.Params{"state_query": "foo"}),
+				)
 			})
+		})
 	})
 }
 
@@ -1309,7 +1309,7 @@ func getAPIWithMocks(ctx context.Context, mockedDataStore store.Storer, mockedGe
 	So(err, ShouldBeNil)
 	cfg.ServiceAuthToken = "dataset"
 	cfg.DatasetAPIURL = "http://localhost:22000"
-	cfg.EnablePrivateEnpoints = true
+	cfg.EnablePrivateEndpoints = true
 
 	return api.NewDatasetAPI(ctx, *cfg, mux.NewRouter(), store.DataStore{Backend: mockedDataStore}, urlBuilder, mockedGeneratedDownloads, mockAuditor, datasetPermissions, permissions)
 }

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func run(ctx context.Context) error {
 	var auditor audit.AuditorService
 	var auditProducer *kafka.Producer
 
-	if cfg.EnablePrivateEnpoints {
+	if cfg.EnablePrivateEndpoints {
 		log.Event(ctx, "private endpoints enabled, enabling action auditing", log.INFO, log.Data{"auditTopicName": cfg.AuditEventsTopic})
 
 		auditProducer, err = serviceList.GetProducer(
@@ -106,8 +106,8 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	// Get graphdb connection for observation store
-	graphDB, err := serviceList.GetGraphDB(ctx)
+	// Get graphDB connection for observation store
+	graphDB, err := serviceList.GetGraphDB(ctx, cfg)
 	if err != nil {
 		log.Event(ctx, "failed to initialise graph driver", log.FATAL, log.Error(err))
 		return err
@@ -150,7 +150,8 @@ func run(ctx context.Context) error {
 		graphDB,
 		mongoClient,
 		zebedeeClient,
-		cfg.EnablePrivateEnpoints); err != nil {
+		cfg.EnablePrivateEndpoints,
+		cfg.EnableObservationEndpoint); err != nil {
 		return err
 	}
 
@@ -203,7 +204,7 @@ func run(ctx context.Context) error {
 			log.Event(shutdownContext, "closed generated downloads kafka producer", log.INFO, log.Data{"producer": "DimensionExtracted"})
 		}
 
-		if cfg.EnablePrivateEnpoints {
+		if cfg.EnablePrivateEndpoints {
 			// If audit events kafka producer exists, close it
 			if serviceList.AuditProducer {
 				log.Event(shutdownContext, "closing audit events kafka producer", log.INFO, log.Data{"producer": "DimensionExtracted"})
@@ -275,11 +276,12 @@ func registerCheckers(ctx context.Context,
 	graphDB *graph.DB,
 	mongoClient *mongoHealth.Client,
 	zebedeeClient *zebedee.Client,
-	enablePrivateEnpoints bool) (err error) {
+	enablePrivateEndpoints,
+	enableObservationEndpoint bool) (err error) {
 
 	hasErrors := false
 
-	if enablePrivateEnpoints {
+	if enablePrivateEndpoints {
 		if err = hc.AddCheck("Kafka Audit Producer", auditProducer.Checker); err != nil {
 			hasErrors = true
 			log.Event(ctx, "error adding check for kafka audit producer", log.ERROR, log.Error(err))
@@ -305,10 +307,12 @@ func registerCheckers(ctx context.Context,
 		log.Event(ctx, "error adding check for mongo db", log.ERROR, log.Error(err))
 	}
 
-	log.Event(ctx, "adding graph db health check as the observations endpoint is enabled", log.INFO)
-	if err = hc.AddCheck("Graph DB", graphDB.Driver.Checker); err != nil {
-		hasErrors = true
-		log.Event(ctx, "error adding check for graph db", log.ERROR, log.Error(err))
+	if enablePrivateEndpoints || enableObservationEndpoint {
+		log.Event(ctx, "adding graph db health check as the private or observation endpoints are enabled", log.INFO)
+		if err = hc.AddCheck("Graph DB", graphDB.Driver.Checker); err != nil {
+			hasErrors = true
+			log.Event(ctx, "error adding check for graph db", log.ERROR, log.Error(err))
+		}
 	}
 
 	if hasErrors {


### PR DESCRIPTION
### What

- Create dp-graph client and healthcheck only if observation endpoint or private endpoints are enabled.

#### Reason:
dp-graph dependency is only needed by:
- observation API and
- `PUT /datasets/{dataset_id}/editions/{edition}/versions/{version}` (private endpoint)

In this PR I reintroduce the previous idea of creating the dependency only when needed, but extending it to any of the conditions stated above (instead of only observation endpoints being enabled)

### How to review

- Make sure code changes make sense
- Unit tests should pass
- You can try `make debug` and verify that you don't see the graph DB checker iif both `ENABLE_OBSERVATION_ENDPOINT=false` and `ENABLE_PRIVATE_ENDPOINTS=false`

### Who can review

Anyone