### PR TITLE
Removed log namespace for auth lib - overwriting app namespace and mi…

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -162,7 +162,6 @@ func getAuthorisationHandlers(ctx context.Context, cfg *config.Configuration) (a
 	}
 
 	log.Event(ctx, "feature flag enabled", log.INFO, log.Data{"feature": "ENABLE_PERMISSIONS_AUTH"})
-	auth.LoggerNamespace("dp-dataset-api-auth")
 
 	authClient := auth.NewPermissionsClient(dphttp.NewClient())
 	authVerifier := auth.DefaultPermissionsVerifier()


### PR DESCRIPTION
Remove line setting `auth` lib namespace.

Our log library is single threaded and cannot support multiple concurrent namespaces. Setting a namespace for the auth lib overwrites any previously set app namespace. As a result any app logs are collated under a different namespace in Kibana.

Removing this line means all log output from this app will be placed under the correct namespace.
