### PR TITLE
set default limit to 100 items

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,7 +68,7 @@ func Get() (*Configuration, error) {
 			BindAddr:   "localhost:27017",
 			Collection: "datasets",
 			Database:   "datasets",
-			Limit:      0,
+			Limit:      100,
 			Offset:     0,
 		},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,7 +33,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.MongoConfig.BindAddr, ShouldEqual, "localhost:27017")
 				So(cfg.MongoConfig.Collection, ShouldEqual, "datasets")
 				So(cfg.MongoConfig.Database, ShouldEqual, "datasets")
-				So(cfg.MongoConfig.Limit, ShouldEqual, 0)
+				So(cfg.MongoConfig.Limit, ShouldEqual, 100)
 				So(cfg.MongoConfig.Offset, ShouldEqual, 0)
 				So(cfg.EnablePermissionsAuth, ShouldBeFalse)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -162,7 +162,7 @@ parameters:
       $ref: '#/definitions/UpdateVersion'
   limit:
     name: limit
-    description: "Maximum number of items that will be returned. A value of zero (default) will return all available items, without limit."
+    description: "Maximum number of items that will be returned. A value of zero will return all available items, without limit. The default value is 100."
     in: query
     required: false
     type: integer


### PR DESCRIPTION
### What

Set default limit to 100, so that we return the first 100 options by default in `GET options` endpoint.
Changed swagger spec accordingly

### How to review

- Make sure change makes sense
- Make sure unit tests pass
- (already tested locally with postman)

### Who can review

Anyone