### PR TITLE
Prevent nil pointer panic when validating version number

### DIFF
--- a/instance/editions.go
+++ b/instance/editions.go
@@ -47,7 +47,7 @@ func (s *Store) confirmEdition(ctx context.Context, datasetID, edition, instance
 			// TODO - feature flag. Will need removing eventually.
 			if s.EnableDetachDataset {
 				// Abort if a new/next version is already in flight
-				if editionDoc.Current.Links.LatestVersion.ID != editionDoc.Next.Links.LatestVersion.ID {
+				if editionDoc.Current != nil && editionDoc.Next != nil && editionDoc.Current.Links.LatestVersion.ID != editionDoc.Next.Links.LatestVersion.ID {
 					log.Event(ctx, "confirm edition: there was an attempted skip of versioning sequence. Aborting edition update", log.INFO, logData)
 					return nil, action, errs.ErrVersionAlreadyExists
 				}

--- a/instance/editions_internal_test.go
+++ b/instance/editions_internal_test.go
@@ -264,6 +264,80 @@ func Test_ConfirmEditionReturnsError(t *testing.T) {
 		})
 	})
 
+	Convey("given an edition exists with nil current doc", t, func() {
+		mockedDataStore := &storetest.StorerMock{
+			GetEditionFunc: func(dataset, edition, state string) (*models.EditionUpdate, error) {
+				return &models.EditionUpdate{
+					ID: "test",
+					Next: &models.Edition{
+						Links: &models.EditionUpdateLinks{
+							LatestVersion: &models.LinkObject{
+								ID: ""},
+						},
+					},
+				}, nil
+			},
+		}
+
+		host := "example.com"
+		s := Store{
+			Storer:              mockedDataStore,
+			Host:                host,
+			Auditor:             auditortest.New(),
+			EnableDetachDataset: true,
+		}
+
+		Convey("when confirmEdition is called", func() {
+			datasetID := "1234"
+			editionName := "failure"
+			instanceID := "new-instance-1234"
+
+			_, err := s.confirmEdition(ctx, datasetID, editionName, instanceID)
+
+			Convey("then updating links fails and an error is returned", func() {
+				So(err, ShouldNotBeNil)
+				So(err, ShouldResemble, models.ErrEditionLinksInvalid)
+			})
+		})
+	})
+
+	Convey("given an edition exists with nil next doc", t, func() {
+		mockedDataStore := &storetest.StorerMock{
+			GetEditionFunc: func(dataset, edition, state string) (*models.EditionUpdate, error) {
+				return &models.EditionUpdate{
+					ID: "test",
+					Current: &models.Edition{
+						Links: &models.EditionUpdateLinks{
+							LatestVersion: &models.LinkObject{
+								ID: ""},
+						},
+					},
+				}, nil
+			},
+		}
+
+		host := "example.com"
+		s := Store{
+			Storer:              mockedDataStore,
+			Host:                host,
+			Auditor:             auditortest.New(),
+			EnableDetachDataset: true,
+		}
+
+		Convey("when confirmEdition is called", func() {
+			datasetID := "1234"
+			editionName := "failure"
+			instanceID := "new-instance-1234"
+
+			_, err := s.confirmEdition(ctx, datasetID, editionName, instanceID)
+
+			Convey("then updating links fails and an error is returned", func() {
+				So(err, ShouldNotBeNil)
+				So(err, ShouldResemble, models.ErrEditionLinksInvalid)
+			})
+		})
+	})
+
 	Convey("given intermittent datastore failures", t, func() {
 		mockedDataStore := &storetest.StorerMock{
 			GetEditionFunc: func(dataset, edition, state string) (*models.EditionUpdate, error) {


### PR DESCRIPTION
### What
Prevent nil pointer panic when validating version number
Check the edition's current and next doc are not nil before validating the version.

### How to review
Sanity check + check tests pass

### Who can review
Anyone
