### PR TITLE
Prevent error from being masked by generic errs.ErrInternalServer

### DIFF
--- a/api/observation.go
+++ b/api/observation.go
@@ -373,6 +373,7 @@ func (api *DatasetAPI) getObservationList(ctx context.Context, versionDoc *model
 func handleObservationsErrorType(ctx context.Context, w http.ResponseWriter, err error, data log.Data) {
 	_, isObservationErr := err.(observationQueryError)
 	var status int
+	resErrMsg := err.Error()
 
 	switch {
 	case isObservationErr:
@@ -382,7 +383,7 @@ func handleObservationsErrorType(ctx context.Context, w http.ResponseWriter, err
 	case observationBadRequest[err]:
 		status = http.StatusBadRequest
 	default:
-		err = errs.ErrInternalServer
+		resErrMsg = errs.ErrInternalServer.Error()
 		status = http.StatusInternalServerError
 	}
 
@@ -392,5 +393,5 @@ func handleObservationsErrorType(ctx context.Context, w http.ResponseWriter, err
 
 	data["responseStatus"] = status
 	log.Event(ctx, "get observation endpoint: request unsuccessful", log.ERROR, log.Error(err), data)
-	http.Error(w, err.Error(), status)
+	http.Error(w, resErrMsg, status)
 }


### PR DESCRIPTION
### What
Prevent error from being masked by generic errs.ErrInternalServer

The default case sets err to the generic errs.ErrInternalServer err, which masks the original error detail and prevents it from being logged. The error is overwritten to prevent error details from being leaked into the HTTP response, but in doing so it prevents the original error data from being logged.

To prevent this I have introduced a new variable that maintains the error message to return in the HTTP response. This defaults to the error message, and only gets overwritten in the default case. Doing this prevents err from being overwritten allowing it to be logged.

### How to review
Sanity check

### Who can review
Anyone
