### PR TITLE
get dimensionn options and get instances now return empty items if limit=0

### DIFF
--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -182,6 +182,10 @@ func (m *Mongo) GetEditions(ctx context.Context, id, state string, offset, limit
 		return nil, err
 	}
 
+	if totalCount < 1 {
+		return nil, errs.ErrEditionNotFound
+	}
+
 	iter := q.Sort().Skip(offset).Limit(limit).Iter()
 	defer func() {
 		err := iter.Close()
@@ -207,9 +211,6 @@ func (m *Mongo) GetEditions(ctx context.Context, id, state string, offset, limit
 		}
 	}
 
-	if len(results) < 1 {
-		return nil, errs.ErrEditionNotFound
-	}
 	return &models.EditionUpdateResults{
 		Items:      results,
 		Count:      len(results),

--- a/mongo/dimension_store.go
+++ b/mongo/dimension_store.go
@@ -104,13 +104,16 @@ func (m *Mongo) GetDimensionOptions(version *models.Version, dimension string, o
 	}
 
 	var values []models.PublicDimensionOption
-	iter := q.Sort("option").Skip(offset).Limit(limit).Iter()
-	if err := iter.All(&values); err != nil {
-		return nil, err
-	}
 
-	for i := 0; i < len(values); i++ {
-		values[i].Links.Version = *version.Links.Self
+	if limit > 0 {
+		iter := q.Sort("option").Skip(offset).Limit(limit).Iter()
+		if err := iter.All(&values); err != nil {
+			return nil, err
+		}
+
+		for i := 0; i < len(values); i++ {
+			values[i].Links.Version = *version.Links.Self
+		}
 	}
 
 	return &models.DimensionOptionResults{


### PR DESCRIPTION
### What

There was a change in the API standards, that required limit=0 to return no items, and limit the maximum limit that a caller can request.
These changes were already implemented in the latest paginated endpoints, but not in the old ones. In this task, this change is implemented for:
- `GET dimensions options`
- `GET instances`

Also, there is a bug fix:
- `GET editions` with limit=0 would fail due to the `len(results)` check. Now this check is performed at the Count step.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

anyone
