### PR TITLE
Fix/new dataset detach check

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -190,7 +190,7 @@ func NewDatasetAPI(ctx context.Context, cfg config.Configuration, router *mux.Ro
 			Host:                api.host,
 			Storer:              api.dataStore.Backend,
 			Auditor:             api.auditor,
-			EnableDetachDataset: api.enablePrivateEndpoints,
+			EnableDetachDataset: api.enableDetachDataset,
 		}
 
 		dimensionAPI := &dimension.Store{

--- a/instance/editions.go
+++ b/instance/editions.go
@@ -47,7 +47,7 @@ func (s *Store) confirmEdition(ctx context.Context, datasetID, edition, instance
 			// TODO - feature flag. Will need removing eventually.
 			if s.EnableDetachDataset {
 				// Abort if a new/next version is already in flight
-				if editionDoc.Current == nil || editionDoc.Current.Links.LatestVersion.ID != editionDoc.Next.Links.LatestVersion.ID {
+				if editionDoc.Current.Links.LatestVersion.ID != editionDoc.Next.Links.LatestVersion.ID {
 					log.Event(ctx, "confirm edition: there was an attempted skip of versioning sequence. Aborting edition update", log.INFO, logData)
 					return nil, action, errs.ErrVersionAlreadyExists
 				}


### PR DESCRIPTION
### What
Creating new datasets in CMD is failing. I tracked it down to the `EnableDetachDataset` logic, that checks for the current doc being nil. In the case of new datasets the current doc is always nil. I couldn't think of another case where the doc would be nil, so I think it's safe to remove this check.

I also noticed that the `EnableDetachDataset` value in the store was not being set as the incoming `EnableDetachDataset` value. This may have been intentional, but seems odd as the config value is still present

Ideally we can remove the feature flag for `EnableDetachDataset` if its no longer required, though I need to check with someone who is familiar with it.

### How to review
Sanity check

### Who can review
Anyone
