### PR TITLE
Added type and nomis_ref_url fields to dataset in swagger

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1052,6 +1052,15 @@ definitions:
       uri:
         description: "The uri to the location of this resource on the web"
         type: string
+      type:
+        description: "The type for a dataset" 
+        type: string
+        enum: [filterable, nomis]
+        example: "filterable"
+      nomis_ref_url:
+        description: "The NOMIS reference url for the dataset"
+        type: string
+        example: "https://www.nomisweb.co.uk/census/2011/ks106ew"
   Dimension:
     description: "A single dimension within a dataset"
     type: object


### PR DESCRIPTION
### What

Added following fields to dataset in swagger:
type: filterable or nomis which will be an enum
nomis_ref_url 
https://trello.com/c/nkYdTCTd/126-add-a-new-field-to-dataset-api-at-the-dataset-level-for-type-5d
### How to review

confirm additions are correct as per trello ticket

### Who can review

Anyone
