### PR TITLE
updated /healthcheck endpoint to return 404 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ the path to get to `completed` is longer than the `submitted` one.
 
 ### Healthcheck
 
-The endpoint `/healthcheck` checks the connection to the database and returns
+The endpoint `/health` checks the connection to the database and returns
 one of:
 
 * success (200, JSON "status": "OK")
 * failure (500, JSON "status": "error").
+
+The `/health` endpoint replaces `/healthcheck`, which now returns a `404 Not Found` response.
 
 ### Kafka scripts
 

--- a/service/service.go
+++ b/service/service.go
@@ -216,6 +216,9 @@ func newMiddleware(healthcheckHandler func(http.ResponseWriter, *http.Request), 
 			if req.Method == "GET" && req.URL.Path == path {
 				healthcheckHandler(w, req)
 				return
+			} else if req.Method == "GET" && req.URL.Path == "/healthcheck" {
+				http.NotFound(w, req)
+				return
 			}
 
 			h.ServeHTTP(w, req)


### PR DESCRIPTION
### What

/healthcheck endpoint now returns 404 error, as per this ticket - https://trello.com/c/M7SNbNC1/4742-dataset-api-remove-transitional-health-check-code-new-1d

### How to review

Run service locally and confirm that /healthcheck endpoint returns a 404 error

### Who can review

Anyone
