### PR TITLE
Add nancy-ignore file w/ exception for jwt-go

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,0 +1,2 @@
+CVE-2020-26160 # No upgrade path for github.com/dgrijalva/jwt-go. See: https://ossindex.sonatype.org/vulnerability/c16fb56d-9de6-4065-9fca-d2b4cfb13020?component-type=golang&component-name=github.com%2Fdgrijalva%2Fjwt-go&utm_source=nancy-client&utm_medium=integration&utm_content=0.0.0-dev
+

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: audit test build
 
 .PHONY: audit
 audit:
-	go list -m all | nancy sleuth --exclude-vulnerability CVE-2020-26160
+	go list -m all | nancy sleuth
 
 .PHONY: build
 build:


### PR DESCRIPTION
### What

Added .nancy-ignore file with audit exception for jwt-go package, to unblock current work while we investigate alternative packages

### How to review

Check CVE-ID is correct (see link in .nancy-ignore)

Clone and install `nancy` - https://github.com/sonatype-nexus-community/nancy

Run `go list -json -m all | nancy sleuth` in service root dir and check for 0 vulnerabilities.

### Who can review

Anyone
