### PR TITLE
Paginate instance dimensions and options getter endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -111,7 +111,7 @@ func Setup(ctx context.Context, cfg *config.Configuration, router *mux.Router, d
 
 		api.enablePrivateDatasetEndpoints(ctx, paginator)
 		api.enablePrivateInstancesEndpoints(instanceAPI, paginator)
-		api.enablePrivateDimensionsEndpoints(dimensionAPI)
+		api.enablePrivateDimensionsEndpoints(dimensionAPI, paginator)
 	} else {
 		log.Event(ctx, "enabling only public endpoints for dataset api", log.INFO)
 		api.enablePublicEndpoints(ctx, paginator)
@@ -289,12 +289,12 @@ func (api *DatasetAPI) enablePrivateInstancesEndpoints(instanceAPI *instance.Sto
 
 // enablePrivateDatasetEndpoints register the dimenions endpoints with the appropriate authentication and authorisation
 // checks required when running the dataset API in publishing (private) mode.
-func (api *DatasetAPI) enablePrivateDimensionsEndpoints(dimensionAPI *dimension.Store) {
+func (api *DatasetAPI) enablePrivateDimensionsEndpoints(dimensionAPI *dimension.Store, paginator *pagination.Paginator) {
 	api.get(
 		"/instances/{instance_id}/dimensions",
 		api.isAuthenticated(
 			api.isAuthorised(readPermission,
-				dimensionAPI.GetDimensionsHandler)),
+				paginator.Paginate(dimensionAPI.GetDimensionsHandler))),
 	)
 
 	api.post(
@@ -308,7 +308,7 @@ func (api *DatasetAPI) enablePrivateDimensionsEndpoints(dimensionAPI *dimension.
 		"/instances/{instance_id}/dimensions/{dimension}/options",
 		api.isAuthenticated(
 			api.isAuthorised(readPermission,
-				dimensionAPI.GetUniqueDimensionAndOptionsHandler)),
+				paginator.Paginate(dimensionAPI.GetUniqueDimensionAndOptionsHandler))),
 	)
 
 	api.patch(

--- a/api/dimensions.go
+++ b/api/dimensions.go
@@ -173,7 +173,7 @@ func (api *DatasetAPI) getDimensionOptions(w http.ResponseWriter, r *http.Reques
 	var totalCount int
 	if len(ids) == 0 {
 		// get sorted dimension options, starting at offset index, with a limit on the number of items
-		results, totalCount, err = api.dataStore.Backend.GetDimensionOptions(version, dimension, offset, limit)
+		results, totalCount, err = api.dataStore.Backend.GetDimensionOptions(ctx, version, dimension, offset, limit)
 		if err != nil {
 			handleDimensionsErr(ctx, w, "failed to get a list of dimension options", err, logData)
 			return nil, 0, err

--- a/dimension/dimension.go
+++ b/dimension/dimension.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store"
+	"github.com/ONSdigital/dp-dataset-api/utils"
 	dphttp "github.com/ONSdigital/dp-net/http"
 	dprequest "github.com/ONSdigital/dp-net/request"
 	"github.com/ONSdigital/log.go/log"
@@ -94,6 +95,7 @@ func (s *Store) GetUniqueDimensionAndOptionsHandler(w http.ResponseWriter, r *ht
 	}
 
 	// Get dimension options corresponding to the instance in the right state
+	// Note: GetUniqueDimensionAndOptions does not implement pagination at query level
 	options, totalCount, err := s.GetUniqueDimensionAndOptions(ctx, instanceID, dimension, offset, limit)
 	if err != nil {
 		log.Event(ctx, "failed to get unique dimension options for instance", log.ERROR, log.Error(err), logData)
@@ -101,8 +103,14 @@ func (s *Store) GetUniqueDimensionAndOptionsHandler(w http.ResponseWriter, r *ht
 		return nil, 0, err
 	}
 
+	// create the paginated result by cutting the slice
+	slicedOptions := []*string{}
+	if limit > 0 {
+		slicedOptions = utils.SliceStr(options, offset, limit)
+	}
+
 	log.Event(ctx, "successfully get unique dimension options for an instance resource", log.INFO, logData)
-	return options, totalCount, nil
+	return slicedOptions, totalCount, nil
 }
 
 // AddHandler represents adding a dimension to a specific instance

--- a/dimension/dimension_test.go
+++ b/dimension/dimension_test.go
@@ -307,7 +307,7 @@ func TestAddNodeIDToDimensionReturnsInternalError(t *testing.T) {
 		datasetAPI.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 	})
 
 	Convey("Given instance state is invalid, then response returns an internal error", t, func() {
@@ -328,7 +328,7 @@ func TestAddNodeIDToDimensionReturnsInternalError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		// Gets called twice as there is a check wrapper around this route which
 		// checks the instance is not published before entering handler
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 	})
 }
 
@@ -356,7 +356,7 @@ func TestPatchOptionReturnsInternalError(t *testing.T) {
 		datasetAPI.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 	})
 
 	Convey("Given instance state is invalid, then response returns an internal error", t, func() {
@@ -377,7 +377,7 @@ func TestPatchOptionReturnsInternalError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		// Gets called twice as there is a check wrapper around this route which
 		// checks the instance is not published before entering handler
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 	})
 
 	Convey("Given an internal error is returned from mongo GetInstance on the second call, then response returns an internal error", t, func() {
@@ -398,7 +398,7 @@ func TestPatchOptionReturnsInternalError(t *testing.T) {
 		datasetAPI.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 2)
 	})
 
 }
@@ -422,7 +422,7 @@ func TestAddNodeIDToDimensionReturnsForbidden(t *testing.T) {
 		datasetAPI.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusForbidden)
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 	})
 }
 
@@ -448,7 +448,7 @@ func TestPatchOptionReturnsForbidden(t *testing.T) {
 		datasetAPI.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusForbidden)
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 	})
 }
 
@@ -461,17 +461,12 @@ func TestAddNodeIDToDimensionReturnsUnauthorized(t *testing.T) {
 
 		w := httptest.NewRecorder()
 
-		mockedDataStore := &storetest.StorerMock{
-			GetInstanceFunc: func(ID string) (*models.Instance, error) {
-				return &models.Instance{State: models.PublishedState}, nil
-			},
-		}
+		mockedDataStore := &storetest.StorerMock{}
 
 		datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		datasetAPI.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusUnauthorized)
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 0)
 	})
 }
 
@@ -487,17 +482,12 @@ func TestPatchOptionReturnsUnauthorized(t *testing.T) {
 
 		w := httptest.NewRecorder()
 
-		mockedDataStore := &storetest.StorerMock{
-			GetInstanceFunc: func(ID string) (*models.Instance, error) {
-				return &models.Instance{State: models.PublishedState}, nil
-			},
-		}
+		mockedDataStore := &storetest.StorerMock{}
 
 		datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		datasetAPI.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusUnauthorized)
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 0)
 	})
 }
 
@@ -524,11 +514,11 @@ func TestAddDimensionToInstanceReturnsOk(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusOK)
 		// Gets called twice as there is a check wrapper around this route which
 		// checks the instance is not published before entering handler
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 2)
 		So(mockedDataStore.GetInstanceCalls()[0].ID, ShouldEqual, "123")
 		So(mockedDataStore.GetInstanceCalls()[1].ID, ShouldEqual, "123")
 
-		So(len(mockedDataStore.AddDimensionToInstanceCalls()), ShouldEqual, 1)
+		So(mockedDataStore.AddDimensionToInstanceCalls(), ShouldHaveLength, 1)
 		So(mockedDataStore.AddDimensionToInstanceCalls()[0].Dimension.CodeList, ShouldEqual, "123-456")
 		So(mockedDataStore.AddDimensionToInstanceCalls()[0].Dimension.Name, ShouldEqual, "test")
 		So(*mockedDataStore.AddDimensionToInstanceCalls()[0].Dimension.Order, ShouldEqual, 1)
@@ -560,8 +550,8 @@ func TestAddDimensionToInstanceReturnsNotFound(t *testing.T) {
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrDimensionNodeNotFound.Error())
 		// Gets called twice as there is a check wrapper around this route which
 		// checks the instance is not published before entering handler
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
-		So(len(mockedDataStore.AddDimensionToInstanceCalls()), ShouldEqual, 1)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 2)
+		So(mockedDataStore.AddDimensionToInstanceCalls(), ShouldHaveLength, 1)
 	})
 }
 
@@ -578,9 +568,6 @@ func TestAddDimensionToInstanceReturnsForbidden(t *testing.T) {
 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
 				return &models.Instance{State: models.PublishedState}, nil
 			},
-			AddDimensionToInstanceFunc: func(event *models.CachedDimensionOption) error {
-				return nil
-			},
 		}
 
 		datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{})
@@ -588,8 +575,7 @@ func TestAddDimensionToInstanceReturnsForbidden(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrResourcePublished.Error())
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.AddDimensionToInstanceCalls()), ShouldEqual, 0)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 	})
 }
 
@@ -602,18 +588,13 @@ func TestAddDimensionToInstanceReturnsUnauthorized(t *testing.T) {
 
 		w := httptest.NewRecorder()
 
-		mockedDataStore := &storetest.StorerMock{
-			GetInstanceFunc: func(ID string) (*models.Instance, error) {
-				return &models.Instance{State: models.CreatedState}, nil
-			},
-		}
+		mockedDataStore := &storetest.StorerMock{}
 
 		datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{})
 		datasetAPI.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusUnauthorized)
 		So(w.Body.String(), ShouldContainSubstring, "unauthenticated request")
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 0)
 	})
 }
 
@@ -631,9 +612,6 @@ func TestAddDimensionToInstanceReturnsInternalError(t *testing.T) {
 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
 				return nil, errs.ErrInternalServer
 			},
-			AddDimensionToInstanceFunc: func(event *models.CachedDimensionOption) error {
-				return nil
-			},
 		}
 
 		datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{})
@@ -642,8 +620,7 @@ func TestAddDimensionToInstanceReturnsInternalError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
 
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.AddDimensionToInstanceCalls()), ShouldEqual, 0)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 	})
 
 	Convey("Given instance state is invalid, then response returns an internal error", t, func() {
@@ -657,9 +634,6 @@ func TestAddDimensionToInstanceReturnsInternalError(t *testing.T) {
 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
 				return &models.Instance{State: "gobbledygook"}, nil
 			},
-			AddDimensionToInstanceFunc: func(event *models.CachedDimensionOption) error {
-				return nil
-			},
 		}
 
 		datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{})
@@ -669,8 +643,7 @@ func TestAddDimensionToInstanceReturnsInternalError(t *testing.T) {
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
 		// Gets called twice as there is a check wrapper around this route which
 		// checks the instance is not published before entering handler
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.AddDimensionToInstanceCalls()), ShouldEqual, 0)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 	})
 }
 
@@ -686,8 +659,8 @@ func TestGetDimensionsReturnsOk(t *testing.T) {
 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
 				return &models.Instance{State: models.CreatedState}, nil
 			},
-			GetDimensionsFromInstanceFunc: func(id string) (*models.DimensionNodeResults, error) {
-				return &models.DimensionNodeResults{}, nil
+			GetDimensionsFromInstanceFunc: func(ctx context.Context, id string, offset, limit int) ([]*models.DimensionOption, int, error) {
+				return []*models.DimensionOption{}, 0, nil
 			},
 		}
 
@@ -695,8 +668,8 @@ func TestGetDimensionsReturnsOk(t *testing.T) {
 		datasetAPI.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetDimensionsFromInstanceCalls()), ShouldEqual, 1)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.GetDimensionsFromInstanceCalls(), ShouldHaveLength, 1)
 	})
 }
 
@@ -712,8 +685,8 @@ func TestGetDimensionsReturnsNotFound(t *testing.T) {
 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
 				return &models.Instance{State: models.CreatedState}, nil
 			},
-			GetDimensionsFromInstanceFunc: func(id string) (*models.DimensionNodeResults, error) {
-				return nil, errs.ErrDimensionNodeNotFound
+			GetDimensionsFromInstanceFunc: func(ctx context.Context, id string, offset, limit int) ([]*models.DimensionOption, int, error) {
+				return nil, 0, errs.ErrDimensionNodeNotFound
 			},
 		}
 
@@ -722,8 +695,8 @@ func TestGetDimensionsReturnsNotFound(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrDimensionNodeNotFound.Error())
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetDimensionsFromInstanceCalls()), ShouldEqual, 1)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.GetDimensionsFromInstanceCalls(), ShouldHaveLength, 1)
 	})
 }
 
@@ -739,9 +712,6 @@ func TestGetDimensionsAndOptionsReturnsInternalError(t *testing.T) {
 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
 				return nil, errs.ErrInternalServer
 			},
-			GetDimensionsFromInstanceFunc: func(id string) (*models.DimensionNodeResults, error) {
-				return &models.DimensionNodeResults{}, nil
-			},
 		}
 
 		datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{})
@@ -749,8 +719,7 @@ func TestGetDimensionsAndOptionsReturnsInternalError(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetDimensionsFromInstanceCalls()), ShouldEqual, 0)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 	})
 
 	Convey("Given instance state is invalid, then response returns an internal error", t, func() {
@@ -763,9 +732,6 @@ func TestGetDimensionsAndOptionsReturnsInternalError(t *testing.T) {
 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
 				return &models.Instance{State: "gobbly gook"}, nil
 			},
-			GetDimensionsFromInstanceFunc: func(id string) (*models.DimensionNodeResults, error) {
-				return &models.DimensionNodeResults{}, nil
-			},
 		}
 
 		datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{})
@@ -773,8 +739,7 @@ func TestGetDimensionsAndOptionsReturnsInternalError(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetDimensionsFromInstanceCalls()), ShouldEqual, 0)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 	})
 }
 
@@ -790,8 +755,8 @@ func TestGetUniqueDimensionAndOptionsReturnsOk(t *testing.T) {
 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
 				return &models.Instance{State: models.CreatedState}, nil
 			},
-			GetUniqueDimensionAndOptionsFunc: func(id, dimension string) (*models.DimensionValues, error) {
-				return &models.DimensionValues{}, nil
+			GetUniqueDimensionAndOptionsFunc: func(ctx context.Context, ID string, dimension string, offset int, limit int) ([]*string, int, error) {
+				return []*string{}, 0, nil
 			},
 		}
 
@@ -799,8 +764,8 @@ func TestGetUniqueDimensionAndOptionsReturnsOk(t *testing.T) {
 		datasetAPI.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetUniqueDimensionAndOptionsCalls()), ShouldEqual, 1)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.GetUniqueDimensionAndOptionsCalls(), ShouldHaveLength, 1)
 	})
 }
 
@@ -815,8 +780,8 @@ func TestGetUniqueDimensionAndOptionsReturnsNotFound(t *testing.T) {
 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
 				return &models.Instance{State: models.CreatedState}, nil
 			},
-			GetUniqueDimensionAndOptionsFunc: func(id, dimension string) (*models.DimensionValues, error) {
-				return nil, errs.ErrInstanceNotFound
+			GetUniqueDimensionAndOptionsFunc: func(ctx context.Context, ID string, dimension string, offset int, limit int) ([]*string, int, error) {
+				return nil, 0, errs.ErrInstanceNotFound
 			},
 		}
 
@@ -825,8 +790,8 @@ func TestGetUniqueDimensionAndOptionsReturnsNotFound(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrInstanceNotFound.Error())
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetUniqueDimensionAndOptionsCalls()), ShouldEqual, 1)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.GetUniqueDimensionAndOptionsCalls(), ShouldHaveLength, 1)
 	})
 }
 
@@ -841,9 +806,6 @@ func TestGetUniqueDimensionAndOptionsReturnsInternalError(t *testing.T) {
 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
 				return nil, errs.ErrInternalServer
 			},
-			GetDimensionsFromInstanceFunc: func(id string) (*models.DimensionNodeResults, error) {
-				return &models.DimensionNodeResults{}, nil
-			},
 		}
 
 		datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{})
@@ -851,8 +813,7 @@ func TestGetUniqueDimensionAndOptionsReturnsInternalError(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetUniqueDimensionAndOptionsCalls()), ShouldEqual, 0)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 	})
 
 	Convey("Given instance state is invalid, then response returns an internal error", t, func() {
@@ -864,9 +825,6 @@ func TestGetUniqueDimensionAndOptionsReturnsInternalError(t *testing.T) {
 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
 				return &models.Instance{State: "gobbly gook"}, nil
 			},
-			GetDimensionsFromInstanceFunc: func(id string) (*models.DimensionNodeResults, error) {
-				return &models.DimensionNodeResults{}, nil
-			},
 		}
 
 		datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{})
@@ -874,8 +832,7 @@ func TestGetUniqueDimensionAndOptionsReturnsInternalError(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
-		So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetUniqueDimensionAndOptionsCalls()), ShouldEqual, 0)
+		So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 	})
 }
 

--- a/features/dimensions.feature
+++ b/features/dimensions.feature
@@ -184,7 +184,7 @@ Feature: Dataset API
             """
             {
                 "count": 0,
-                "items": null,
+                "items": [],
                 "limit": 20,
                 "offset": 0,
                 "total_count": 0

--- a/features/instance_dimensions.feature
+++ b/features/instance_dimensions.feature
@@ -1,0 +1,306 @@
+Feature: Dataset API
+
+    Background: we have instances
+        Given I have these instances:
+            """            
+            [
+                {
+                    "id": "test-item-1",
+                    "state": "published",
+                    "links": {
+                        "dataset": {
+                            "id": "population-estimates"
+                        }
+                    },
+                    "dimensions" : [
+                        {
+                            "href" : "http://localhost:22400/code-lists/yyyy-qq",
+                            "id" : "yyyy-qq",
+                            "name": "time"
+                        }, 
+                        {
+                            "href" : "http://localhost:22400/code-lists/uk-only",
+                            "id" : "uk-only",
+                            "name" : "geography"
+                        }
+                    ]
+                }
+            ]
+            """
+
+        And I have these dimensions:
+            """
+            [
+                {
+                    "instance_id": "test-item-1",
+                    "label" : "2021 Q1",
+                    "links" : {
+                        "code" : {
+                            "href" : "http://localhost:22400/code-lists/yyyy-qq/codes/2021-q1",
+                            "id" : "2021-q1"
+                        },
+                        "code_list" : {
+                            "href" : "http://localhost:22400/code-lists/yyyy-qq",
+                            "id" : "yyyy-qq"
+                        }
+                    },
+                    "dimension" : "time",
+                    "option" : "2021-q1",
+                    "node_id" : "_e9ddf7a4-c72f-44e6-a23a-a02666b92139_time_2021-q1"
+                },
+                {
+                    "instance_id": "test-item-1",
+                    "label" : "2021 Q2",
+                    "links" : {
+                        "code" : {
+                            "href" : "http://localhost:22400/code-lists/yyyy-qq/codes/2021-q2",
+                            "id" : "2021-q2"
+                        },
+                        "code_list" : {
+                            "href" : "http://localhost:22400/code-lists/yyyy-qq",
+                            "id" : "yyyy-qq"
+                        }
+                    },
+                    "dimension" : "time",
+                    "option" : "2021-q2",
+                    "node_id" : "_e9ddf7a4-c72f-44e6-a23a-a02666b92139_time_2021-q2"
+                },
+                {
+                    "instance_id": "test-item-1",
+                    "label" : "2021 Q3",
+                    "links" : {
+                        "code" : {
+                            "href" : "http://localhost:22400/code-lists/yyyy-qq/codes/2021-q3",
+                            "id" : "2021-q3"
+                        },
+                        "code_list" : {
+                            "href" : "http://localhost:22400/code-lists/yyyy-qq",
+                            "id" : "yyyy-qq"
+                        }
+                    },
+                    "dimension" : "time",
+                    "option" : "2021-q3",
+                    "node_id" : "_e9ddf7a4-c72f-44e6-a23a-a02666b92139_time_2021-q3"
+                },
+                {
+                    "instance_id": "test-item-1",
+                    "label" : "United Kingdom",
+                    "links": {
+                        "code" : {
+                            "href" : "http://localhost:22400/code-lists/uk-only/codes/K02000001",
+                            "id" : "K02000001"
+                        },
+                        "code_list" : {
+                            "href" : "http://localhost:22400/code-lists/uk-only",
+                            "id" : "uk-only"
+                        }
+                    },
+                    "dimension" : "geography",
+                    "option" : "K02000001",
+                    "node_id" : "_7b48a92b-059f-4ff6-b96d-41858ffb4d3c_geography_K02000001"
+                },
+                {
+                    "instance_id": "test-item-2",
+                    "label" : "2021 Q4",
+                    "links" : {},
+                    "dimension": "time",
+                    "option" : "2021-q4",
+                    "node_id" : "_e9ddf7a4-c72f-44e6-a23a-a02666b92139_time_2021-q4"
+                }
+            ]
+            """
+
+    Scenario: GET /instances/test-item-1/dimensions in private mode returns first page of 20 instance dimensions
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I GET "/instances/test-item-1/dimensions"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "count": 4,
+                "items": [
+                    {
+                        "label": "2021 Q1",
+                        "links": {
+                            "code": {
+                                "href": "http://localhost:22400/code-lists/yyyy-qq/codes/2021-q1",
+                                "id": "2021-q1"
+                            },
+                            "code_list": {
+                                "href": "http://localhost:22400/code-lists/yyyy-qq",
+                                "id": "yyyy-qq"
+                            },
+                            "version": {}
+                        },
+                        "dimension": "time",
+                        "order": null,
+                        "node_id": "_e9ddf7a4-c72f-44e6-a23a-a02666b92139_time_2021-q1",
+                        "option": "2021-q1"
+                    },
+                    {
+                        "label": "2021 Q2",
+                        "links": {
+                            "code": {
+                                "href": "http://localhost:22400/code-lists/yyyy-qq/codes/2021-q2",
+                                "id": "2021-q2"
+                            },
+                            "code_list": {
+                                "href": "http://localhost:22400/code-lists/yyyy-qq",
+                                "id": "yyyy-qq"
+                            },
+                            "version": {}
+                        },
+                        "dimension": "time",
+                        "order": null,
+                        "node_id": "_e9ddf7a4-c72f-44e6-a23a-a02666b92139_time_2021-q2",
+                        "option": "2021-q2"
+                    },
+                    {
+                        "label": "2021 Q3",
+                        "links": {
+                            "code": {
+                                "href": "http://localhost:22400/code-lists/yyyy-qq/codes/2021-q3",
+                                "id": "2021-q3"
+                            },
+                            "code_list": {
+                                "href": "http://localhost:22400/code-lists/yyyy-qq",
+                                "id": "yyyy-qq"
+                            },
+                            "version": {}
+                        },
+                        "dimension": "time",
+                        "order": null,
+                        "node_id": "_e9ddf7a4-c72f-44e6-a23a-a02666b92139_time_2021-q3",
+                        "option": "2021-q3"
+                    },
+                    {
+                        "label" : "United Kingdom",
+                        "links": {
+                            "code" : {
+                                "href" : "http://localhost:22400/code-lists/uk-only/codes/K02000001",
+                                "id" : "K02000001"
+                            },
+                            "code_list" : {
+                                "href" : "http://localhost:22400/code-lists/uk-only",
+                                "id" : "uk-only"
+                            },
+                            "version": {}
+                        },
+                        "dimension" : "geography",
+                        "order": null,
+                        "option" : "K02000001",
+                        "node_id" : "_7b48a92b-059f-4ff6-b96d-41858ffb4d3c_geography_K02000001"
+                    }
+                ],
+                "limit": 20,
+                "offset": 0,
+                "total_count": 4
+            }
+            """
+
+    Scenario: GET /instances/test-item-1/dimensions?offset=3&limit=7 in private mode returns the paginated instance dimensions values according to offset and limit
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I GET "/instances/test-item-1/dimensions?offset=3&limit=7"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "count": 1,
+                "items": [
+                    {
+                        "label" : "United Kingdom",
+                        "links": {
+                            "code" : {
+                                "href" : "http://localhost:22400/code-lists/uk-only/codes/K02000001",
+                                "id" : "K02000001"
+                            },
+                            "code_list" : {
+                                "href" : "http://localhost:22400/code-lists/uk-only",
+                                "id" : "uk-only"
+                            },
+                            "version": {}
+                        },
+                        "dimension" : "geography",
+                        "order": null,
+                        "option" : "K02000001",
+                        "node_id" : "_7b48a92b-059f-4ff6-b96d-41858ffb4d3c_geography_K02000001"
+                    }
+                ],
+                "limit": 7,
+                "offset": 3,
+                "total_count": 4
+            }
+            """
+
+    Scenario: GET /instances/inexistent/dimensions in private mode returns a notFound status code
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I GET "/instances/inexistent/dimensions"
+        Then the HTTP status code should be "404"
+        And I should receive the following response:
+            """
+            instance not found
+            """
+
+    Scenario: GET /instances/test-item-1/dimensions/time/options in private mode returns the first page of 20 instance dimensions options
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I GET "/instances/test-item-1/dimensions/time/options"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "count": 3,
+                "items": [
+                    "2021-q1",
+                    "2021-q2",
+                    "2021-q3"
+                ],
+                "limit": 20,
+                "offset": 0,
+                "total_count": 3
+            }
+            """
+
+    Scenario: GET /instances/test-item-1/dimensions/time/options?offset=1&limit=1 in private mode returns the paginated instance dimensions options according to the provided offset and limit
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I GET "/instances/test-item-1/dimensions/time/options?offset=1&limit=1"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "count": 1,
+                "items": [
+                    "2021-q2"
+                ],
+                "limit": 1,
+                "offset": 1,
+                "total_count": 3
+            }
+            """
+
+    Scenario: GET /instances/inexistent/dimensions/time/options in private mode returns a notFound status code
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I GET "/instances/inexistent/dimensions/time/options"
+        Then the HTTP status code should be "404"
+        And I should receive the following response:
+            """
+            instance not found
+            """
+
+    Scenario: GET /instances/test-item-1/dimensions/inexistent/options in private mode returns a notFound status code
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I GET "/instances/test-item-1/dimensions/inexistent/options"
+        Then the HTTP status code should be "404"
+        And I should receive the following response:
+            """
+            dimension node not found
+            """

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ONSdigital/dp-graph/v2 v2.7.1
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.1.2
-	github.com/ONSdigital/dp-mongodb v1.5.0
+	github.com/ONSdigital/dp-mongodb v1.5.1-0.20210603140007-7c7a5c23b80f
 	github.com/ONSdigital/dp-net v1.0.12
 	github.com/ONSdigital/go-ns v0.0.0-20200902154605-290c8b5ba5eb
 	github.com/ONSdigital/log.go v1.0.1
@@ -30,7 +30,6 @@ require (
 	github.com/satori/go.uuid v1.2.0
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.6.1
-	go.mongodb.org/mongo-driver v1.4.6
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
 	golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ONSdigital/dp-graph/v2 v2.7.1
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.1.2
-	github.com/ONSdigital/dp-mongodb v1.5.1-0.20210603140007-7c7a5c23b80f
+	github.com/ONSdigital/dp-mongodb v1.5.0
 	github.com/ONSdigital/dp-net v1.0.12
 	github.com/ONSdigital/go-ns v0.0.0-20200902154605-290c8b5ba5eb
 	github.com/ONSdigital/log.go v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/ONSdigital/dp-kafka/v2 v2.1.2 h1:gXqS9zQXJDOuRlhokz7uenYMKElENCdC7Kbd
 github.com/ONSdigital/dp-kafka/v2 v2.1.2/go.mod h1:iyDeWxp1QyJJBQ4cOCWuwrwU9iGS9qYbfV7avbcaenI=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
-github.com/ONSdigital/dp-mongodb v1.5.1-0.20210603140007-7c7a5c23b80f h1:JiUjQBbLoFEFApqDsQvxgXX1JolqOlZFHdM3xU/Mrg4=
-github.com/ONSdigital/dp-mongodb v1.5.1-0.20210603140007-7c7a5c23b80f/go.mod h1:zm2gWzuqR+aiy2y2NLnfBIafvhKQ0IVPtiClaYyLkmo=
+github.com/ONSdigital/dp-mongodb v1.5.0 h1:Jrqixx0xr9aPSPya0Wce8Ly1zVwB0M6nC3K4umNPfqI=
+github.com/ONSdigital/dp-mongodb v1.5.0/go.mod h1:zm2gWzuqR+aiy2y2NLnfBIafvhKQ0IVPtiClaYyLkmo=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805150805-cac050646ab5/go.mod h1:de3LB9tedE0tObBwa12dUOt5rvTW4qQkF5rXtt4b6CE=

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/ONSdigital/dp-kafka/v2 v2.1.2 h1:gXqS9zQXJDOuRlhokz7uenYMKElENCdC7Kbd
 github.com/ONSdigital/dp-kafka/v2 v2.1.2/go.mod h1:iyDeWxp1QyJJBQ4cOCWuwrwU9iGS9qYbfV7avbcaenI=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
-github.com/ONSdigital/dp-mongodb v1.5.0 h1:Jrqixx0xr9aPSPya0Wce8Ly1zVwB0M6nC3K4umNPfqI=
-github.com/ONSdigital/dp-mongodb v1.5.0/go.mod h1:zm2gWzuqR+aiy2y2NLnfBIafvhKQ0IVPtiClaYyLkmo=
+github.com/ONSdigital/dp-mongodb v1.5.1-0.20210603140007-7c7a5c23b80f h1:JiUjQBbLoFEFApqDsQvxgXX1JolqOlZFHdM3xU/Mrg4=
+github.com/ONSdigital/dp-mongodb v1.5.1-0.20210603140007-7c7a5c23b80f/go.mod h1:zm2gWzuqR+aiy2y2NLnfBIafvhKQ0IVPtiClaYyLkmo=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805150805-cac050646ab5/go.mod h1:de3LB9tedE0tObBwa12dUOt5rvTW4qQkF5rXtt4b6CE=
@@ -96,7 +96,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cucumber/gherkin-go/v11 v11.0.0 h1:cwVwN1Qn2VRSfHZNLEh5x00tPBmZcjATBWDpxsR5Xug=
 github.com/cucumber/gherkin-go/v11 v11.0.0/go.mod h1:CX33k2XU2qog4e+TFjOValoq6mIUq0DmVccZs238R9w=
-github.com/cucumber/godog v0.10.0 h1:W01u1+o8bRpgqJRLrclN3iAanU1jAao+TwOMoSV9g1Y=
 github.com/cucumber/godog v0.10.0/go.mod h1:0Q+MOUg8Z9AhzLV+nNMbThQ2x1b17yYwGyahApTLjJA=
 github.com/cucumber/godog v0.11.0 h1:xgaWyJuAD6A+aW4TfVGNDBhuMyKW0jjl0cvY3KNxEak=
 github.com/cucumber/godog v0.11.0/go.mod h1:GyxCIrsg1sgEgpL2GD/rMr3fIoNHpgkjm9nANw/89XY=
@@ -115,10 +114,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
-github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9 h1:wWke/RUCl7VRjQhwPlR/v0glZXNYzBHdNUzf/Am2Nmg=
 github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9/go.mod h1:uPmAp6Sws4L7+Q/OokbWDAK1ibXYhB3PXFP1kol5hPg=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
@@ -170,7 +167,6 @@ github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPh
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -217,13 +213,10 @@ github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
-github.com/hashicorp/go-immutable-radix v1.2.0 h1:l6UW37iCXwZkZoAbEYnptSHVE/cQ5bOTPYG5W3vf9+8=
 github.com/hashicorp/go-immutable-radix v1.2.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.0 h1:8exGP7ego3OmkfksihtSouGMZ+hQrhxx+FVELeXpVPE=
 github.com/hashicorp/go-immutable-radix v1.3.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
-github.com/hashicorp/go-memdb v1.2.1 h1:wI9btDjYUOJJHTCnRlAG/TkRyD/ij7meJMrLK9X31Cc=
 github.com/hashicorp/go-memdb v1.2.1/go.mod h1:OSvLJ662Jim8hMM+gWGyhktyWk2xPCnWMc7DWIqtkGA=
-github.com/hashicorp/go-memdb v1.3.0 h1:xdXq34gBOMEloa9rlGStLxmfX/dyIK8htOv36dQUwHU=
 github.com/hashicorp/go-memdb v1.3.0/go.mod h1:Mluclgwib3R93Hk5fxEfiRhB+6Dar64wWh71LpNSe3g=
 github.com/hashicorp/go-memdb v1.3.1 h1:EIj6L28rTL41BDHBvwq1VJXzcmY2R2JBrxpWxF7Etyk=
 github.com/hashicorp/go-memdb v1.3.1/go.mod h1:Mluclgwib3R93Hk5fxEfiRhB+6Dar64wWh71LpNSe3g=
@@ -247,7 +240,6 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e h1:0aewS5NTyxftZHSnFaJmWE5oCCrj4DyEXkAiMa1iZJM=
 github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519 h1:nqAlWFEdqI0ClbTDrhDvE/8LeQ4pftrqKUX9w5k0j3s=
 github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
@@ -282,7 +274,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -294,7 +285,6 @@ github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
-github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -323,7 +313,6 @@ github.com/mongo-go/testdb v0.0.0-20190724200850-a72a12eee610/go.mod h1:xyZcxcSx
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nats-io/gnatsd v1.4.1/go.mod h1:nqco77VO78hLCJpIcVfygDP2rPGfsEHkGTUk94uh5DQ=
-github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -383,7 +372,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/square/mongo-lock v0.0.0-20191001051310-282c90e422d0/go.mod h1:wR5++/O5fpa0UtI+9T8gKIi5jjl10va/EIEMRySqic4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -424,7 +412,6 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
@@ -469,7 +456,6 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200528225125-3c3fba18258b/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d h1:1aflnvSoWWLI2k/dMUAl5lvU1YO4Mb4hz0gh+1rjcxU=
 golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -482,7 +468,6 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190412183630-56d357773e84/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
@@ -510,7 +495,6 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43 h1:SgQ6LNaYJU0JIuEHv9+s6EbhSCwYeAf5Yvj6lpYlqAE=
@@ -551,7 +535,6 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -583,7 +566,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
@@ -607,7 +589,6 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20200601152816-913338de1bd2 h1:VEmvx0P+GVTgkNu2EdTN988YCZPcD3lo9AoczZpucwc=
 gopkg.in/yaml.v3 v3.0.0-20200601152816-913338de1bd2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -87,7 +87,7 @@ func (m *Mongo) GetDatasets(ctx context.Context, offset, limit int, authorised b
 
 	// get total count and paginated values according to provided offset and limit
 	values := []*models.DatasetUpdate{}
-	totalCount, err := dpmongo.QueryPage(ctx, q, offset, limit, &values)
+	totalCount, err := QueryPage(ctx, q, offset, limit, &values)
 	if err != nil {
 		if err == mgo.ErrNotFound { // ignore ErrNotFound errors
 			return values, totalCount, nil
@@ -124,7 +124,7 @@ func (m *Mongo) GetEditions(ctx context.Context, id, state string, offset, limit
 
 	// get total count and paginated values according to provided offset and limit
 	results := []*models.EditionUpdate{}
-	totalCount, err := dpmongo.QueryPage(ctx, q, offset, limit, &results)
+	totalCount, err := QueryPage(ctx, q, offset, limit, &results)
 	if err != nil {
 		return results, 0, err
 	}
@@ -231,7 +231,7 @@ func (m *Mongo) GetVersions(ctx context.Context, datasetID, editionID, state str
 
 	// get total count and paginated values according to provided offset and limit
 	results := []models.Version{}
-	totalCount, err := dpmongo.QueryPage(ctx, q, offset, limit, &results)
+	totalCount, err := QueryPage(ctx, q, offset, limit, &results)
 	if err != nil {
 		return results, 0, err
 	}

--- a/mongo/dimension_store.go
+++ b/mongo/dimension_store.go
@@ -15,7 +15,9 @@ import (
 const dimensionOptions = "dimension.options"
 const maxIDs = 1000
 
-// GetDimensionsFromInstance returns a list of dimensions and their options for an instance resource
+// GetDimensionsFromInstance returns a list of dimensions and their options for an instance resource.
+// Note that all dimension options for all dimensions are returned as high level items, hence there can be duplicate dimension names,
+// which correspond to different options.
 func (m *Mongo) GetDimensionsFromInstance(ctx context.Context, id string, offset, limit int) ([]*models.DimensionOption, int, error) {
 	s := m.Session.Copy()
 	defer s.Close()

--- a/mongo/dimension_store.go
+++ b/mongo/dimension_store.go
@@ -8,7 +8,6 @@ import (
 
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/models"
-	dpmongo "github.com/ONSdigital/dp-mongodb"
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 )
@@ -27,7 +26,7 @@ func (m *Mongo) GetDimensionsFromInstance(ctx context.Context, id string, offset
 
 	// get total count and paginated values according to provided offset and limit
 	dimensions := []*models.DimensionOption{}
-	totalCount, err := dpmongo.QueryPage(ctx, q, offset, limit, &dimensions)
+	totalCount, err := QueryPage(ctx, q, offset, limit, &dimensions)
 	if err != nil {
 		return dimensions, 0, err
 	}
@@ -120,7 +119,7 @@ func (m *Mongo) GetDimensionOptions(ctx context.Context, version *models.Version
 
 	// get total count and paginated values according to provided offset and limit
 	values := []*models.PublicDimensionOption{}
-	totalCount, err := dpmongo.QueryPage(ctx, q, offset, limit, &values)
+	totalCount, err := QueryPage(ctx, q, offset, limit, &values)
 	if err != nil {
 		return values, 0, err
 	}

--- a/mongo/dimension_store.go
+++ b/mongo/dimension_store.go
@@ -45,7 +45,9 @@ func (m *Mongo) GetUniqueDimensionAndOptions(ctx context.Context, id, dimension 
 		return nil, 0, err
 	}
 
-	// TODO implement pagination with distinct? Is Disctinct necessary?
+	// Is Disctinct necessary?
+	// If we can guarantee that all options will be different for a dimension and instance
+	// then we could create an iterator and get only the necessary items from the DB
 	values := []*string{}
 	err = q.Distinct("option", &values)
 	if err != nil {

--- a/mongo/instance_store.go
+++ b/mongo/instance_store.go
@@ -6,7 +6,7 @@ import (
 
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/models"
-	mongo "github.com/ONSdigital/dp-mongodb"
+	dpmongo "github.com/ONSdigital/dp-mongodb"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
@@ -96,12 +96,12 @@ func (m *Mongo) UpdateInstance(ctx context.Context, instanceID string, instance 
 
 	updates := createInstanceUpdateQuery(ctx, instanceID, instance)
 	update := bson.M{"$set": updates}
-	updateWithTimestamps, err := mongo.WithUpdates(update)
+	updateWithTimestamps, err := dpmongo.WithUpdates(update)
 	if err != nil {
 		return err
 	}
 
-	if err = s.DB(m.Database).C(instanceCollection).Update(bson.M{"id": instanceID, mongo.UniqueTimestampKey: instance.UniqueTimestamp}, updateWithTimestamps); err != nil {
+	if err = s.DB(m.Database).C(instanceCollection).Update(bson.M{"id": instanceID, dpmongo.UniqueTimestampKey: instance.UniqueTimestamp}, updateWithTimestamps); err != nil {
 		if err != mgo.ErrNotFound {
 			return err
 		}

--- a/mongo/instance_store.go
+++ b/mongo/instance_store.go
@@ -32,7 +32,7 @@ func (m *Mongo) GetInstances(ctx context.Context, states []string, datasets []st
 
 	// get total count and paginated values according to provided offset and limit
 	results := []*models.Instance{}
-	totalCount, err := dpmongo.QueryPage(ctx, q, offset, limit, &results)
+	totalCount, err := QueryPage(ctx, q, offset, limit, &results)
 	if err != nil {
 		if err == mgo.ErrNotFound {
 			return results, 0, errs.ErrDatasetNotFound

--- a/mongo/pagination.go
+++ b/mongo/pagination.go
@@ -1,0 +1,52 @@
+package mongo
+
+import (
+	"context"
+
+	"github.com/ONSdigital/log.go/log"
+	"github.com/globalsign/mgo"
+)
+
+// QueryPage obtains the page of documents defined by the provided offset and limit into the provided slice
+// and closes the iterator.
+// It also provides the total count of documents that would satisfy the provided query without offset or limit.
+//
+// The result argument must necessarily be the address for a slice. The slice
+// may be nil or previously allocated.
+//
+// For instance:
+//
+//    var result []struct{ Value int }
+//    q := s.DB(myDatabase).C(myCollection).Find(mySelector)
+//    totalCount, err := queryPage(ctx, q, offset, limit, &result)
+//    if err != nil {
+//        return err
+//    }
+//
+func QueryPage(ctx context.Context, q *mgo.Query, offset, limit int, result interface{}) (totalCount int, err error) {
+
+	// get total count of items for the provided query
+	totalCount, err = q.Count()
+	if err != nil {
+		log.Event(ctx, "error counting items", log.ERROR, log.Error(err))
+		return
+	}
+
+	// query the items corresponding to the provided offest and limit (only if necessary)
+	if totalCount > 0 && limit > 0 && offset < totalCount {
+		iter := q.Skip(offset).Limit(limit).Iter()
+		defer func() {
+			err := iter.Close()
+			if err != nil {
+				log.Event(ctx, "error closing iterator", log.ERROR, log.Error(err), log.Data{"query": q})
+			}
+		}()
+
+		err = iter.All(result)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	return totalCount, nil
+}

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -26,7 +26,7 @@ type dataMongoDB interface {
 	CheckEditionExists(ID, editionID, state string) error
 	GetDataset(ID string) (*models.DatasetUpdate, error)
 	GetDatasets(ctx context.Context, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
-	GetDimensionsFromInstance(ID string) (*models.DimensionNodeResults, error)
+	GetDimensionsFromInstance(ctx context.Context, ID string, offset, limit int) ([]*models.DimensionOption, int, error)
 	GetDimensions(datasetID, versionID string) ([]bson.M, error)
 	GetDimensionOptions(version *models.Version, dimension string, offset, limit int) ([]*models.PublicDimensionOption, int, error)
 	GetDimensionOptionsFromIDs(version *models.Version, dimension string, ids []string) ([]*models.PublicDimensionOption, int, error)
@@ -35,7 +35,7 @@ type dataMongoDB interface {
 	GetInstances(ctx context.Context, states []string, datasets []string, offset, limit int) ([]*models.Instance, int, error)
 	GetInstance(ID string) (*models.Instance, error)
 	GetNextVersion(datasetID, editionID string) (int, error)
-	GetUniqueDimensionAndOptions(ID, dimension string) (*models.DimensionValues, error)
+	GetUniqueDimensionAndOptions(ctx context.Context, ID, dimension string, offset, limit int) ([]*string, int, error)
 	GetVersion(datasetID, editionID, version, state string) (*models.Version, error)
 	GetVersions(ctx context.Context, datasetID, editionID, state string, offset, limit int) ([]models.Version, int, error)
 	UpdateDataset(ctx context.Context, ID string, dataset *models.Dataset, currentState string) error

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -28,7 +28,7 @@ type dataMongoDB interface {
 	GetDatasets(ctx context.Context, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
 	GetDimensionsFromInstance(ctx context.Context, ID string, offset, limit int) ([]*models.DimensionOption, int, error)
 	GetDimensions(datasetID, versionID string) ([]bson.M, error)
-	GetDimensionOptions(version *models.Version, dimension string, offset, limit int) ([]*models.PublicDimensionOption, int, error)
+	GetDimensionOptions(ctx context.Context, version *models.Version, dimension string, offset, limit int) ([]*models.PublicDimensionOption, int, error)
 	GetDimensionOptionsFromIDs(version *models.Version, dimension string, ids []string) ([]*models.PublicDimensionOption, int, error)
 	GetEdition(ID, editionID, state string) (*models.EditionUpdate, error)
 	GetEditions(ctx context.Context, ID, state string, offset, limit int, authorised bool) ([]*models.EditionUpdate, int, error)

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -11,130 +11,169 @@ import (
 	"sync"
 )
 
+var (
+	lockStorerMockAddDimensionToInstance            sync.RWMutex
+	lockStorerMockAddEventToInstance                sync.RWMutex
+	lockStorerMockAddInstance                       sync.RWMutex
+	lockStorerMockAddVersionDetailsToInstance       sync.RWMutex
+	lockStorerMockCheckDatasetExists                sync.RWMutex
+	lockStorerMockCheckEditionExists                sync.RWMutex
+	lockStorerMockDeleteDataset                     sync.RWMutex
+	lockStorerMockDeleteEdition                     sync.RWMutex
+	lockStorerMockGetDataset                        sync.RWMutex
+	lockStorerMockGetDatasets                       sync.RWMutex
+	lockStorerMockGetDimensionOptions               sync.RWMutex
+	lockStorerMockGetDimensionOptionsFromIDs        sync.RWMutex
+	lockStorerMockGetDimensions                     sync.RWMutex
+	lockStorerMockGetDimensionsFromInstance         sync.RWMutex
+	lockStorerMockGetEdition                        sync.RWMutex
+	lockStorerMockGetEditions                       sync.RWMutex
+	lockStorerMockGetInstance                       sync.RWMutex
+	lockStorerMockGetInstances                      sync.RWMutex
+	lockStorerMockGetNextVersion                    sync.RWMutex
+	lockStorerMockGetUniqueDimensionAndOptions      sync.RWMutex
+	lockStorerMockGetVersion                        sync.RWMutex
+	lockStorerMockGetVersions                       sync.RWMutex
+	lockStorerMockSetInstanceIsPublished            sync.RWMutex
+	lockStorerMockUpdateBuildHierarchyTaskState     sync.RWMutex
+	lockStorerMockUpdateBuildSearchTaskState        sync.RWMutex
+	lockStorerMockUpdateDataset                     sync.RWMutex
+	lockStorerMockUpdateDatasetWithAssociation      sync.RWMutex
+	lockStorerMockUpdateDimensionNodeIDAndOrder     sync.RWMutex
+	lockStorerMockUpdateImportObservationsTaskState sync.RWMutex
+	lockStorerMockUpdateInstance                    sync.RWMutex
+	lockStorerMockUpdateObservationInserted         sync.RWMutex
+	lockStorerMockUpdateVersion                     sync.RWMutex
+	lockStorerMockUpsertContact                     sync.RWMutex
+	lockStorerMockUpsertDataset                     sync.RWMutex
+	lockStorerMockUpsertEdition                     sync.RWMutex
+	lockStorerMockUpsertVersion                     sync.RWMutex
+)
+
 // Ensure, that StorerMock does implement store.Storer.
 // If this is not the case, regenerate this file with moq.
 var _ store.Storer = &StorerMock{}
 
 // StorerMock is a mock implementation of store.Storer.
 //
-// 	func TestSomethingThatUsesStorer(t *testing.T) {
+//     func TestSomethingThatUsesStorer(t *testing.T) {
 //
-// 		// make and configure a mocked store.Storer
-// 		mockedStorer := &StorerMock{
-// 			AddDimensionToInstanceFunc: func(dimension *models.CachedDimensionOption) error {
-// 				panic("mock out the AddDimensionToInstance method")
-// 			},
-// 			AddEventToInstanceFunc: func(instanceID string, event *models.Event) error {
-// 				panic("mock out the AddEventToInstance method")
-// 			},
-// 			AddInstanceFunc: func(instance *models.Instance) (*models.Instance, error) {
-// 				panic("mock out the AddInstance method")
-// 			},
-// 			AddVersionDetailsToInstanceFunc: func(ctx context.Context, instanceID string, datasetID string, edition string, version int) error {
-// 				panic("mock out the AddVersionDetailsToInstance method")
-// 			},
-// 			CheckDatasetExistsFunc: func(ID string, state string) error {
-// 				panic("mock out the CheckDatasetExists method")
-// 			},
-// 			CheckEditionExistsFunc: func(ID string, editionID string, state string) error {
-// 				panic("mock out the CheckEditionExists method")
-// 			},
-// 			DeleteDatasetFunc: func(ID string) error {
-// 				panic("mock out the DeleteDataset method")
-// 			},
-// 			DeleteEditionFunc: func(ID string) error {
-// 				panic("mock out the DeleteEdition method")
-// 			},
-// 			GetDatasetFunc: func(ID string) (*models.DatasetUpdate, error) {
-// 				panic("mock out the GetDataset method")
-// 			},
-// 			GetDatasetsFunc: func(ctx context.Context, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
-// 				panic("mock out the GetDatasets method")
-// 			},
-// 			GetDimensionOptionsFunc: func(version *models.Version, dimension string, offset int, limit int) ([]*models.PublicDimensionOption, int, error) {
-// 				panic("mock out the GetDimensionOptions method")
-// 			},
-// 			GetDimensionOptionsFromIDsFunc: func(version *models.Version, dimension string, ids []string) ([]*models.PublicDimensionOption, int, error) {
-// 				panic("mock out the GetDimensionOptionsFromIDs method")
-// 			},
-// 			GetDimensionsFunc: func(datasetID string, versionID string) ([]bson.M, error) {
-// 				panic("mock out the GetDimensions method")
-// 			},
-// 			GetDimensionsFromInstanceFunc: func(ID string) (*models.DimensionNodeResults, error) {
-// 				panic("mock out the GetDimensionsFromInstance method")
-// 			},
-// 			GetEditionFunc: func(ID string, editionID string, state string) (*models.EditionUpdate, error) {
-// 				panic("mock out the GetEdition method")
-// 			},
-// 			GetEditionsFunc: func(ctx context.Context, ID string, state string, offset int, limit int, authorised bool) ([]*models.EditionUpdate, int, error) {
-// 				panic("mock out the GetEditions method")
-// 			},
-// 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
-// 				panic("mock out the GetInstance method")
-// 			},
-// 			GetInstancesFunc: func(ctx context.Context, states []string, datasets []string, offset int, limit int) ([]*models.Instance, int, error) {
-// 				panic("mock out the GetInstances method")
-// 			},
-// 			GetNextVersionFunc: func(datasetID string, editionID string) (int, error) {
-// 				panic("mock out the GetNextVersion method")
-// 			},
-// 			GetUniqueDimensionAndOptionsFunc: func(ID string, dimension string) (*models.DimensionValues, error) {
-// 				panic("mock out the GetUniqueDimensionAndOptions method")
-// 			},
-// 			GetVersionFunc: func(datasetID string, editionID string, version string, state string) (*models.Version, error) {
-// 				panic("mock out the GetVersion method")
-// 			},
-// 			GetVersionsFunc: func(ctx context.Context, datasetID string, editionID string, state string, offset int, limit int) ([]models.Version, int, error) {
-// 				panic("mock out the GetVersions method")
-// 			},
-// 			SetInstanceIsPublishedFunc: func(ctx context.Context, instanceID string) error {
-// 				panic("mock out the SetInstanceIsPublished method")
-// 			},
-// 			UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
-// 				panic("mock out the UpdateBuildHierarchyTaskState method")
-// 			},
-// 			UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
-// 				panic("mock out the UpdateBuildSearchTaskState method")
-// 			},
-// 			UpdateDatasetFunc: func(ctx context.Context, ID string, dataset *models.Dataset, currentState string) error {
-// 				panic("mock out the UpdateDataset method")
-// 			},
-// 			UpdateDatasetWithAssociationFunc: func(ID string, state string, version *models.Version) error {
-// 				panic("mock out the UpdateDatasetWithAssociation method")
-// 			},
-// 			UpdateDimensionNodeIDAndOrderFunc: func(dimension *models.DimensionOption) error {
-// 				panic("mock out the UpdateDimensionNodeIDAndOrder method")
-// 			},
-// 			UpdateImportObservationsTaskStateFunc: func(id string, state string) error {
-// 				panic("mock out the UpdateImportObservationsTaskState method")
-// 			},
-// 			UpdateInstanceFunc: func(ctx context.Context, ID string, instance *models.Instance) error {
-// 				panic("mock out the UpdateInstance method")
-// 			},
-// 			UpdateObservationInsertedFunc: func(ID string, observationInserted int64) error {
-// 				panic("mock out the UpdateObservationInserted method")
-// 			},
-// 			UpdateVersionFunc: func(ID string, version *models.Version) error {
-// 				panic("mock out the UpdateVersion method")
-// 			},
-// 			UpsertContactFunc: func(ID string, update interface{}) error {
-// 				panic("mock out the UpsertContact method")
-// 			},
-// 			UpsertDatasetFunc: func(ID string, datasetDoc *models.DatasetUpdate) error {
-// 				panic("mock out the UpsertDataset method")
-// 			},
-// 			UpsertEditionFunc: func(datasetID string, edition string, editionDoc *models.EditionUpdate) error {
-// 				panic("mock out the UpsertEdition method")
-// 			},
-// 			UpsertVersionFunc: func(ID string, versionDoc *models.Version) error {
-// 				panic("mock out the UpsertVersion method")
-// 			},
-// 		}
+//         // make and configure a mocked store.Storer
+//         mockedStorer := &StorerMock{
+//             AddDimensionToInstanceFunc: func(dimension *models.CachedDimensionOption) error {
+// 	               panic("mock out the AddDimensionToInstance method")
+//             },
+//             AddEventToInstanceFunc: func(instanceID string, event *models.Event) error {
+// 	               panic("mock out the AddEventToInstance method")
+//             },
+//             AddInstanceFunc: func(instance *models.Instance) (*models.Instance, error) {
+// 	               panic("mock out the AddInstance method")
+//             },
+//             AddVersionDetailsToInstanceFunc: func(ctx context.Context, instanceID string, datasetID string, edition string, version int) error {
+// 	               panic("mock out the AddVersionDetailsToInstance method")
+//             },
+//             CheckDatasetExistsFunc: func(ID string, state string) error {
+// 	               panic("mock out the CheckDatasetExists method")
+//             },
+//             CheckEditionExistsFunc: func(ID string, editionID string, state string) error {
+// 	               panic("mock out the CheckEditionExists method")
+//             },
+//             DeleteDatasetFunc: func(ID string) error {
+// 	               panic("mock out the DeleteDataset method")
+//             },
+//             DeleteEditionFunc: func(ID string) error {
+// 	               panic("mock out the DeleteEdition method")
+//             },
+//             GetDatasetFunc: func(ID string) (*models.DatasetUpdate, error) {
+// 	               panic("mock out the GetDataset method")
+//             },
+//             GetDatasetsFunc: func(ctx context.Context, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
+// 	               panic("mock out the GetDatasets method")
+//             },
+//             GetDimensionOptionsFunc: func(version *models.Version, dimension string, offset int, limit int) ([]*models.PublicDimensionOption, int, error) {
+// 	               panic("mock out the GetDimensionOptions method")
+//             },
+//             GetDimensionOptionsFromIDsFunc: func(version *models.Version, dimension string, ids []string) ([]*models.PublicDimensionOption, int, error) {
+// 	               panic("mock out the GetDimensionOptionsFromIDs method")
+//             },
+//             GetDimensionsFunc: func(datasetID string, versionID string) ([]bson.M, error) {
+// 	               panic("mock out the GetDimensions method")
+//             },
+//             GetDimensionsFromInstanceFunc: func(ctx context.Context, ID string, offset int, limit int) ([]*models.DimensionOption, int, error) {
+// 	               panic("mock out the GetDimensionsFromInstance method")
+//             },
+//             GetEditionFunc: func(ID string, editionID string, state string) (*models.EditionUpdate, error) {
+// 	               panic("mock out the GetEdition method")
+//             },
+//             GetEditionsFunc: func(ctx context.Context, ID string, state string, offset int, limit int, authorised bool) ([]*models.EditionUpdate, int, error) {
+// 	               panic("mock out the GetEditions method")
+//             },
+//             GetInstanceFunc: func(ID string) (*models.Instance, error) {
+// 	               panic("mock out the GetInstance method")
+//             },
+//             GetInstancesFunc: func(ctx context.Context, states []string, datasets []string, offset int, limit int) ([]*models.Instance, int, error) {
+// 	               panic("mock out the GetInstances method")
+//             },
+//             GetNextVersionFunc: func(datasetID string, editionID string) (int, error) {
+// 	               panic("mock out the GetNextVersion method")
+//             },
+//             GetUniqueDimensionAndOptionsFunc: func(ctx context.Context, ID string, dimension string, offset int, limit int) ([]*string, int, error) {
+// 	               panic("mock out the GetUniqueDimensionAndOptions method")
+//             },
+//             GetVersionFunc: func(datasetID string, editionID string, version string, state string) (*models.Version, error) {
+// 	               panic("mock out the GetVersion method")
+//             },
+//             GetVersionsFunc: func(ctx context.Context, datasetID string, editionID string, state string, offset int, limit int) ([]models.Version, int, error) {
+// 	               panic("mock out the GetVersions method")
+//             },
+//             SetInstanceIsPublishedFunc: func(ctx context.Context, instanceID string) error {
+// 	               panic("mock out the SetInstanceIsPublished method")
+//             },
+//             UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
+// 	               panic("mock out the UpdateBuildHierarchyTaskState method")
+//             },
+//             UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
+// 	               panic("mock out the UpdateBuildSearchTaskState method")
+//             },
+//             UpdateDatasetFunc: func(ctx context.Context, ID string, dataset *models.Dataset, currentState string) error {
+// 	               panic("mock out the UpdateDataset method")
+//             },
+//             UpdateDatasetWithAssociationFunc: func(ID string, state string, version *models.Version) error {
+// 	               panic("mock out the UpdateDatasetWithAssociation method")
+//             },
+//             UpdateDimensionNodeIDAndOrderFunc: func(dimension *models.DimensionOption) error {
+// 	               panic("mock out the UpdateDimensionNodeIDAndOrder method")
+//             },
+//             UpdateImportObservationsTaskStateFunc: func(id string, state string) error {
+// 	               panic("mock out the UpdateImportObservationsTaskState method")
+//             },
+//             UpdateInstanceFunc: func(ctx context.Context, ID string, instance *models.Instance) error {
+// 	               panic("mock out the UpdateInstance method")
+//             },
+//             UpdateObservationInsertedFunc: func(ID string, observationInserted int64) error {
+// 	               panic("mock out the UpdateObservationInserted method")
+//             },
+//             UpdateVersionFunc: func(ID string, version *models.Version) error {
+// 	               panic("mock out the UpdateVersion method")
+//             },
+//             UpsertContactFunc: func(ID string, update interface{}) error {
+// 	               panic("mock out the UpsertContact method")
+//             },
+//             UpsertDatasetFunc: func(ID string, datasetDoc *models.DatasetUpdate) error {
+// 	               panic("mock out the UpsertDataset method")
+//             },
+//             UpsertEditionFunc: func(datasetID string, edition string, editionDoc *models.EditionUpdate) error {
+// 	               panic("mock out the UpsertEdition method")
+//             },
+//             UpsertVersionFunc: func(ID string, versionDoc *models.Version) error {
+// 	               panic("mock out the UpsertVersion method")
+//             },
+//         }
 //
-// 		// use mockedStorer in code that requires store.Storer
-// 		// and then make assertions.
+//         // use mockedStorer in code that requires store.Storer
+//         // and then make assertions.
 //
-// 	}
+//     }
 type StorerMock struct {
 	// AddDimensionToInstanceFunc mocks the AddDimensionToInstance method.
 	AddDimensionToInstanceFunc func(dimension *models.CachedDimensionOption) error
@@ -176,7 +215,7 @@ type StorerMock struct {
 	GetDimensionsFunc func(datasetID string, versionID string) ([]bson.M, error)
 
 	// GetDimensionsFromInstanceFunc mocks the GetDimensionsFromInstance method.
-	GetDimensionsFromInstanceFunc func(ID string) (*models.DimensionNodeResults, error)
+	GetDimensionsFromInstanceFunc func(ctx context.Context, ID string, offset int, limit int) ([]*models.DimensionOption, int, error)
 
 	// GetEditionFunc mocks the GetEdition method.
 	GetEditionFunc func(ID string, editionID string, state string) (*models.EditionUpdate, error)
@@ -194,7 +233,7 @@ type StorerMock struct {
 	GetNextVersionFunc func(datasetID string, editionID string) (int, error)
 
 	// GetUniqueDimensionAndOptionsFunc mocks the GetUniqueDimensionAndOptions method.
-	GetUniqueDimensionAndOptionsFunc func(ID string, dimension string) (*models.DimensionValues, error)
+	GetUniqueDimensionAndOptionsFunc func(ctx context.Context, ID string, dimension string, offset int, limit int) ([]*string, int, error)
 
 	// GetVersionFunc mocks the GetVersion method.
 	GetVersionFunc func(datasetID string, editionID string, version string, state string) (*models.Version, error)
@@ -347,8 +386,14 @@ type StorerMock struct {
 		}
 		// GetDimensionsFromInstance holds details about calls to the GetDimensionsFromInstance method.
 		GetDimensionsFromInstance []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 			// ID is the ID argument value.
 			ID string
+			// Offset is the offset argument value.
+			Offset int
+			// Limit is the limit argument value.
+			Limit int
 		}
 		// GetEdition holds details about calls to the GetEdition method.
 		GetEdition []struct {
@@ -401,10 +446,16 @@ type StorerMock struct {
 		}
 		// GetUniqueDimensionAndOptions holds details about calls to the GetUniqueDimensionAndOptions method.
 		GetUniqueDimensionAndOptions []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 			// ID is the ID argument value.
 			ID string
 			// Dimension is the dimension argument value.
 			Dimension string
+			// Offset is the offset argument value.
+			Offset int
+			// Limit is the limit argument value.
+			Limit int
 		}
 		// GetVersion holds details about calls to the GetVersion method.
 		GetVersion []struct {
@@ -543,42 +594,6 @@ type StorerMock struct {
 			VersionDoc *models.Version
 		}
 	}
-	lockAddDimensionToInstance            sync.RWMutex
-	lockAddEventToInstance                sync.RWMutex
-	lockAddInstance                       sync.RWMutex
-	lockAddVersionDetailsToInstance       sync.RWMutex
-	lockCheckDatasetExists                sync.RWMutex
-	lockCheckEditionExists                sync.RWMutex
-	lockDeleteDataset                     sync.RWMutex
-	lockDeleteEdition                     sync.RWMutex
-	lockGetDataset                        sync.RWMutex
-	lockGetDatasets                       sync.RWMutex
-	lockGetDimensionOptions               sync.RWMutex
-	lockGetDimensionOptionsFromIDs        sync.RWMutex
-	lockGetDimensions                     sync.RWMutex
-	lockGetDimensionsFromInstance         sync.RWMutex
-	lockGetEdition                        sync.RWMutex
-	lockGetEditions                       sync.RWMutex
-	lockGetInstance                       sync.RWMutex
-	lockGetInstances                      sync.RWMutex
-	lockGetNextVersion                    sync.RWMutex
-	lockGetUniqueDimensionAndOptions      sync.RWMutex
-	lockGetVersion                        sync.RWMutex
-	lockGetVersions                       sync.RWMutex
-	lockSetInstanceIsPublished            sync.RWMutex
-	lockUpdateBuildHierarchyTaskState     sync.RWMutex
-	lockUpdateBuildSearchTaskState        sync.RWMutex
-	lockUpdateDataset                     sync.RWMutex
-	lockUpdateDatasetWithAssociation      sync.RWMutex
-	lockUpdateDimensionNodeIDAndOrder     sync.RWMutex
-	lockUpdateImportObservationsTaskState sync.RWMutex
-	lockUpdateInstance                    sync.RWMutex
-	lockUpdateObservationInserted         sync.RWMutex
-	lockUpdateVersion                     sync.RWMutex
-	lockUpsertContact                     sync.RWMutex
-	lockUpsertDataset                     sync.RWMutex
-	lockUpsertEdition                     sync.RWMutex
-	lockUpsertVersion                     sync.RWMutex
 }
 
 // AddDimensionToInstance calls AddDimensionToInstanceFunc.
@@ -591,9 +606,9 @@ func (mock *StorerMock) AddDimensionToInstance(dimension *models.CachedDimension
 	}{
 		Dimension: dimension,
 	}
-	mock.lockAddDimensionToInstance.Lock()
+	lockStorerMockAddDimensionToInstance.Lock()
 	mock.calls.AddDimensionToInstance = append(mock.calls.AddDimensionToInstance, callInfo)
-	mock.lockAddDimensionToInstance.Unlock()
+	lockStorerMockAddDimensionToInstance.Unlock()
 	return mock.AddDimensionToInstanceFunc(dimension)
 }
 
@@ -606,9 +621,9 @@ func (mock *StorerMock) AddDimensionToInstanceCalls() []struct {
 	var calls []struct {
 		Dimension *models.CachedDimensionOption
 	}
-	mock.lockAddDimensionToInstance.RLock()
+	lockStorerMockAddDimensionToInstance.RLock()
 	calls = mock.calls.AddDimensionToInstance
-	mock.lockAddDimensionToInstance.RUnlock()
+	lockStorerMockAddDimensionToInstance.RUnlock()
 	return calls
 }
 
@@ -624,9 +639,9 @@ func (mock *StorerMock) AddEventToInstance(instanceID string, event *models.Even
 		InstanceID: instanceID,
 		Event:      event,
 	}
-	mock.lockAddEventToInstance.Lock()
+	lockStorerMockAddEventToInstance.Lock()
 	mock.calls.AddEventToInstance = append(mock.calls.AddEventToInstance, callInfo)
-	mock.lockAddEventToInstance.Unlock()
+	lockStorerMockAddEventToInstance.Unlock()
 	return mock.AddEventToInstanceFunc(instanceID, event)
 }
 
@@ -641,9 +656,9 @@ func (mock *StorerMock) AddEventToInstanceCalls() []struct {
 		InstanceID string
 		Event      *models.Event
 	}
-	mock.lockAddEventToInstance.RLock()
+	lockStorerMockAddEventToInstance.RLock()
 	calls = mock.calls.AddEventToInstance
-	mock.lockAddEventToInstance.RUnlock()
+	lockStorerMockAddEventToInstance.RUnlock()
 	return calls
 }
 
@@ -657,9 +672,9 @@ func (mock *StorerMock) AddInstance(instance *models.Instance) (*models.Instance
 	}{
 		Instance: instance,
 	}
-	mock.lockAddInstance.Lock()
+	lockStorerMockAddInstance.Lock()
 	mock.calls.AddInstance = append(mock.calls.AddInstance, callInfo)
-	mock.lockAddInstance.Unlock()
+	lockStorerMockAddInstance.Unlock()
 	return mock.AddInstanceFunc(instance)
 }
 
@@ -672,9 +687,9 @@ func (mock *StorerMock) AddInstanceCalls() []struct {
 	var calls []struct {
 		Instance *models.Instance
 	}
-	mock.lockAddInstance.RLock()
+	lockStorerMockAddInstance.RLock()
 	calls = mock.calls.AddInstance
-	mock.lockAddInstance.RUnlock()
+	lockStorerMockAddInstance.RUnlock()
 	return calls
 }
 
@@ -696,9 +711,9 @@ func (mock *StorerMock) AddVersionDetailsToInstance(ctx context.Context, instanc
 		Edition:    edition,
 		Version:    version,
 	}
-	mock.lockAddVersionDetailsToInstance.Lock()
+	lockStorerMockAddVersionDetailsToInstance.Lock()
 	mock.calls.AddVersionDetailsToInstance = append(mock.calls.AddVersionDetailsToInstance, callInfo)
-	mock.lockAddVersionDetailsToInstance.Unlock()
+	lockStorerMockAddVersionDetailsToInstance.Unlock()
 	return mock.AddVersionDetailsToInstanceFunc(ctx, instanceID, datasetID, edition, version)
 }
 
@@ -719,9 +734,9 @@ func (mock *StorerMock) AddVersionDetailsToInstanceCalls() []struct {
 		Edition    string
 		Version    int
 	}
-	mock.lockAddVersionDetailsToInstance.RLock()
+	lockStorerMockAddVersionDetailsToInstance.RLock()
 	calls = mock.calls.AddVersionDetailsToInstance
-	mock.lockAddVersionDetailsToInstance.RUnlock()
+	lockStorerMockAddVersionDetailsToInstance.RUnlock()
 	return calls
 }
 
@@ -737,9 +752,9 @@ func (mock *StorerMock) CheckDatasetExists(ID string, state string) error {
 		ID:    ID,
 		State: state,
 	}
-	mock.lockCheckDatasetExists.Lock()
+	lockStorerMockCheckDatasetExists.Lock()
 	mock.calls.CheckDatasetExists = append(mock.calls.CheckDatasetExists, callInfo)
-	mock.lockCheckDatasetExists.Unlock()
+	lockStorerMockCheckDatasetExists.Unlock()
 	return mock.CheckDatasetExistsFunc(ID, state)
 }
 
@@ -754,9 +769,9 @@ func (mock *StorerMock) CheckDatasetExistsCalls() []struct {
 		ID    string
 		State string
 	}
-	mock.lockCheckDatasetExists.RLock()
+	lockStorerMockCheckDatasetExists.RLock()
 	calls = mock.calls.CheckDatasetExists
-	mock.lockCheckDatasetExists.RUnlock()
+	lockStorerMockCheckDatasetExists.RUnlock()
 	return calls
 }
 
@@ -774,9 +789,9 @@ func (mock *StorerMock) CheckEditionExists(ID string, editionID string, state st
 		EditionID: editionID,
 		State:     state,
 	}
-	mock.lockCheckEditionExists.Lock()
+	lockStorerMockCheckEditionExists.Lock()
 	mock.calls.CheckEditionExists = append(mock.calls.CheckEditionExists, callInfo)
-	mock.lockCheckEditionExists.Unlock()
+	lockStorerMockCheckEditionExists.Unlock()
 	return mock.CheckEditionExistsFunc(ID, editionID, state)
 }
 
@@ -793,9 +808,9 @@ func (mock *StorerMock) CheckEditionExistsCalls() []struct {
 		EditionID string
 		State     string
 	}
-	mock.lockCheckEditionExists.RLock()
+	lockStorerMockCheckEditionExists.RLock()
 	calls = mock.calls.CheckEditionExists
-	mock.lockCheckEditionExists.RUnlock()
+	lockStorerMockCheckEditionExists.RUnlock()
 	return calls
 }
 
@@ -809,9 +824,9 @@ func (mock *StorerMock) DeleteDataset(ID string) error {
 	}{
 		ID: ID,
 	}
-	mock.lockDeleteDataset.Lock()
+	lockStorerMockDeleteDataset.Lock()
 	mock.calls.DeleteDataset = append(mock.calls.DeleteDataset, callInfo)
-	mock.lockDeleteDataset.Unlock()
+	lockStorerMockDeleteDataset.Unlock()
 	return mock.DeleteDatasetFunc(ID)
 }
 
@@ -824,9 +839,9 @@ func (mock *StorerMock) DeleteDatasetCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	mock.lockDeleteDataset.RLock()
+	lockStorerMockDeleteDataset.RLock()
 	calls = mock.calls.DeleteDataset
-	mock.lockDeleteDataset.RUnlock()
+	lockStorerMockDeleteDataset.RUnlock()
 	return calls
 }
 
@@ -840,9 +855,9 @@ func (mock *StorerMock) DeleteEdition(ID string) error {
 	}{
 		ID: ID,
 	}
-	mock.lockDeleteEdition.Lock()
+	lockStorerMockDeleteEdition.Lock()
 	mock.calls.DeleteEdition = append(mock.calls.DeleteEdition, callInfo)
-	mock.lockDeleteEdition.Unlock()
+	lockStorerMockDeleteEdition.Unlock()
 	return mock.DeleteEditionFunc(ID)
 }
 
@@ -855,9 +870,9 @@ func (mock *StorerMock) DeleteEditionCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	mock.lockDeleteEdition.RLock()
+	lockStorerMockDeleteEdition.RLock()
 	calls = mock.calls.DeleteEdition
-	mock.lockDeleteEdition.RUnlock()
+	lockStorerMockDeleteEdition.RUnlock()
 	return calls
 }
 
@@ -871,9 +886,9 @@ func (mock *StorerMock) GetDataset(ID string) (*models.DatasetUpdate, error) {
 	}{
 		ID: ID,
 	}
-	mock.lockGetDataset.Lock()
+	lockStorerMockGetDataset.Lock()
 	mock.calls.GetDataset = append(mock.calls.GetDataset, callInfo)
-	mock.lockGetDataset.Unlock()
+	lockStorerMockGetDataset.Unlock()
 	return mock.GetDatasetFunc(ID)
 }
 
@@ -886,9 +901,9 @@ func (mock *StorerMock) GetDatasetCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	mock.lockGetDataset.RLock()
+	lockStorerMockGetDataset.RLock()
 	calls = mock.calls.GetDataset
-	mock.lockGetDataset.RUnlock()
+	lockStorerMockGetDataset.RUnlock()
 	return calls
 }
 
@@ -908,9 +923,9 @@ func (mock *StorerMock) GetDatasets(ctx context.Context, offset int, limit int, 
 		Limit:      limit,
 		Authorised: authorised,
 	}
-	mock.lockGetDatasets.Lock()
+	lockStorerMockGetDatasets.Lock()
 	mock.calls.GetDatasets = append(mock.calls.GetDatasets, callInfo)
-	mock.lockGetDatasets.Unlock()
+	lockStorerMockGetDatasets.Unlock()
 	return mock.GetDatasetsFunc(ctx, offset, limit, authorised)
 }
 
@@ -929,9 +944,9 @@ func (mock *StorerMock) GetDatasetsCalls() []struct {
 		Limit      int
 		Authorised bool
 	}
-	mock.lockGetDatasets.RLock()
+	lockStorerMockGetDatasets.RLock()
 	calls = mock.calls.GetDatasets
-	mock.lockGetDatasets.RUnlock()
+	lockStorerMockGetDatasets.RUnlock()
 	return calls
 }
 
@@ -951,9 +966,9 @@ func (mock *StorerMock) GetDimensionOptions(version *models.Version, dimension s
 		Offset:    offset,
 		Limit:     limit,
 	}
-	mock.lockGetDimensionOptions.Lock()
+	lockStorerMockGetDimensionOptions.Lock()
 	mock.calls.GetDimensionOptions = append(mock.calls.GetDimensionOptions, callInfo)
-	mock.lockGetDimensionOptions.Unlock()
+	lockStorerMockGetDimensionOptions.Unlock()
 	return mock.GetDimensionOptionsFunc(version, dimension, offset, limit)
 }
 
@@ -972,9 +987,9 @@ func (mock *StorerMock) GetDimensionOptionsCalls() []struct {
 		Offset    int
 		Limit     int
 	}
-	mock.lockGetDimensionOptions.RLock()
+	lockStorerMockGetDimensionOptions.RLock()
 	calls = mock.calls.GetDimensionOptions
-	mock.lockGetDimensionOptions.RUnlock()
+	lockStorerMockGetDimensionOptions.RUnlock()
 	return calls
 }
 
@@ -992,9 +1007,9 @@ func (mock *StorerMock) GetDimensionOptionsFromIDs(version *models.Version, dime
 		Dimension: dimension,
 		Ids:       ids,
 	}
-	mock.lockGetDimensionOptionsFromIDs.Lock()
+	lockStorerMockGetDimensionOptionsFromIDs.Lock()
 	mock.calls.GetDimensionOptionsFromIDs = append(mock.calls.GetDimensionOptionsFromIDs, callInfo)
-	mock.lockGetDimensionOptionsFromIDs.Unlock()
+	lockStorerMockGetDimensionOptionsFromIDs.Unlock()
 	return mock.GetDimensionOptionsFromIDsFunc(version, dimension, ids)
 }
 
@@ -1011,9 +1026,9 @@ func (mock *StorerMock) GetDimensionOptionsFromIDsCalls() []struct {
 		Dimension string
 		Ids       []string
 	}
-	mock.lockGetDimensionOptionsFromIDs.RLock()
+	lockStorerMockGetDimensionOptionsFromIDs.RLock()
 	calls = mock.calls.GetDimensionOptionsFromIDs
-	mock.lockGetDimensionOptionsFromIDs.RUnlock()
+	lockStorerMockGetDimensionOptionsFromIDs.RUnlock()
 	return calls
 }
 
@@ -1029,9 +1044,9 @@ func (mock *StorerMock) GetDimensions(datasetID string, versionID string) ([]bso
 		DatasetID: datasetID,
 		VersionID: versionID,
 	}
-	mock.lockGetDimensions.Lock()
+	lockStorerMockGetDimensions.Lock()
 	mock.calls.GetDimensions = append(mock.calls.GetDimensions, callInfo)
-	mock.lockGetDimensions.Unlock()
+	lockStorerMockGetDimensions.Unlock()
 	return mock.GetDimensionsFunc(datasetID, versionID)
 }
 
@@ -1046,40 +1061,52 @@ func (mock *StorerMock) GetDimensionsCalls() []struct {
 		DatasetID string
 		VersionID string
 	}
-	mock.lockGetDimensions.RLock()
+	lockStorerMockGetDimensions.RLock()
 	calls = mock.calls.GetDimensions
-	mock.lockGetDimensions.RUnlock()
+	lockStorerMockGetDimensions.RUnlock()
 	return calls
 }
 
 // GetDimensionsFromInstance calls GetDimensionsFromInstanceFunc.
-func (mock *StorerMock) GetDimensionsFromInstance(ID string) (*models.DimensionNodeResults, error) {
+func (mock *StorerMock) GetDimensionsFromInstance(ctx context.Context, ID string, offset int, limit int) ([]*models.DimensionOption, int, error) {
 	if mock.GetDimensionsFromInstanceFunc == nil {
 		panic("StorerMock.GetDimensionsFromInstanceFunc: method is nil but Storer.GetDimensionsFromInstance was just called")
 	}
 	callInfo := struct {
-		ID string
+		Ctx    context.Context
+		ID     string
+		Offset int
+		Limit  int
 	}{
-		ID: ID,
+		Ctx:    ctx,
+		ID:     ID,
+		Offset: offset,
+		Limit:  limit,
 	}
-	mock.lockGetDimensionsFromInstance.Lock()
+	lockStorerMockGetDimensionsFromInstance.Lock()
 	mock.calls.GetDimensionsFromInstance = append(mock.calls.GetDimensionsFromInstance, callInfo)
-	mock.lockGetDimensionsFromInstance.Unlock()
-	return mock.GetDimensionsFromInstanceFunc(ID)
+	lockStorerMockGetDimensionsFromInstance.Unlock()
+	return mock.GetDimensionsFromInstanceFunc(ctx, ID, offset, limit)
 }
 
 // GetDimensionsFromInstanceCalls gets all the calls that were made to GetDimensionsFromInstance.
 // Check the length with:
 //     len(mockedStorer.GetDimensionsFromInstanceCalls())
 func (mock *StorerMock) GetDimensionsFromInstanceCalls() []struct {
-	ID string
+	Ctx    context.Context
+	ID     string
+	Offset int
+	Limit  int
 } {
 	var calls []struct {
-		ID string
+		Ctx    context.Context
+		ID     string
+		Offset int
+		Limit  int
 	}
-	mock.lockGetDimensionsFromInstance.RLock()
+	lockStorerMockGetDimensionsFromInstance.RLock()
 	calls = mock.calls.GetDimensionsFromInstance
-	mock.lockGetDimensionsFromInstance.RUnlock()
+	lockStorerMockGetDimensionsFromInstance.RUnlock()
 	return calls
 }
 
@@ -1097,9 +1124,9 @@ func (mock *StorerMock) GetEdition(ID string, editionID string, state string) (*
 		EditionID: editionID,
 		State:     state,
 	}
-	mock.lockGetEdition.Lock()
+	lockStorerMockGetEdition.Lock()
 	mock.calls.GetEdition = append(mock.calls.GetEdition, callInfo)
-	mock.lockGetEdition.Unlock()
+	lockStorerMockGetEdition.Unlock()
 	return mock.GetEditionFunc(ID, editionID, state)
 }
 
@@ -1116,9 +1143,9 @@ func (mock *StorerMock) GetEditionCalls() []struct {
 		EditionID string
 		State     string
 	}
-	mock.lockGetEdition.RLock()
+	lockStorerMockGetEdition.RLock()
 	calls = mock.calls.GetEdition
-	mock.lockGetEdition.RUnlock()
+	lockStorerMockGetEdition.RUnlock()
 	return calls
 }
 
@@ -1142,9 +1169,9 @@ func (mock *StorerMock) GetEditions(ctx context.Context, ID string, state string
 		Limit:      limit,
 		Authorised: authorised,
 	}
-	mock.lockGetEditions.Lock()
+	lockStorerMockGetEditions.Lock()
 	mock.calls.GetEditions = append(mock.calls.GetEditions, callInfo)
-	mock.lockGetEditions.Unlock()
+	lockStorerMockGetEditions.Unlock()
 	return mock.GetEditionsFunc(ctx, ID, state, offset, limit, authorised)
 }
 
@@ -1167,9 +1194,9 @@ func (mock *StorerMock) GetEditionsCalls() []struct {
 		Limit      int
 		Authorised bool
 	}
-	mock.lockGetEditions.RLock()
+	lockStorerMockGetEditions.RLock()
 	calls = mock.calls.GetEditions
-	mock.lockGetEditions.RUnlock()
+	lockStorerMockGetEditions.RUnlock()
 	return calls
 }
 
@@ -1183,9 +1210,9 @@ func (mock *StorerMock) GetInstance(ID string) (*models.Instance, error) {
 	}{
 		ID: ID,
 	}
-	mock.lockGetInstance.Lock()
+	lockStorerMockGetInstance.Lock()
 	mock.calls.GetInstance = append(mock.calls.GetInstance, callInfo)
-	mock.lockGetInstance.Unlock()
+	lockStorerMockGetInstance.Unlock()
 	return mock.GetInstanceFunc(ID)
 }
 
@@ -1198,9 +1225,9 @@ func (mock *StorerMock) GetInstanceCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	mock.lockGetInstance.RLock()
+	lockStorerMockGetInstance.RLock()
 	calls = mock.calls.GetInstance
-	mock.lockGetInstance.RUnlock()
+	lockStorerMockGetInstance.RUnlock()
 	return calls
 }
 
@@ -1222,9 +1249,9 @@ func (mock *StorerMock) GetInstances(ctx context.Context, states []string, datas
 		Offset:   offset,
 		Limit:    limit,
 	}
-	mock.lockGetInstances.Lock()
+	lockStorerMockGetInstances.Lock()
 	mock.calls.GetInstances = append(mock.calls.GetInstances, callInfo)
-	mock.lockGetInstances.Unlock()
+	lockStorerMockGetInstances.Unlock()
 	return mock.GetInstancesFunc(ctx, states, datasets, offset, limit)
 }
 
@@ -1245,9 +1272,9 @@ func (mock *StorerMock) GetInstancesCalls() []struct {
 		Offset   int
 		Limit    int
 	}
-	mock.lockGetInstances.RLock()
+	lockStorerMockGetInstances.RLock()
 	calls = mock.calls.GetInstances
-	mock.lockGetInstances.RUnlock()
+	lockStorerMockGetInstances.RUnlock()
 	return calls
 }
 
@@ -1263,9 +1290,9 @@ func (mock *StorerMock) GetNextVersion(datasetID string, editionID string) (int,
 		DatasetID: datasetID,
 		EditionID: editionID,
 	}
-	mock.lockGetNextVersion.Lock()
+	lockStorerMockGetNextVersion.Lock()
 	mock.calls.GetNextVersion = append(mock.calls.GetNextVersion, callInfo)
-	mock.lockGetNextVersion.Unlock()
+	lockStorerMockGetNextVersion.Unlock()
 	return mock.GetNextVersionFunc(datasetID, editionID)
 }
 
@@ -1280,44 +1307,56 @@ func (mock *StorerMock) GetNextVersionCalls() []struct {
 		DatasetID string
 		EditionID string
 	}
-	mock.lockGetNextVersion.RLock()
+	lockStorerMockGetNextVersion.RLock()
 	calls = mock.calls.GetNextVersion
-	mock.lockGetNextVersion.RUnlock()
+	lockStorerMockGetNextVersion.RUnlock()
 	return calls
 }
 
 // GetUniqueDimensionAndOptions calls GetUniqueDimensionAndOptionsFunc.
-func (mock *StorerMock) GetUniqueDimensionAndOptions(ID string, dimension string) (*models.DimensionValues, error) {
+func (mock *StorerMock) GetUniqueDimensionAndOptions(ctx context.Context, ID string, dimension string, offset int, limit int) ([]*string, int, error) {
 	if mock.GetUniqueDimensionAndOptionsFunc == nil {
 		panic("StorerMock.GetUniqueDimensionAndOptionsFunc: method is nil but Storer.GetUniqueDimensionAndOptions was just called")
 	}
 	callInfo := struct {
+		Ctx       context.Context
 		ID        string
 		Dimension string
+		Offset    int
+		Limit     int
 	}{
+		Ctx:       ctx,
 		ID:        ID,
 		Dimension: dimension,
+		Offset:    offset,
+		Limit:     limit,
 	}
-	mock.lockGetUniqueDimensionAndOptions.Lock()
+	lockStorerMockGetUniqueDimensionAndOptions.Lock()
 	mock.calls.GetUniqueDimensionAndOptions = append(mock.calls.GetUniqueDimensionAndOptions, callInfo)
-	mock.lockGetUniqueDimensionAndOptions.Unlock()
-	return mock.GetUniqueDimensionAndOptionsFunc(ID, dimension)
+	lockStorerMockGetUniqueDimensionAndOptions.Unlock()
+	return mock.GetUniqueDimensionAndOptionsFunc(ctx, ID, dimension, offset, limit)
 }
 
 // GetUniqueDimensionAndOptionsCalls gets all the calls that were made to GetUniqueDimensionAndOptions.
 // Check the length with:
 //     len(mockedStorer.GetUniqueDimensionAndOptionsCalls())
 func (mock *StorerMock) GetUniqueDimensionAndOptionsCalls() []struct {
+	Ctx       context.Context
 	ID        string
 	Dimension string
+	Offset    int
+	Limit     int
 } {
 	var calls []struct {
+		Ctx       context.Context
 		ID        string
 		Dimension string
+		Offset    int
+		Limit     int
 	}
-	mock.lockGetUniqueDimensionAndOptions.RLock()
+	lockStorerMockGetUniqueDimensionAndOptions.RLock()
 	calls = mock.calls.GetUniqueDimensionAndOptions
-	mock.lockGetUniqueDimensionAndOptions.RUnlock()
+	lockStorerMockGetUniqueDimensionAndOptions.RUnlock()
 	return calls
 }
 
@@ -1337,9 +1376,9 @@ func (mock *StorerMock) GetVersion(datasetID string, editionID string, version s
 		Version:   version,
 		State:     state,
 	}
-	mock.lockGetVersion.Lock()
+	lockStorerMockGetVersion.Lock()
 	mock.calls.GetVersion = append(mock.calls.GetVersion, callInfo)
-	mock.lockGetVersion.Unlock()
+	lockStorerMockGetVersion.Unlock()
 	return mock.GetVersionFunc(datasetID, editionID, version, state)
 }
 
@@ -1358,9 +1397,9 @@ func (mock *StorerMock) GetVersionCalls() []struct {
 		Version   string
 		State     string
 	}
-	mock.lockGetVersion.RLock()
+	lockStorerMockGetVersion.RLock()
 	calls = mock.calls.GetVersion
-	mock.lockGetVersion.RUnlock()
+	lockStorerMockGetVersion.RUnlock()
 	return calls
 }
 
@@ -1384,9 +1423,9 @@ func (mock *StorerMock) GetVersions(ctx context.Context, datasetID string, editi
 		Offset:    offset,
 		Limit:     limit,
 	}
-	mock.lockGetVersions.Lock()
+	lockStorerMockGetVersions.Lock()
 	mock.calls.GetVersions = append(mock.calls.GetVersions, callInfo)
-	mock.lockGetVersions.Unlock()
+	lockStorerMockGetVersions.Unlock()
 	return mock.GetVersionsFunc(ctx, datasetID, editionID, state, offset, limit)
 }
 
@@ -1409,9 +1448,9 @@ func (mock *StorerMock) GetVersionsCalls() []struct {
 		Offset    int
 		Limit     int
 	}
-	mock.lockGetVersions.RLock()
+	lockStorerMockGetVersions.RLock()
 	calls = mock.calls.GetVersions
-	mock.lockGetVersions.RUnlock()
+	lockStorerMockGetVersions.RUnlock()
 	return calls
 }
 
@@ -1427,9 +1466,9 @@ func (mock *StorerMock) SetInstanceIsPublished(ctx context.Context, instanceID s
 		Ctx:        ctx,
 		InstanceID: instanceID,
 	}
-	mock.lockSetInstanceIsPublished.Lock()
+	lockStorerMockSetInstanceIsPublished.Lock()
 	mock.calls.SetInstanceIsPublished = append(mock.calls.SetInstanceIsPublished, callInfo)
-	mock.lockSetInstanceIsPublished.Unlock()
+	lockStorerMockSetInstanceIsPublished.Unlock()
 	return mock.SetInstanceIsPublishedFunc(ctx, instanceID)
 }
 
@@ -1444,9 +1483,9 @@ func (mock *StorerMock) SetInstanceIsPublishedCalls() []struct {
 		Ctx        context.Context
 		InstanceID string
 	}
-	mock.lockSetInstanceIsPublished.RLock()
+	lockStorerMockSetInstanceIsPublished.RLock()
 	calls = mock.calls.SetInstanceIsPublished
-	mock.lockSetInstanceIsPublished.RUnlock()
+	lockStorerMockSetInstanceIsPublished.RUnlock()
 	return calls
 }
 
@@ -1464,9 +1503,9 @@ func (mock *StorerMock) UpdateBuildHierarchyTaskState(id string, dimension strin
 		Dimension: dimension,
 		State:     state,
 	}
-	mock.lockUpdateBuildHierarchyTaskState.Lock()
+	lockStorerMockUpdateBuildHierarchyTaskState.Lock()
 	mock.calls.UpdateBuildHierarchyTaskState = append(mock.calls.UpdateBuildHierarchyTaskState, callInfo)
-	mock.lockUpdateBuildHierarchyTaskState.Unlock()
+	lockStorerMockUpdateBuildHierarchyTaskState.Unlock()
 	return mock.UpdateBuildHierarchyTaskStateFunc(id, dimension, state)
 }
 
@@ -1483,9 +1522,9 @@ func (mock *StorerMock) UpdateBuildHierarchyTaskStateCalls() []struct {
 		Dimension string
 		State     string
 	}
-	mock.lockUpdateBuildHierarchyTaskState.RLock()
+	lockStorerMockUpdateBuildHierarchyTaskState.RLock()
 	calls = mock.calls.UpdateBuildHierarchyTaskState
-	mock.lockUpdateBuildHierarchyTaskState.RUnlock()
+	lockStorerMockUpdateBuildHierarchyTaskState.RUnlock()
 	return calls
 }
 
@@ -1503,9 +1542,9 @@ func (mock *StorerMock) UpdateBuildSearchTaskState(id string, dimension string, 
 		Dimension: dimension,
 		State:     state,
 	}
-	mock.lockUpdateBuildSearchTaskState.Lock()
+	lockStorerMockUpdateBuildSearchTaskState.Lock()
 	mock.calls.UpdateBuildSearchTaskState = append(mock.calls.UpdateBuildSearchTaskState, callInfo)
-	mock.lockUpdateBuildSearchTaskState.Unlock()
+	lockStorerMockUpdateBuildSearchTaskState.Unlock()
 	return mock.UpdateBuildSearchTaskStateFunc(id, dimension, state)
 }
 
@@ -1522,9 +1561,9 @@ func (mock *StorerMock) UpdateBuildSearchTaskStateCalls() []struct {
 		Dimension string
 		State     string
 	}
-	mock.lockUpdateBuildSearchTaskState.RLock()
+	lockStorerMockUpdateBuildSearchTaskState.RLock()
 	calls = mock.calls.UpdateBuildSearchTaskState
-	mock.lockUpdateBuildSearchTaskState.RUnlock()
+	lockStorerMockUpdateBuildSearchTaskState.RUnlock()
 	return calls
 }
 
@@ -1544,9 +1583,9 @@ func (mock *StorerMock) UpdateDataset(ctx context.Context, ID string, dataset *m
 		Dataset:      dataset,
 		CurrentState: currentState,
 	}
-	mock.lockUpdateDataset.Lock()
+	lockStorerMockUpdateDataset.Lock()
 	mock.calls.UpdateDataset = append(mock.calls.UpdateDataset, callInfo)
-	mock.lockUpdateDataset.Unlock()
+	lockStorerMockUpdateDataset.Unlock()
 	return mock.UpdateDatasetFunc(ctx, ID, dataset, currentState)
 }
 
@@ -1565,9 +1604,9 @@ func (mock *StorerMock) UpdateDatasetCalls() []struct {
 		Dataset      *models.Dataset
 		CurrentState string
 	}
-	mock.lockUpdateDataset.RLock()
+	lockStorerMockUpdateDataset.RLock()
 	calls = mock.calls.UpdateDataset
-	mock.lockUpdateDataset.RUnlock()
+	lockStorerMockUpdateDataset.RUnlock()
 	return calls
 }
 
@@ -1585,9 +1624,9 @@ func (mock *StorerMock) UpdateDatasetWithAssociation(ID string, state string, ve
 		State:   state,
 		Version: version,
 	}
-	mock.lockUpdateDatasetWithAssociation.Lock()
+	lockStorerMockUpdateDatasetWithAssociation.Lock()
 	mock.calls.UpdateDatasetWithAssociation = append(mock.calls.UpdateDatasetWithAssociation, callInfo)
-	mock.lockUpdateDatasetWithAssociation.Unlock()
+	lockStorerMockUpdateDatasetWithAssociation.Unlock()
 	return mock.UpdateDatasetWithAssociationFunc(ID, state, version)
 }
 
@@ -1604,9 +1643,9 @@ func (mock *StorerMock) UpdateDatasetWithAssociationCalls() []struct {
 		State   string
 		Version *models.Version
 	}
-	mock.lockUpdateDatasetWithAssociation.RLock()
+	lockStorerMockUpdateDatasetWithAssociation.RLock()
 	calls = mock.calls.UpdateDatasetWithAssociation
-	mock.lockUpdateDatasetWithAssociation.RUnlock()
+	lockStorerMockUpdateDatasetWithAssociation.RUnlock()
 	return calls
 }
 
@@ -1620,9 +1659,9 @@ func (mock *StorerMock) UpdateDimensionNodeIDAndOrder(dimension *models.Dimensio
 	}{
 		Dimension: dimension,
 	}
-	mock.lockUpdateDimensionNodeIDAndOrder.Lock()
+	lockStorerMockUpdateDimensionNodeIDAndOrder.Lock()
 	mock.calls.UpdateDimensionNodeIDAndOrder = append(mock.calls.UpdateDimensionNodeIDAndOrder, callInfo)
-	mock.lockUpdateDimensionNodeIDAndOrder.Unlock()
+	lockStorerMockUpdateDimensionNodeIDAndOrder.Unlock()
 	return mock.UpdateDimensionNodeIDAndOrderFunc(dimension)
 }
 
@@ -1635,9 +1674,9 @@ func (mock *StorerMock) UpdateDimensionNodeIDAndOrderCalls() []struct {
 	var calls []struct {
 		Dimension *models.DimensionOption
 	}
-	mock.lockUpdateDimensionNodeIDAndOrder.RLock()
+	lockStorerMockUpdateDimensionNodeIDAndOrder.RLock()
 	calls = mock.calls.UpdateDimensionNodeIDAndOrder
-	mock.lockUpdateDimensionNodeIDAndOrder.RUnlock()
+	lockStorerMockUpdateDimensionNodeIDAndOrder.RUnlock()
 	return calls
 }
 
@@ -1653,9 +1692,9 @@ func (mock *StorerMock) UpdateImportObservationsTaskState(id string, state strin
 		ID:    id,
 		State: state,
 	}
-	mock.lockUpdateImportObservationsTaskState.Lock()
+	lockStorerMockUpdateImportObservationsTaskState.Lock()
 	mock.calls.UpdateImportObservationsTaskState = append(mock.calls.UpdateImportObservationsTaskState, callInfo)
-	mock.lockUpdateImportObservationsTaskState.Unlock()
+	lockStorerMockUpdateImportObservationsTaskState.Unlock()
 	return mock.UpdateImportObservationsTaskStateFunc(id, state)
 }
 
@@ -1670,9 +1709,9 @@ func (mock *StorerMock) UpdateImportObservationsTaskStateCalls() []struct {
 		ID    string
 		State string
 	}
-	mock.lockUpdateImportObservationsTaskState.RLock()
+	lockStorerMockUpdateImportObservationsTaskState.RLock()
 	calls = mock.calls.UpdateImportObservationsTaskState
-	mock.lockUpdateImportObservationsTaskState.RUnlock()
+	lockStorerMockUpdateImportObservationsTaskState.RUnlock()
 	return calls
 }
 
@@ -1690,9 +1729,9 @@ func (mock *StorerMock) UpdateInstance(ctx context.Context, ID string, instance 
 		ID:       ID,
 		Instance: instance,
 	}
-	mock.lockUpdateInstance.Lock()
+	lockStorerMockUpdateInstance.Lock()
 	mock.calls.UpdateInstance = append(mock.calls.UpdateInstance, callInfo)
-	mock.lockUpdateInstance.Unlock()
+	lockStorerMockUpdateInstance.Unlock()
 	return mock.UpdateInstanceFunc(ctx, ID, instance)
 }
 
@@ -1709,9 +1748,9 @@ func (mock *StorerMock) UpdateInstanceCalls() []struct {
 		ID       string
 		Instance *models.Instance
 	}
-	mock.lockUpdateInstance.RLock()
+	lockStorerMockUpdateInstance.RLock()
 	calls = mock.calls.UpdateInstance
-	mock.lockUpdateInstance.RUnlock()
+	lockStorerMockUpdateInstance.RUnlock()
 	return calls
 }
 
@@ -1727,9 +1766,9 @@ func (mock *StorerMock) UpdateObservationInserted(ID string, observationInserted
 		ID:                  ID,
 		ObservationInserted: observationInserted,
 	}
-	mock.lockUpdateObservationInserted.Lock()
+	lockStorerMockUpdateObservationInserted.Lock()
 	mock.calls.UpdateObservationInserted = append(mock.calls.UpdateObservationInserted, callInfo)
-	mock.lockUpdateObservationInserted.Unlock()
+	lockStorerMockUpdateObservationInserted.Unlock()
 	return mock.UpdateObservationInsertedFunc(ID, observationInserted)
 }
 
@@ -1744,9 +1783,9 @@ func (mock *StorerMock) UpdateObservationInsertedCalls() []struct {
 		ID                  string
 		ObservationInserted int64
 	}
-	mock.lockUpdateObservationInserted.RLock()
+	lockStorerMockUpdateObservationInserted.RLock()
 	calls = mock.calls.UpdateObservationInserted
-	mock.lockUpdateObservationInserted.RUnlock()
+	lockStorerMockUpdateObservationInserted.RUnlock()
 	return calls
 }
 
@@ -1762,9 +1801,9 @@ func (mock *StorerMock) UpdateVersion(ID string, version *models.Version) error 
 		ID:      ID,
 		Version: version,
 	}
-	mock.lockUpdateVersion.Lock()
+	lockStorerMockUpdateVersion.Lock()
 	mock.calls.UpdateVersion = append(mock.calls.UpdateVersion, callInfo)
-	mock.lockUpdateVersion.Unlock()
+	lockStorerMockUpdateVersion.Unlock()
 	return mock.UpdateVersionFunc(ID, version)
 }
 
@@ -1779,9 +1818,9 @@ func (mock *StorerMock) UpdateVersionCalls() []struct {
 		ID      string
 		Version *models.Version
 	}
-	mock.lockUpdateVersion.RLock()
+	lockStorerMockUpdateVersion.RLock()
 	calls = mock.calls.UpdateVersion
-	mock.lockUpdateVersion.RUnlock()
+	lockStorerMockUpdateVersion.RUnlock()
 	return calls
 }
 
@@ -1797,9 +1836,9 @@ func (mock *StorerMock) UpsertContact(ID string, update interface{}) error {
 		ID:     ID,
 		Update: update,
 	}
-	mock.lockUpsertContact.Lock()
+	lockStorerMockUpsertContact.Lock()
 	mock.calls.UpsertContact = append(mock.calls.UpsertContact, callInfo)
-	mock.lockUpsertContact.Unlock()
+	lockStorerMockUpsertContact.Unlock()
 	return mock.UpsertContactFunc(ID, update)
 }
 
@@ -1814,9 +1853,9 @@ func (mock *StorerMock) UpsertContactCalls() []struct {
 		ID     string
 		Update interface{}
 	}
-	mock.lockUpsertContact.RLock()
+	lockStorerMockUpsertContact.RLock()
 	calls = mock.calls.UpsertContact
-	mock.lockUpsertContact.RUnlock()
+	lockStorerMockUpsertContact.RUnlock()
 	return calls
 }
 
@@ -1832,9 +1871,9 @@ func (mock *StorerMock) UpsertDataset(ID string, datasetDoc *models.DatasetUpdat
 		ID:         ID,
 		DatasetDoc: datasetDoc,
 	}
-	mock.lockUpsertDataset.Lock()
+	lockStorerMockUpsertDataset.Lock()
 	mock.calls.UpsertDataset = append(mock.calls.UpsertDataset, callInfo)
-	mock.lockUpsertDataset.Unlock()
+	lockStorerMockUpsertDataset.Unlock()
 	return mock.UpsertDatasetFunc(ID, datasetDoc)
 }
 
@@ -1849,9 +1888,9 @@ func (mock *StorerMock) UpsertDatasetCalls() []struct {
 		ID         string
 		DatasetDoc *models.DatasetUpdate
 	}
-	mock.lockUpsertDataset.RLock()
+	lockStorerMockUpsertDataset.RLock()
 	calls = mock.calls.UpsertDataset
-	mock.lockUpsertDataset.RUnlock()
+	lockStorerMockUpsertDataset.RUnlock()
 	return calls
 }
 
@@ -1869,9 +1908,9 @@ func (mock *StorerMock) UpsertEdition(datasetID string, edition string, editionD
 		Edition:    edition,
 		EditionDoc: editionDoc,
 	}
-	mock.lockUpsertEdition.Lock()
+	lockStorerMockUpsertEdition.Lock()
 	mock.calls.UpsertEdition = append(mock.calls.UpsertEdition, callInfo)
-	mock.lockUpsertEdition.Unlock()
+	lockStorerMockUpsertEdition.Unlock()
 	return mock.UpsertEditionFunc(datasetID, edition, editionDoc)
 }
 
@@ -1888,9 +1927,9 @@ func (mock *StorerMock) UpsertEditionCalls() []struct {
 		Edition    string
 		EditionDoc *models.EditionUpdate
 	}
-	mock.lockUpsertEdition.RLock()
+	lockStorerMockUpsertEdition.RLock()
 	calls = mock.calls.UpsertEdition
-	mock.lockUpsertEdition.RUnlock()
+	lockStorerMockUpsertEdition.RUnlock()
 	return calls
 }
 
@@ -1906,9 +1945,9 @@ func (mock *StorerMock) UpsertVersion(ID string, versionDoc *models.Version) err
 		ID:         ID,
 		VersionDoc: versionDoc,
 	}
-	mock.lockUpsertVersion.Lock()
+	lockStorerMockUpsertVersion.Lock()
 	mock.calls.UpsertVersion = append(mock.calls.UpsertVersion, callInfo)
-	mock.lockUpsertVersion.Unlock()
+	lockStorerMockUpsertVersion.Unlock()
 	return mock.UpsertVersionFunc(ID, versionDoc)
 }
 
@@ -1923,8 +1962,8 @@ func (mock *StorerMock) UpsertVersionCalls() []struct {
 		ID         string
 		VersionDoc *models.Version
 	}
-	mock.lockUpsertVersion.RLock()
+	lockStorerMockUpsertVersion.RLock()
 	calls = mock.calls.UpsertVersion
-	mock.lockUpsertVersion.RUnlock()
+	lockStorerMockUpsertVersion.RUnlock()
 	return calls
 }

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -951,7 +951,7 @@ func (mock *StorerMock) GetDatasetsCalls() []struct {
 }
 
 // GetDimensionOptions calls GetDimensionOptionsFunc.
-func (mock *StorerMock) GetDimensionOptions(version *models.Version, dimension string, offset int, limit int) ([]*models.PublicDimensionOption, int, error) {
+func (mock *StorerMock) GetDimensionOptions(ctx context.Context, version *models.Version, dimension string, offset int, limit int) ([]*models.PublicDimensionOption, int, error) {
 	if mock.GetDimensionOptionsFunc == nil {
 		panic("StorerMock.GetDimensionOptionsFunc: method is nil but Storer.GetDimensionOptions was just called")
 	}

--- a/store/datastoretest/graph.go
+++ b/store/datastoretest/graph.go
@@ -10,40 +10,47 @@ import (
 	"sync"
 )
 
+var (
+	lockGraphDBMockAddVersionDetailsToInstance sync.RWMutex
+	lockGraphDBMockChecker                     sync.RWMutex
+	lockGraphDBMockClose                       sync.RWMutex
+	lockGraphDBMockSetInstanceIsPublished      sync.RWMutex
+)
+
 // Ensure, that GraphDBMock does implement store.GraphDB.
 // If this is not the case, regenerate this file with moq.
 var _ store.GraphDB = &GraphDBMock{}
 
 // GraphDBMock is a mock implementation of store.GraphDB.
 //
-// 	func TestSomethingThatUsesGraphDB(t *testing.T) {
+//     func TestSomethingThatUsesGraphDB(t *testing.T) {
 //
-// 		// make and configure a mocked store.GraphDB
-// 		mockedGraphDB := &GraphDBMock{
-// 			AddVersionDetailsToInstanceFunc: func(ctx context.Context, instanceID string, datasetID string, edition string, version int) error {
-// 				panic("mock out the AddVersionDetailsToInstance method")
-// 			},
-// 			CheckerFunc: func(contextMoqParam context.Context, checkState *healthcheck.CheckState) error {
-// 				panic("mock out the Checker method")
-// 			},
-// 			CloseFunc: func(ctx context.Context) error {
-// 				panic("mock out the Close method")
-// 			},
-// 			SetInstanceIsPublishedFunc: func(ctx context.Context, instanceID string) error {
-// 				panic("mock out the SetInstanceIsPublished method")
-// 			},
-// 		}
+//         // make and configure a mocked store.GraphDB
+//         mockedGraphDB := &GraphDBMock{
+//             AddVersionDetailsToInstanceFunc: func(ctx context.Context, instanceID string, datasetID string, edition string, version int) error {
+// 	               panic("mock out the AddVersionDetailsToInstance method")
+//             },
+//             CheckerFunc: func(in1 context.Context, in2 *healthcheck.CheckState) error {
+// 	               panic("mock out the Checker method")
+//             },
+//             CloseFunc: func(ctx context.Context) error {
+// 	               panic("mock out the Close method")
+//             },
+//             SetInstanceIsPublishedFunc: func(ctx context.Context, instanceID string) error {
+// 	               panic("mock out the SetInstanceIsPublished method")
+//             },
+//         }
 //
-// 		// use mockedGraphDB in code that requires store.GraphDB
-// 		// and then make assertions.
+//         // use mockedGraphDB in code that requires store.GraphDB
+//         // and then make assertions.
 //
-// 	}
+//     }
 type GraphDBMock struct {
 	// AddVersionDetailsToInstanceFunc mocks the AddVersionDetailsToInstance method.
 	AddVersionDetailsToInstanceFunc func(ctx context.Context, instanceID string, datasetID string, edition string, version int) error
 
 	// CheckerFunc mocks the Checker method.
-	CheckerFunc func(contextMoqParam context.Context, checkState *healthcheck.CheckState) error
+	CheckerFunc func(in1 context.Context, in2 *healthcheck.CheckState) error
 
 	// CloseFunc mocks the Close method.
 	CloseFunc func(ctx context.Context) error
@@ -68,10 +75,10 @@ type GraphDBMock struct {
 		}
 		// Checker holds details about calls to the Checker method.
 		Checker []struct {
-			// ContextMoqParam is the contextMoqParam argument value.
-			ContextMoqParam context.Context
-			// CheckState is the checkState argument value.
-			CheckState *healthcheck.CheckState
+			// In1 is the in1 argument value.
+			In1 context.Context
+			// In2 is the in2 argument value.
+			In2 *healthcheck.CheckState
 		}
 		// Close holds details about calls to the Close method.
 		Close []struct {
@@ -86,10 +93,6 @@ type GraphDBMock struct {
 			InstanceID string
 		}
 	}
-	lockAddVersionDetailsToInstance sync.RWMutex
-	lockChecker                     sync.RWMutex
-	lockClose                       sync.RWMutex
-	lockSetInstanceIsPublished      sync.RWMutex
 }
 
 // AddVersionDetailsToInstance calls AddVersionDetailsToInstanceFunc.
@@ -110,9 +113,9 @@ func (mock *GraphDBMock) AddVersionDetailsToInstance(ctx context.Context, instan
 		Edition:    edition,
 		Version:    version,
 	}
-	mock.lockAddVersionDetailsToInstance.Lock()
+	lockGraphDBMockAddVersionDetailsToInstance.Lock()
 	mock.calls.AddVersionDetailsToInstance = append(mock.calls.AddVersionDetailsToInstance, callInfo)
-	mock.lockAddVersionDetailsToInstance.Unlock()
+	lockGraphDBMockAddVersionDetailsToInstance.Unlock()
 	return mock.AddVersionDetailsToInstanceFunc(ctx, instanceID, datasetID, edition, version)
 }
 
@@ -133,44 +136,44 @@ func (mock *GraphDBMock) AddVersionDetailsToInstanceCalls() []struct {
 		Edition    string
 		Version    int
 	}
-	mock.lockAddVersionDetailsToInstance.RLock()
+	lockGraphDBMockAddVersionDetailsToInstance.RLock()
 	calls = mock.calls.AddVersionDetailsToInstance
-	mock.lockAddVersionDetailsToInstance.RUnlock()
+	lockGraphDBMockAddVersionDetailsToInstance.RUnlock()
 	return calls
 }
 
 // Checker calls CheckerFunc.
-func (mock *GraphDBMock) Checker(contextMoqParam context.Context, checkState *healthcheck.CheckState) error {
+func (mock *GraphDBMock) Checker(in1 context.Context, in2 *healthcheck.CheckState) error {
 	if mock.CheckerFunc == nil {
 		panic("GraphDBMock.CheckerFunc: method is nil but GraphDB.Checker was just called")
 	}
 	callInfo := struct {
-		ContextMoqParam context.Context
-		CheckState      *healthcheck.CheckState
+		In1 context.Context
+		In2 *healthcheck.CheckState
 	}{
-		ContextMoqParam: contextMoqParam,
-		CheckState:      checkState,
+		In1: in1,
+		In2: in2,
 	}
-	mock.lockChecker.Lock()
+	lockGraphDBMockChecker.Lock()
 	mock.calls.Checker = append(mock.calls.Checker, callInfo)
-	mock.lockChecker.Unlock()
-	return mock.CheckerFunc(contextMoqParam, checkState)
+	lockGraphDBMockChecker.Unlock()
+	return mock.CheckerFunc(in1, in2)
 }
 
 // CheckerCalls gets all the calls that were made to Checker.
 // Check the length with:
 //     len(mockedGraphDB.CheckerCalls())
 func (mock *GraphDBMock) CheckerCalls() []struct {
-	ContextMoqParam context.Context
-	CheckState      *healthcheck.CheckState
+	In1 context.Context
+	In2 *healthcheck.CheckState
 } {
 	var calls []struct {
-		ContextMoqParam context.Context
-		CheckState      *healthcheck.CheckState
+		In1 context.Context
+		In2 *healthcheck.CheckState
 	}
-	mock.lockChecker.RLock()
+	lockGraphDBMockChecker.RLock()
 	calls = mock.calls.Checker
-	mock.lockChecker.RUnlock()
+	lockGraphDBMockChecker.RUnlock()
 	return calls
 }
 
@@ -184,9 +187,9 @@ func (mock *GraphDBMock) Close(ctx context.Context) error {
 	}{
 		Ctx: ctx,
 	}
-	mock.lockClose.Lock()
+	lockGraphDBMockClose.Lock()
 	mock.calls.Close = append(mock.calls.Close, callInfo)
-	mock.lockClose.Unlock()
+	lockGraphDBMockClose.Unlock()
 	return mock.CloseFunc(ctx)
 }
 
@@ -199,9 +202,9 @@ func (mock *GraphDBMock) CloseCalls() []struct {
 	var calls []struct {
 		Ctx context.Context
 	}
-	mock.lockClose.RLock()
+	lockGraphDBMockClose.RLock()
 	calls = mock.calls.Close
-	mock.lockClose.RUnlock()
+	lockGraphDBMockClose.RUnlock()
 	return calls
 }
 
@@ -217,9 +220,9 @@ func (mock *GraphDBMock) SetInstanceIsPublished(ctx context.Context, instanceID 
 		Ctx:        ctx,
 		InstanceID: instanceID,
 	}
-	mock.lockSetInstanceIsPublished.Lock()
+	lockGraphDBMockSetInstanceIsPublished.Lock()
 	mock.calls.SetInstanceIsPublished = append(mock.calls.SetInstanceIsPublished, callInfo)
-	mock.lockSetInstanceIsPublished.Unlock()
+	lockGraphDBMockSetInstanceIsPublished.Unlock()
 	return mock.SetInstanceIsPublishedFunc(ctx, instanceID)
 }
 
@@ -234,8 +237,8 @@ func (mock *GraphDBMock) SetInstanceIsPublishedCalls() []struct {
 		Ctx        context.Context
 		InstanceID string
 	}
-	mock.lockSetInstanceIsPublished.RLock()
+	lockGraphDBMockSetInstanceIsPublished.RLock()
 	calls = mock.calls.SetInstanceIsPublished
-	mock.lockSetInstanceIsPublished.RUnlock()
+	lockGraphDBMockSetInstanceIsPublished.RUnlock()
 	return calls
 }

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -12,130 +12,169 @@ import (
 	"sync"
 )
 
+var (
+	lockMongoDBMockAddDimensionToInstance            sync.RWMutex
+	lockMongoDBMockAddEventToInstance                sync.RWMutex
+	lockMongoDBMockAddInstance                       sync.RWMutex
+	lockMongoDBMockCheckDatasetExists                sync.RWMutex
+	lockMongoDBMockCheckEditionExists                sync.RWMutex
+	lockMongoDBMockChecker                           sync.RWMutex
+	lockMongoDBMockClose                             sync.RWMutex
+	lockMongoDBMockDeleteDataset                     sync.RWMutex
+	lockMongoDBMockDeleteEdition                     sync.RWMutex
+	lockMongoDBMockGetDataset                        sync.RWMutex
+	lockMongoDBMockGetDatasets                       sync.RWMutex
+	lockMongoDBMockGetDimensionOptions               sync.RWMutex
+	lockMongoDBMockGetDimensionOptionsFromIDs        sync.RWMutex
+	lockMongoDBMockGetDimensions                     sync.RWMutex
+	lockMongoDBMockGetDimensionsFromInstance         sync.RWMutex
+	lockMongoDBMockGetEdition                        sync.RWMutex
+	lockMongoDBMockGetEditions                       sync.RWMutex
+	lockMongoDBMockGetInstance                       sync.RWMutex
+	lockMongoDBMockGetInstances                      sync.RWMutex
+	lockMongoDBMockGetNextVersion                    sync.RWMutex
+	lockMongoDBMockGetUniqueDimensionAndOptions      sync.RWMutex
+	lockMongoDBMockGetVersion                        sync.RWMutex
+	lockMongoDBMockGetVersions                       sync.RWMutex
+	lockMongoDBMockUpdateBuildHierarchyTaskState     sync.RWMutex
+	lockMongoDBMockUpdateBuildSearchTaskState        sync.RWMutex
+	lockMongoDBMockUpdateDataset                     sync.RWMutex
+	lockMongoDBMockUpdateDatasetWithAssociation      sync.RWMutex
+	lockMongoDBMockUpdateDimensionNodeIDAndOrder     sync.RWMutex
+	lockMongoDBMockUpdateImportObservationsTaskState sync.RWMutex
+	lockMongoDBMockUpdateInstance                    sync.RWMutex
+	lockMongoDBMockUpdateObservationInserted         sync.RWMutex
+	lockMongoDBMockUpdateVersion                     sync.RWMutex
+	lockMongoDBMockUpsertContact                     sync.RWMutex
+	lockMongoDBMockUpsertDataset                     sync.RWMutex
+	lockMongoDBMockUpsertEdition                     sync.RWMutex
+	lockMongoDBMockUpsertVersion                     sync.RWMutex
+)
+
 // Ensure, that MongoDBMock does implement store.MongoDB.
 // If this is not the case, regenerate this file with moq.
 var _ store.MongoDB = &MongoDBMock{}
 
 // MongoDBMock is a mock implementation of store.MongoDB.
 //
-// 	func TestSomethingThatUsesMongoDB(t *testing.T) {
+//     func TestSomethingThatUsesMongoDB(t *testing.T) {
 //
-// 		// make and configure a mocked store.MongoDB
-// 		mockedMongoDB := &MongoDBMock{
-// 			AddDimensionToInstanceFunc: func(dimension *models.CachedDimensionOption) error {
-// 				panic("mock out the AddDimensionToInstance method")
-// 			},
-// 			AddEventToInstanceFunc: func(instanceID string, event *models.Event) error {
-// 				panic("mock out the AddEventToInstance method")
-// 			},
-// 			AddInstanceFunc: func(instance *models.Instance) (*models.Instance, error) {
-// 				panic("mock out the AddInstance method")
-// 			},
-// 			CheckDatasetExistsFunc: func(ID string, state string) error {
-// 				panic("mock out the CheckDatasetExists method")
-// 			},
-// 			CheckEditionExistsFunc: func(ID string, editionID string, state string) error {
-// 				panic("mock out the CheckEditionExists method")
-// 			},
-// 			CheckerFunc: func(contextMoqParam context.Context, checkState *healthcheck.CheckState) error {
-// 				panic("mock out the Checker method")
-// 			},
-// 			CloseFunc: func(contextMoqParam context.Context) error {
-// 				panic("mock out the Close method")
-// 			},
-// 			DeleteDatasetFunc: func(ID string) error {
-// 				panic("mock out the DeleteDataset method")
-// 			},
-// 			DeleteEditionFunc: func(ID string) error {
-// 				panic("mock out the DeleteEdition method")
-// 			},
-// 			GetDatasetFunc: func(ID string) (*models.DatasetUpdate, error) {
-// 				panic("mock out the GetDataset method")
-// 			},
-// 			GetDatasetsFunc: func(ctx context.Context, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
-// 				panic("mock out the GetDatasets method")
-// 			},
-// 			GetDimensionOptionsFunc: func(version *models.Version, dimension string, offset int, limit int) ([]*models.PublicDimensionOption, int, error) {
-// 				panic("mock out the GetDimensionOptions method")
-// 			},
-// 			GetDimensionOptionsFromIDsFunc: func(version *models.Version, dimension string, ids []string) ([]*models.PublicDimensionOption, int, error) {
-// 				panic("mock out the GetDimensionOptionsFromIDs method")
-// 			},
-// 			GetDimensionsFunc: func(datasetID string, versionID string) ([]bson.M, error) {
-// 				panic("mock out the GetDimensions method")
-// 			},
-// 			GetDimensionsFromInstanceFunc: func(ID string) (*models.DimensionNodeResults, error) {
-// 				panic("mock out the GetDimensionsFromInstance method")
-// 			},
-// 			GetEditionFunc: func(ID string, editionID string, state string) (*models.EditionUpdate, error) {
-// 				panic("mock out the GetEdition method")
-// 			},
-// 			GetEditionsFunc: func(ctx context.Context, ID string, state string, offset int, limit int, authorised bool) ([]*models.EditionUpdate, int, error) {
-// 				panic("mock out the GetEditions method")
-// 			},
-// 			GetInstanceFunc: func(ID string) (*models.Instance, error) {
-// 				panic("mock out the GetInstance method")
-// 			},
-// 			GetInstancesFunc: func(ctx context.Context, states []string, datasets []string, offset int, limit int) ([]*models.Instance, int, error) {
-// 				panic("mock out the GetInstances method")
-// 			},
-// 			GetNextVersionFunc: func(datasetID string, editionID string) (int, error) {
-// 				panic("mock out the GetNextVersion method")
-// 			},
-// 			GetUniqueDimensionAndOptionsFunc: func(ID string, dimension string) (*models.DimensionValues, error) {
-// 				panic("mock out the GetUniqueDimensionAndOptions method")
-// 			},
-// 			GetVersionFunc: func(datasetID string, editionID string, version string, state string) (*models.Version, error) {
-// 				panic("mock out the GetVersion method")
-// 			},
-// 			GetVersionsFunc: func(ctx context.Context, datasetID string, editionID string, state string, offset int, limit int) ([]models.Version, int, error) {
-// 				panic("mock out the GetVersions method")
-// 			},
-// 			UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
-// 				panic("mock out the UpdateBuildHierarchyTaskState method")
-// 			},
-// 			UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
-// 				panic("mock out the UpdateBuildSearchTaskState method")
-// 			},
-// 			UpdateDatasetFunc: func(ctx context.Context, ID string, dataset *models.Dataset, currentState string) error {
-// 				panic("mock out the UpdateDataset method")
-// 			},
-// 			UpdateDatasetWithAssociationFunc: func(ID string, state string, version *models.Version) error {
-// 				panic("mock out the UpdateDatasetWithAssociation method")
-// 			},
-// 			UpdateDimensionNodeIDAndOrderFunc: func(dimension *models.DimensionOption) error {
-// 				panic("mock out the UpdateDimensionNodeIDAndOrder method")
-// 			},
-// 			UpdateImportObservationsTaskStateFunc: func(id string, state string) error {
-// 				panic("mock out the UpdateImportObservationsTaskState method")
-// 			},
-// 			UpdateInstanceFunc: func(ctx context.Context, ID string, instance *models.Instance) error {
-// 				panic("mock out the UpdateInstance method")
-// 			},
-// 			UpdateObservationInsertedFunc: func(ID string, observationInserted int64) error {
-// 				panic("mock out the UpdateObservationInserted method")
-// 			},
-// 			UpdateVersionFunc: func(ID string, version *models.Version) error {
-// 				panic("mock out the UpdateVersion method")
-// 			},
-// 			UpsertContactFunc: func(ID string, update interface{}) error {
-// 				panic("mock out the UpsertContact method")
-// 			},
-// 			UpsertDatasetFunc: func(ID string, datasetDoc *models.DatasetUpdate) error {
-// 				panic("mock out the UpsertDataset method")
-// 			},
-// 			UpsertEditionFunc: func(datasetID string, edition string, editionDoc *models.EditionUpdate) error {
-// 				panic("mock out the UpsertEdition method")
-// 			},
-// 			UpsertVersionFunc: func(ID string, versionDoc *models.Version) error {
-// 				panic("mock out the UpsertVersion method")
-// 			},
-// 		}
+//         // make and configure a mocked store.MongoDB
+//         mockedMongoDB := &MongoDBMock{
+//             AddDimensionToInstanceFunc: func(dimension *models.CachedDimensionOption) error {
+// 	               panic("mock out the AddDimensionToInstance method")
+//             },
+//             AddEventToInstanceFunc: func(instanceID string, event *models.Event) error {
+// 	               panic("mock out the AddEventToInstance method")
+//             },
+//             AddInstanceFunc: func(instance *models.Instance) (*models.Instance, error) {
+// 	               panic("mock out the AddInstance method")
+//             },
+//             CheckDatasetExistsFunc: func(ID string, state string) error {
+// 	               panic("mock out the CheckDatasetExists method")
+//             },
+//             CheckEditionExistsFunc: func(ID string, editionID string, state string) error {
+// 	               panic("mock out the CheckEditionExists method")
+//             },
+//             CheckerFunc: func(in1 context.Context, in2 *healthcheck.CheckState) error {
+// 	               panic("mock out the Checker method")
+//             },
+//             CloseFunc: func(in1 context.Context) error {
+// 	               panic("mock out the Close method")
+//             },
+//             DeleteDatasetFunc: func(ID string) error {
+// 	               panic("mock out the DeleteDataset method")
+//             },
+//             DeleteEditionFunc: func(ID string) error {
+// 	               panic("mock out the DeleteEdition method")
+//             },
+//             GetDatasetFunc: func(ID string) (*models.DatasetUpdate, error) {
+// 	               panic("mock out the GetDataset method")
+//             },
+//             GetDatasetsFunc: func(ctx context.Context, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
+// 	               panic("mock out the GetDatasets method")
+//             },
+//             GetDimensionOptionsFunc: func(version *models.Version, dimension string, offset int, limit int) ([]*models.PublicDimensionOption, int, error) {
+// 	               panic("mock out the GetDimensionOptions method")
+//             },
+//             GetDimensionOptionsFromIDsFunc: func(version *models.Version, dimension string, ids []string) ([]*models.PublicDimensionOption, int, error) {
+// 	               panic("mock out the GetDimensionOptionsFromIDs method")
+//             },
+//             GetDimensionsFunc: func(datasetID string, versionID string) ([]bson.M, error) {
+// 	               panic("mock out the GetDimensions method")
+//             },
+//             GetDimensionsFromInstanceFunc: func(ctx context.Context, ID string, offset int, limit int) ([]*models.DimensionOption, int, error) {
+// 	               panic("mock out the GetDimensionsFromInstance method")
+//             },
+//             GetEditionFunc: func(ID string, editionID string, state string) (*models.EditionUpdate, error) {
+// 	               panic("mock out the GetEdition method")
+//             },
+//             GetEditionsFunc: func(ctx context.Context, ID string, state string, offset int, limit int, authorised bool) ([]*models.EditionUpdate, int, error) {
+// 	               panic("mock out the GetEditions method")
+//             },
+//             GetInstanceFunc: func(ID string) (*models.Instance, error) {
+// 	               panic("mock out the GetInstance method")
+//             },
+//             GetInstancesFunc: func(ctx context.Context, states []string, datasets []string, offset int, limit int) ([]*models.Instance, int, error) {
+// 	               panic("mock out the GetInstances method")
+//             },
+//             GetNextVersionFunc: func(datasetID string, editionID string) (int, error) {
+// 	               panic("mock out the GetNextVersion method")
+//             },
+//             GetUniqueDimensionAndOptionsFunc: func(ctx context.Context, ID string, dimension string, offset int, limit int) ([]*string, int, error) {
+// 	               panic("mock out the GetUniqueDimensionAndOptions method")
+//             },
+//             GetVersionFunc: func(datasetID string, editionID string, version string, state string) (*models.Version, error) {
+// 	               panic("mock out the GetVersion method")
+//             },
+//             GetVersionsFunc: func(ctx context.Context, datasetID string, editionID string, state string, offset int, limit int) ([]models.Version, int, error) {
+// 	               panic("mock out the GetVersions method")
+//             },
+//             UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
+// 	               panic("mock out the UpdateBuildHierarchyTaskState method")
+//             },
+//             UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
+// 	               panic("mock out the UpdateBuildSearchTaskState method")
+//             },
+//             UpdateDatasetFunc: func(ctx context.Context, ID string, dataset *models.Dataset, currentState string) error {
+// 	               panic("mock out the UpdateDataset method")
+//             },
+//             UpdateDatasetWithAssociationFunc: func(ID string, state string, version *models.Version) error {
+// 	               panic("mock out the UpdateDatasetWithAssociation method")
+//             },
+//             UpdateDimensionNodeIDAndOrderFunc: func(dimension *models.DimensionOption) error {
+// 	               panic("mock out the UpdateDimensionNodeIDAndOrder method")
+//             },
+//             UpdateImportObservationsTaskStateFunc: func(id string, state string) error {
+// 	               panic("mock out the UpdateImportObservationsTaskState method")
+//             },
+//             UpdateInstanceFunc: func(ctx context.Context, ID string, instance *models.Instance) error {
+// 	               panic("mock out the UpdateInstance method")
+//             },
+//             UpdateObservationInsertedFunc: func(ID string, observationInserted int64) error {
+// 	               panic("mock out the UpdateObservationInserted method")
+//             },
+//             UpdateVersionFunc: func(ID string, version *models.Version) error {
+// 	               panic("mock out the UpdateVersion method")
+//             },
+//             UpsertContactFunc: func(ID string, update interface{}) error {
+// 	               panic("mock out the UpsertContact method")
+//             },
+//             UpsertDatasetFunc: func(ID string, datasetDoc *models.DatasetUpdate) error {
+// 	               panic("mock out the UpsertDataset method")
+//             },
+//             UpsertEditionFunc: func(datasetID string, edition string, editionDoc *models.EditionUpdate) error {
+// 	               panic("mock out the UpsertEdition method")
+//             },
+//             UpsertVersionFunc: func(ID string, versionDoc *models.Version) error {
+// 	               panic("mock out the UpsertVersion method")
+//             },
+//         }
 //
-// 		// use mockedMongoDB in code that requires store.MongoDB
-// 		// and then make assertions.
+//         // use mockedMongoDB in code that requires store.MongoDB
+//         // and then make assertions.
 //
-// 	}
+//     }
 type MongoDBMock struct {
 	// AddDimensionToInstanceFunc mocks the AddDimensionToInstance method.
 	AddDimensionToInstanceFunc func(dimension *models.CachedDimensionOption) error
@@ -153,10 +192,10 @@ type MongoDBMock struct {
 	CheckEditionExistsFunc func(ID string, editionID string, state string) error
 
 	// CheckerFunc mocks the Checker method.
-	CheckerFunc func(contextMoqParam context.Context, checkState *healthcheck.CheckState) error
+	CheckerFunc func(in1 context.Context, in2 *healthcheck.CheckState) error
 
 	// CloseFunc mocks the Close method.
-	CloseFunc func(contextMoqParam context.Context) error
+	CloseFunc func(in1 context.Context) error
 
 	// DeleteDatasetFunc mocks the DeleteDataset method.
 	DeleteDatasetFunc func(ID string) error
@@ -180,7 +219,7 @@ type MongoDBMock struct {
 	GetDimensionsFunc func(datasetID string, versionID string) ([]bson.M, error)
 
 	// GetDimensionsFromInstanceFunc mocks the GetDimensionsFromInstance method.
-	GetDimensionsFromInstanceFunc func(ID string) (*models.DimensionNodeResults, error)
+	GetDimensionsFromInstanceFunc func(ctx context.Context, ID string, offset int, limit int) ([]*models.DimensionOption, int, error)
 
 	// GetEditionFunc mocks the GetEdition method.
 	GetEditionFunc func(ID string, editionID string, state string) (*models.EditionUpdate, error)
@@ -198,7 +237,7 @@ type MongoDBMock struct {
 	GetNextVersionFunc func(datasetID string, editionID string) (int, error)
 
 	// GetUniqueDimensionAndOptionsFunc mocks the GetUniqueDimensionAndOptions method.
-	GetUniqueDimensionAndOptionsFunc func(ID string, dimension string) (*models.DimensionValues, error)
+	GetUniqueDimensionAndOptionsFunc func(ctx context.Context, ID string, dimension string, offset int, limit int) ([]*string, int, error)
 
 	// GetVersionFunc mocks the GetVersion method.
 	GetVersionFunc func(datasetID string, editionID string, version string, state string) (*models.Version, error)
@@ -282,15 +321,15 @@ type MongoDBMock struct {
 		}
 		// Checker holds details about calls to the Checker method.
 		Checker []struct {
-			// ContextMoqParam is the contextMoqParam argument value.
-			ContextMoqParam context.Context
-			// CheckState is the checkState argument value.
-			CheckState *healthcheck.CheckState
+			// In1 is the in1 argument value.
+			In1 context.Context
+			// In2 is the in2 argument value.
+			In2 *healthcheck.CheckState
 		}
 		// Close holds details about calls to the Close method.
 		Close []struct {
-			// ContextMoqParam is the contextMoqParam argument value.
-			ContextMoqParam context.Context
+			// In1 is the in1 argument value.
+			In1 context.Context
 		}
 		// DeleteDataset holds details about calls to the DeleteDataset method.
 		DeleteDataset []struct {
@@ -347,8 +386,14 @@ type MongoDBMock struct {
 		}
 		// GetDimensionsFromInstance holds details about calls to the GetDimensionsFromInstance method.
 		GetDimensionsFromInstance []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 			// ID is the ID argument value.
 			ID string
+			// Offset is the offset argument value.
+			Offset int
+			// Limit is the limit argument value.
+			Limit int
 		}
 		// GetEdition holds details about calls to the GetEdition method.
 		GetEdition []struct {
@@ -401,10 +446,16 @@ type MongoDBMock struct {
 		}
 		// GetUniqueDimensionAndOptions holds details about calls to the GetUniqueDimensionAndOptions method.
 		GetUniqueDimensionAndOptions []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 			// ID is the ID argument value.
 			ID string
 			// Dimension is the dimension argument value.
 			Dimension string
+			// Offset is the offset argument value.
+			Offset int
+			// Limit is the limit argument value.
+			Limit int
 		}
 		// GetVersion holds details about calls to the GetVersion method.
 		GetVersion []struct {
@@ -536,42 +587,6 @@ type MongoDBMock struct {
 			VersionDoc *models.Version
 		}
 	}
-	lockAddDimensionToInstance            sync.RWMutex
-	lockAddEventToInstance                sync.RWMutex
-	lockAddInstance                       sync.RWMutex
-	lockCheckDatasetExists                sync.RWMutex
-	lockCheckEditionExists                sync.RWMutex
-	lockChecker                           sync.RWMutex
-	lockClose                             sync.RWMutex
-	lockDeleteDataset                     sync.RWMutex
-	lockDeleteEdition                     sync.RWMutex
-	lockGetDataset                        sync.RWMutex
-	lockGetDatasets                       sync.RWMutex
-	lockGetDimensionOptions               sync.RWMutex
-	lockGetDimensionOptionsFromIDs        sync.RWMutex
-	lockGetDimensions                     sync.RWMutex
-	lockGetDimensionsFromInstance         sync.RWMutex
-	lockGetEdition                        sync.RWMutex
-	lockGetEditions                       sync.RWMutex
-	lockGetInstance                       sync.RWMutex
-	lockGetInstances                      sync.RWMutex
-	lockGetNextVersion                    sync.RWMutex
-	lockGetUniqueDimensionAndOptions      sync.RWMutex
-	lockGetVersion                        sync.RWMutex
-	lockGetVersions                       sync.RWMutex
-	lockUpdateBuildHierarchyTaskState     sync.RWMutex
-	lockUpdateBuildSearchTaskState        sync.RWMutex
-	lockUpdateDataset                     sync.RWMutex
-	lockUpdateDatasetWithAssociation      sync.RWMutex
-	lockUpdateDimensionNodeIDAndOrder     sync.RWMutex
-	lockUpdateImportObservationsTaskState sync.RWMutex
-	lockUpdateInstance                    sync.RWMutex
-	lockUpdateObservationInserted         sync.RWMutex
-	lockUpdateVersion                     sync.RWMutex
-	lockUpsertContact                     sync.RWMutex
-	lockUpsertDataset                     sync.RWMutex
-	lockUpsertEdition                     sync.RWMutex
-	lockUpsertVersion                     sync.RWMutex
 }
 
 // AddDimensionToInstance calls AddDimensionToInstanceFunc.
@@ -584,9 +599,9 @@ func (mock *MongoDBMock) AddDimensionToInstance(dimension *models.CachedDimensio
 	}{
 		Dimension: dimension,
 	}
-	mock.lockAddDimensionToInstance.Lock()
+	lockMongoDBMockAddDimensionToInstance.Lock()
 	mock.calls.AddDimensionToInstance = append(mock.calls.AddDimensionToInstance, callInfo)
-	mock.lockAddDimensionToInstance.Unlock()
+	lockMongoDBMockAddDimensionToInstance.Unlock()
 	return mock.AddDimensionToInstanceFunc(dimension)
 }
 
@@ -599,9 +614,9 @@ func (mock *MongoDBMock) AddDimensionToInstanceCalls() []struct {
 	var calls []struct {
 		Dimension *models.CachedDimensionOption
 	}
-	mock.lockAddDimensionToInstance.RLock()
+	lockMongoDBMockAddDimensionToInstance.RLock()
 	calls = mock.calls.AddDimensionToInstance
-	mock.lockAddDimensionToInstance.RUnlock()
+	lockMongoDBMockAddDimensionToInstance.RUnlock()
 	return calls
 }
 
@@ -617,9 +632,9 @@ func (mock *MongoDBMock) AddEventToInstance(instanceID string, event *models.Eve
 		InstanceID: instanceID,
 		Event:      event,
 	}
-	mock.lockAddEventToInstance.Lock()
+	lockMongoDBMockAddEventToInstance.Lock()
 	mock.calls.AddEventToInstance = append(mock.calls.AddEventToInstance, callInfo)
-	mock.lockAddEventToInstance.Unlock()
+	lockMongoDBMockAddEventToInstance.Unlock()
 	return mock.AddEventToInstanceFunc(instanceID, event)
 }
 
@@ -634,9 +649,9 @@ func (mock *MongoDBMock) AddEventToInstanceCalls() []struct {
 		InstanceID string
 		Event      *models.Event
 	}
-	mock.lockAddEventToInstance.RLock()
+	lockMongoDBMockAddEventToInstance.RLock()
 	calls = mock.calls.AddEventToInstance
-	mock.lockAddEventToInstance.RUnlock()
+	lockMongoDBMockAddEventToInstance.RUnlock()
 	return calls
 }
 
@@ -650,9 +665,9 @@ func (mock *MongoDBMock) AddInstance(instance *models.Instance) (*models.Instanc
 	}{
 		Instance: instance,
 	}
-	mock.lockAddInstance.Lock()
+	lockMongoDBMockAddInstance.Lock()
 	mock.calls.AddInstance = append(mock.calls.AddInstance, callInfo)
-	mock.lockAddInstance.Unlock()
+	lockMongoDBMockAddInstance.Unlock()
 	return mock.AddInstanceFunc(instance)
 }
 
@@ -665,9 +680,9 @@ func (mock *MongoDBMock) AddInstanceCalls() []struct {
 	var calls []struct {
 		Instance *models.Instance
 	}
-	mock.lockAddInstance.RLock()
+	lockMongoDBMockAddInstance.RLock()
 	calls = mock.calls.AddInstance
-	mock.lockAddInstance.RUnlock()
+	lockMongoDBMockAddInstance.RUnlock()
 	return calls
 }
 
@@ -683,9 +698,9 @@ func (mock *MongoDBMock) CheckDatasetExists(ID string, state string) error {
 		ID:    ID,
 		State: state,
 	}
-	mock.lockCheckDatasetExists.Lock()
+	lockMongoDBMockCheckDatasetExists.Lock()
 	mock.calls.CheckDatasetExists = append(mock.calls.CheckDatasetExists, callInfo)
-	mock.lockCheckDatasetExists.Unlock()
+	lockMongoDBMockCheckDatasetExists.Unlock()
 	return mock.CheckDatasetExistsFunc(ID, state)
 }
 
@@ -700,9 +715,9 @@ func (mock *MongoDBMock) CheckDatasetExistsCalls() []struct {
 		ID    string
 		State string
 	}
-	mock.lockCheckDatasetExists.RLock()
+	lockMongoDBMockCheckDatasetExists.RLock()
 	calls = mock.calls.CheckDatasetExists
-	mock.lockCheckDatasetExists.RUnlock()
+	lockMongoDBMockCheckDatasetExists.RUnlock()
 	return calls
 }
 
@@ -720,9 +735,9 @@ func (mock *MongoDBMock) CheckEditionExists(ID string, editionID string, state s
 		EditionID: editionID,
 		State:     state,
 	}
-	mock.lockCheckEditionExists.Lock()
+	lockMongoDBMockCheckEditionExists.Lock()
 	mock.calls.CheckEditionExists = append(mock.calls.CheckEditionExists, callInfo)
-	mock.lockCheckEditionExists.Unlock()
+	lockMongoDBMockCheckEditionExists.Unlock()
 	return mock.CheckEditionExistsFunc(ID, editionID, state)
 }
 
@@ -739,75 +754,75 @@ func (mock *MongoDBMock) CheckEditionExistsCalls() []struct {
 		EditionID string
 		State     string
 	}
-	mock.lockCheckEditionExists.RLock()
+	lockMongoDBMockCheckEditionExists.RLock()
 	calls = mock.calls.CheckEditionExists
-	mock.lockCheckEditionExists.RUnlock()
+	lockMongoDBMockCheckEditionExists.RUnlock()
 	return calls
 }
 
 // Checker calls CheckerFunc.
-func (mock *MongoDBMock) Checker(contextMoqParam context.Context, checkState *healthcheck.CheckState) error {
+func (mock *MongoDBMock) Checker(in1 context.Context, in2 *healthcheck.CheckState) error {
 	if mock.CheckerFunc == nil {
 		panic("MongoDBMock.CheckerFunc: method is nil but MongoDB.Checker was just called")
 	}
 	callInfo := struct {
-		ContextMoqParam context.Context
-		CheckState      *healthcheck.CheckState
+		In1 context.Context
+		In2 *healthcheck.CheckState
 	}{
-		ContextMoqParam: contextMoqParam,
-		CheckState:      checkState,
+		In1: in1,
+		In2: in2,
 	}
-	mock.lockChecker.Lock()
+	lockMongoDBMockChecker.Lock()
 	mock.calls.Checker = append(mock.calls.Checker, callInfo)
-	mock.lockChecker.Unlock()
-	return mock.CheckerFunc(contextMoqParam, checkState)
+	lockMongoDBMockChecker.Unlock()
+	return mock.CheckerFunc(in1, in2)
 }
 
 // CheckerCalls gets all the calls that were made to Checker.
 // Check the length with:
 //     len(mockedMongoDB.CheckerCalls())
 func (mock *MongoDBMock) CheckerCalls() []struct {
-	ContextMoqParam context.Context
-	CheckState      *healthcheck.CheckState
+	In1 context.Context
+	In2 *healthcheck.CheckState
 } {
 	var calls []struct {
-		ContextMoqParam context.Context
-		CheckState      *healthcheck.CheckState
+		In1 context.Context
+		In2 *healthcheck.CheckState
 	}
-	mock.lockChecker.RLock()
+	lockMongoDBMockChecker.RLock()
 	calls = mock.calls.Checker
-	mock.lockChecker.RUnlock()
+	lockMongoDBMockChecker.RUnlock()
 	return calls
 }
 
 // Close calls CloseFunc.
-func (mock *MongoDBMock) Close(contextMoqParam context.Context) error {
+func (mock *MongoDBMock) Close(in1 context.Context) error {
 	if mock.CloseFunc == nil {
 		panic("MongoDBMock.CloseFunc: method is nil but MongoDB.Close was just called")
 	}
 	callInfo := struct {
-		ContextMoqParam context.Context
+		In1 context.Context
 	}{
-		ContextMoqParam: contextMoqParam,
+		In1: in1,
 	}
-	mock.lockClose.Lock()
+	lockMongoDBMockClose.Lock()
 	mock.calls.Close = append(mock.calls.Close, callInfo)
-	mock.lockClose.Unlock()
-	return mock.CloseFunc(contextMoqParam)
+	lockMongoDBMockClose.Unlock()
+	return mock.CloseFunc(in1)
 }
 
 // CloseCalls gets all the calls that were made to Close.
 // Check the length with:
 //     len(mockedMongoDB.CloseCalls())
 func (mock *MongoDBMock) CloseCalls() []struct {
-	ContextMoqParam context.Context
+	In1 context.Context
 } {
 	var calls []struct {
-		ContextMoqParam context.Context
+		In1 context.Context
 	}
-	mock.lockClose.RLock()
+	lockMongoDBMockClose.RLock()
 	calls = mock.calls.Close
-	mock.lockClose.RUnlock()
+	lockMongoDBMockClose.RUnlock()
 	return calls
 }
 
@@ -821,9 +836,9 @@ func (mock *MongoDBMock) DeleteDataset(ID string) error {
 	}{
 		ID: ID,
 	}
-	mock.lockDeleteDataset.Lock()
+	lockMongoDBMockDeleteDataset.Lock()
 	mock.calls.DeleteDataset = append(mock.calls.DeleteDataset, callInfo)
-	mock.lockDeleteDataset.Unlock()
+	lockMongoDBMockDeleteDataset.Unlock()
 	return mock.DeleteDatasetFunc(ID)
 }
 
@@ -836,9 +851,9 @@ func (mock *MongoDBMock) DeleteDatasetCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	mock.lockDeleteDataset.RLock()
+	lockMongoDBMockDeleteDataset.RLock()
 	calls = mock.calls.DeleteDataset
-	mock.lockDeleteDataset.RUnlock()
+	lockMongoDBMockDeleteDataset.RUnlock()
 	return calls
 }
 
@@ -852,9 +867,9 @@ func (mock *MongoDBMock) DeleteEdition(ID string) error {
 	}{
 		ID: ID,
 	}
-	mock.lockDeleteEdition.Lock()
+	lockMongoDBMockDeleteEdition.Lock()
 	mock.calls.DeleteEdition = append(mock.calls.DeleteEdition, callInfo)
-	mock.lockDeleteEdition.Unlock()
+	lockMongoDBMockDeleteEdition.Unlock()
 	return mock.DeleteEditionFunc(ID)
 }
 
@@ -867,9 +882,9 @@ func (mock *MongoDBMock) DeleteEditionCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	mock.lockDeleteEdition.RLock()
+	lockMongoDBMockDeleteEdition.RLock()
 	calls = mock.calls.DeleteEdition
-	mock.lockDeleteEdition.RUnlock()
+	lockMongoDBMockDeleteEdition.RUnlock()
 	return calls
 }
 
@@ -883,9 +898,9 @@ func (mock *MongoDBMock) GetDataset(ID string) (*models.DatasetUpdate, error) {
 	}{
 		ID: ID,
 	}
-	mock.lockGetDataset.Lock()
+	lockMongoDBMockGetDataset.Lock()
 	mock.calls.GetDataset = append(mock.calls.GetDataset, callInfo)
-	mock.lockGetDataset.Unlock()
+	lockMongoDBMockGetDataset.Unlock()
 	return mock.GetDatasetFunc(ID)
 }
 
@@ -898,9 +913,9 @@ func (mock *MongoDBMock) GetDatasetCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	mock.lockGetDataset.RLock()
+	lockMongoDBMockGetDataset.RLock()
 	calls = mock.calls.GetDataset
-	mock.lockGetDataset.RUnlock()
+	lockMongoDBMockGetDataset.RUnlock()
 	return calls
 }
 
@@ -920,9 +935,9 @@ func (mock *MongoDBMock) GetDatasets(ctx context.Context, offset int, limit int,
 		Limit:      limit,
 		Authorised: authorised,
 	}
-	mock.lockGetDatasets.Lock()
+	lockMongoDBMockGetDatasets.Lock()
 	mock.calls.GetDatasets = append(mock.calls.GetDatasets, callInfo)
-	mock.lockGetDatasets.Unlock()
+	lockMongoDBMockGetDatasets.Unlock()
 	return mock.GetDatasetsFunc(ctx, offset, limit, authorised)
 }
 
@@ -941,9 +956,9 @@ func (mock *MongoDBMock) GetDatasetsCalls() []struct {
 		Limit      int
 		Authorised bool
 	}
-	mock.lockGetDatasets.RLock()
+	lockMongoDBMockGetDatasets.RLock()
 	calls = mock.calls.GetDatasets
-	mock.lockGetDatasets.RUnlock()
+	lockMongoDBMockGetDatasets.RUnlock()
 	return calls
 }
 
@@ -963,9 +978,9 @@ func (mock *MongoDBMock) GetDimensionOptions(version *models.Version, dimension 
 		Offset:    offset,
 		Limit:     limit,
 	}
-	mock.lockGetDimensionOptions.Lock()
+	lockMongoDBMockGetDimensionOptions.Lock()
 	mock.calls.GetDimensionOptions = append(mock.calls.GetDimensionOptions, callInfo)
-	mock.lockGetDimensionOptions.Unlock()
+	lockMongoDBMockGetDimensionOptions.Unlock()
 	return mock.GetDimensionOptionsFunc(version, dimension, offset, limit)
 }
 
@@ -984,9 +999,9 @@ func (mock *MongoDBMock) GetDimensionOptionsCalls() []struct {
 		Offset    int
 		Limit     int
 	}
-	mock.lockGetDimensionOptions.RLock()
+	lockMongoDBMockGetDimensionOptions.RLock()
 	calls = mock.calls.GetDimensionOptions
-	mock.lockGetDimensionOptions.RUnlock()
+	lockMongoDBMockGetDimensionOptions.RUnlock()
 	return calls
 }
 
@@ -1004,9 +1019,9 @@ func (mock *MongoDBMock) GetDimensionOptionsFromIDs(version *models.Version, dim
 		Dimension: dimension,
 		Ids:       ids,
 	}
-	mock.lockGetDimensionOptionsFromIDs.Lock()
+	lockMongoDBMockGetDimensionOptionsFromIDs.Lock()
 	mock.calls.GetDimensionOptionsFromIDs = append(mock.calls.GetDimensionOptionsFromIDs, callInfo)
-	mock.lockGetDimensionOptionsFromIDs.Unlock()
+	lockMongoDBMockGetDimensionOptionsFromIDs.Unlock()
 	return mock.GetDimensionOptionsFromIDsFunc(version, dimension, ids)
 }
 
@@ -1023,9 +1038,9 @@ func (mock *MongoDBMock) GetDimensionOptionsFromIDsCalls() []struct {
 		Dimension string
 		Ids       []string
 	}
-	mock.lockGetDimensionOptionsFromIDs.RLock()
+	lockMongoDBMockGetDimensionOptionsFromIDs.RLock()
 	calls = mock.calls.GetDimensionOptionsFromIDs
-	mock.lockGetDimensionOptionsFromIDs.RUnlock()
+	lockMongoDBMockGetDimensionOptionsFromIDs.RUnlock()
 	return calls
 }
 
@@ -1041,9 +1056,9 @@ func (mock *MongoDBMock) GetDimensions(datasetID string, versionID string) ([]bs
 		DatasetID: datasetID,
 		VersionID: versionID,
 	}
-	mock.lockGetDimensions.Lock()
+	lockMongoDBMockGetDimensions.Lock()
 	mock.calls.GetDimensions = append(mock.calls.GetDimensions, callInfo)
-	mock.lockGetDimensions.Unlock()
+	lockMongoDBMockGetDimensions.Unlock()
 	return mock.GetDimensionsFunc(datasetID, versionID)
 }
 
@@ -1058,40 +1073,52 @@ func (mock *MongoDBMock) GetDimensionsCalls() []struct {
 		DatasetID string
 		VersionID string
 	}
-	mock.lockGetDimensions.RLock()
+	lockMongoDBMockGetDimensions.RLock()
 	calls = mock.calls.GetDimensions
-	mock.lockGetDimensions.RUnlock()
+	lockMongoDBMockGetDimensions.RUnlock()
 	return calls
 }
 
 // GetDimensionsFromInstance calls GetDimensionsFromInstanceFunc.
-func (mock *MongoDBMock) GetDimensionsFromInstance(ID string) (*models.DimensionNodeResults, error) {
+func (mock *MongoDBMock) GetDimensionsFromInstance(ctx context.Context, ID string, offset int, limit int) ([]*models.DimensionOption, int, error) {
 	if mock.GetDimensionsFromInstanceFunc == nil {
 		panic("MongoDBMock.GetDimensionsFromInstanceFunc: method is nil but MongoDB.GetDimensionsFromInstance was just called")
 	}
 	callInfo := struct {
-		ID string
+		Ctx    context.Context
+		ID     string
+		Offset int
+		Limit  int
 	}{
-		ID: ID,
+		Ctx:    ctx,
+		ID:     ID,
+		Offset: offset,
+		Limit:  limit,
 	}
-	mock.lockGetDimensionsFromInstance.Lock()
+	lockMongoDBMockGetDimensionsFromInstance.Lock()
 	mock.calls.GetDimensionsFromInstance = append(mock.calls.GetDimensionsFromInstance, callInfo)
-	mock.lockGetDimensionsFromInstance.Unlock()
-	return mock.GetDimensionsFromInstanceFunc(ID)
+	lockMongoDBMockGetDimensionsFromInstance.Unlock()
+	return mock.GetDimensionsFromInstanceFunc(ctx, ID, offset, limit)
 }
 
 // GetDimensionsFromInstanceCalls gets all the calls that were made to GetDimensionsFromInstance.
 // Check the length with:
 //     len(mockedMongoDB.GetDimensionsFromInstanceCalls())
 func (mock *MongoDBMock) GetDimensionsFromInstanceCalls() []struct {
-	ID string
+	Ctx    context.Context
+	ID     string
+	Offset int
+	Limit  int
 } {
 	var calls []struct {
-		ID string
+		Ctx    context.Context
+		ID     string
+		Offset int
+		Limit  int
 	}
-	mock.lockGetDimensionsFromInstance.RLock()
+	lockMongoDBMockGetDimensionsFromInstance.RLock()
 	calls = mock.calls.GetDimensionsFromInstance
-	mock.lockGetDimensionsFromInstance.RUnlock()
+	lockMongoDBMockGetDimensionsFromInstance.RUnlock()
 	return calls
 }
 
@@ -1109,9 +1136,9 @@ func (mock *MongoDBMock) GetEdition(ID string, editionID string, state string) (
 		EditionID: editionID,
 		State:     state,
 	}
-	mock.lockGetEdition.Lock()
+	lockMongoDBMockGetEdition.Lock()
 	mock.calls.GetEdition = append(mock.calls.GetEdition, callInfo)
-	mock.lockGetEdition.Unlock()
+	lockMongoDBMockGetEdition.Unlock()
 	return mock.GetEditionFunc(ID, editionID, state)
 }
 
@@ -1128,9 +1155,9 @@ func (mock *MongoDBMock) GetEditionCalls() []struct {
 		EditionID string
 		State     string
 	}
-	mock.lockGetEdition.RLock()
+	lockMongoDBMockGetEdition.RLock()
 	calls = mock.calls.GetEdition
-	mock.lockGetEdition.RUnlock()
+	lockMongoDBMockGetEdition.RUnlock()
 	return calls
 }
 
@@ -1154,9 +1181,9 @@ func (mock *MongoDBMock) GetEditions(ctx context.Context, ID string, state strin
 		Limit:      limit,
 		Authorised: authorised,
 	}
-	mock.lockGetEditions.Lock()
+	lockMongoDBMockGetEditions.Lock()
 	mock.calls.GetEditions = append(mock.calls.GetEditions, callInfo)
-	mock.lockGetEditions.Unlock()
+	lockMongoDBMockGetEditions.Unlock()
 	return mock.GetEditionsFunc(ctx, ID, state, offset, limit, authorised)
 }
 
@@ -1179,9 +1206,9 @@ func (mock *MongoDBMock) GetEditionsCalls() []struct {
 		Limit      int
 		Authorised bool
 	}
-	mock.lockGetEditions.RLock()
+	lockMongoDBMockGetEditions.RLock()
 	calls = mock.calls.GetEditions
-	mock.lockGetEditions.RUnlock()
+	lockMongoDBMockGetEditions.RUnlock()
 	return calls
 }
 
@@ -1195,9 +1222,9 @@ func (mock *MongoDBMock) GetInstance(ID string) (*models.Instance, error) {
 	}{
 		ID: ID,
 	}
-	mock.lockGetInstance.Lock()
+	lockMongoDBMockGetInstance.Lock()
 	mock.calls.GetInstance = append(mock.calls.GetInstance, callInfo)
-	mock.lockGetInstance.Unlock()
+	lockMongoDBMockGetInstance.Unlock()
 	return mock.GetInstanceFunc(ID)
 }
 
@@ -1210,9 +1237,9 @@ func (mock *MongoDBMock) GetInstanceCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	mock.lockGetInstance.RLock()
+	lockMongoDBMockGetInstance.RLock()
 	calls = mock.calls.GetInstance
-	mock.lockGetInstance.RUnlock()
+	lockMongoDBMockGetInstance.RUnlock()
 	return calls
 }
 
@@ -1234,9 +1261,9 @@ func (mock *MongoDBMock) GetInstances(ctx context.Context, states []string, data
 		Offset:   offset,
 		Limit:    limit,
 	}
-	mock.lockGetInstances.Lock()
+	lockMongoDBMockGetInstances.Lock()
 	mock.calls.GetInstances = append(mock.calls.GetInstances, callInfo)
-	mock.lockGetInstances.Unlock()
+	lockMongoDBMockGetInstances.Unlock()
 	return mock.GetInstancesFunc(ctx, states, datasets, offset, limit)
 }
 
@@ -1257,9 +1284,9 @@ func (mock *MongoDBMock) GetInstancesCalls() []struct {
 		Offset   int
 		Limit    int
 	}
-	mock.lockGetInstances.RLock()
+	lockMongoDBMockGetInstances.RLock()
 	calls = mock.calls.GetInstances
-	mock.lockGetInstances.RUnlock()
+	lockMongoDBMockGetInstances.RUnlock()
 	return calls
 }
 
@@ -1275,9 +1302,9 @@ func (mock *MongoDBMock) GetNextVersion(datasetID string, editionID string) (int
 		DatasetID: datasetID,
 		EditionID: editionID,
 	}
-	mock.lockGetNextVersion.Lock()
+	lockMongoDBMockGetNextVersion.Lock()
 	mock.calls.GetNextVersion = append(mock.calls.GetNextVersion, callInfo)
-	mock.lockGetNextVersion.Unlock()
+	lockMongoDBMockGetNextVersion.Unlock()
 	return mock.GetNextVersionFunc(datasetID, editionID)
 }
 
@@ -1292,44 +1319,56 @@ func (mock *MongoDBMock) GetNextVersionCalls() []struct {
 		DatasetID string
 		EditionID string
 	}
-	mock.lockGetNextVersion.RLock()
+	lockMongoDBMockGetNextVersion.RLock()
 	calls = mock.calls.GetNextVersion
-	mock.lockGetNextVersion.RUnlock()
+	lockMongoDBMockGetNextVersion.RUnlock()
 	return calls
 }
 
 // GetUniqueDimensionAndOptions calls GetUniqueDimensionAndOptionsFunc.
-func (mock *MongoDBMock) GetUniqueDimensionAndOptions(ID string, dimension string) (*models.DimensionValues, error) {
+func (mock *MongoDBMock) GetUniqueDimensionAndOptions(ctx context.Context, ID string, dimension string, offset int, limit int) ([]*string, int, error) {
 	if mock.GetUniqueDimensionAndOptionsFunc == nil {
 		panic("MongoDBMock.GetUniqueDimensionAndOptionsFunc: method is nil but MongoDB.GetUniqueDimensionAndOptions was just called")
 	}
 	callInfo := struct {
+		Ctx       context.Context
 		ID        string
 		Dimension string
+		Offset    int
+		Limit     int
 	}{
+		Ctx:       ctx,
 		ID:        ID,
 		Dimension: dimension,
+		Offset:    offset,
+		Limit:     limit,
 	}
-	mock.lockGetUniqueDimensionAndOptions.Lock()
+	lockMongoDBMockGetUniqueDimensionAndOptions.Lock()
 	mock.calls.GetUniqueDimensionAndOptions = append(mock.calls.GetUniqueDimensionAndOptions, callInfo)
-	mock.lockGetUniqueDimensionAndOptions.Unlock()
-	return mock.GetUniqueDimensionAndOptionsFunc(ID, dimension)
+	lockMongoDBMockGetUniqueDimensionAndOptions.Unlock()
+	return mock.GetUniqueDimensionAndOptionsFunc(ctx, ID, dimension, offset, limit)
 }
 
 // GetUniqueDimensionAndOptionsCalls gets all the calls that were made to GetUniqueDimensionAndOptions.
 // Check the length with:
 //     len(mockedMongoDB.GetUniqueDimensionAndOptionsCalls())
 func (mock *MongoDBMock) GetUniqueDimensionAndOptionsCalls() []struct {
+	Ctx       context.Context
 	ID        string
 	Dimension string
+	Offset    int
+	Limit     int
 } {
 	var calls []struct {
+		Ctx       context.Context
 		ID        string
 		Dimension string
+		Offset    int
+		Limit     int
 	}
-	mock.lockGetUniqueDimensionAndOptions.RLock()
+	lockMongoDBMockGetUniqueDimensionAndOptions.RLock()
 	calls = mock.calls.GetUniqueDimensionAndOptions
-	mock.lockGetUniqueDimensionAndOptions.RUnlock()
+	lockMongoDBMockGetUniqueDimensionAndOptions.RUnlock()
 	return calls
 }
 
@@ -1349,9 +1388,9 @@ func (mock *MongoDBMock) GetVersion(datasetID string, editionID string, version 
 		Version:   version,
 		State:     state,
 	}
-	mock.lockGetVersion.Lock()
+	lockMongoDBMockGetVersion.Lock()
 	mock.calls.GetVersion = append(mock.calls.GetVersion, callInfo)
-	mock.lockGetVersion.Unlock()
+	lockMongoDBMockGetVersion.Unlock()
 	return mock.GetVersionFunc(datasetID, editionID, version, state)
 }
 
@@ -1370,9 +1409,9 @@ func (mock *MongoDBMock) GetVersionCalls() []struct {
 		Version   string
 		State     string
 	}
-	mock.lockGetVersion.RLock()
+	lockMongoDBMockGetVersion.RLock()
 	calls = mock.calls.GetVersion
-	mock.lockGetVersion.RUnlock()
+	lockMongoDBMockGetVersion.RUnlock()
 	return calls
 }
 
@@ -1396,9 +1435,9 @@ func (mock *MongoDBMock) GetVersions(ctx context.Context, datasetID string, edit
 		Offset:    offset,
 		Limit:     limit,
 	}
-	mock.lockGetVersions.Lock()
+	lockMongoDBMockGetVersions.Lock()
 	mock.calls.GetVersions = append(mock.calls.GetVersions, callInfo)
-	mock.lockGetVersions.Unlock()
+	lockMongoDBMockGetVersions.Unlock()
 	return mock.GetVersionsFunc(ctx, datasetID, editionID, state, offset, limit)
 }
 
@@ -1421,9 +1460,9 @@ func (mock *MongoDBMock) GetVersionsCalls() []struct {
 		Offset    int
 		Limit     int
 	}
-	mock.lockGetVersions.RLock()
+	lockMongoDBMockGetVersions.RLock()
 	calls = mock.calls.GetVersions
-	mock.lockGetVersions.RUnlock()
+	lockMongoDBMockGetVersions.RUnlock()
 	return calls
 }
 
@@ -1441,9 +1480,9 @@ func (mock *MongoDBMock) UpdateBuildHierarchyTaskState(id string, dimension stri
 		Dimension: dimension,
 		State:     state,
 	}
-	mock.lockUpdateBuildHierarchyTaskState.Lock()
+	lockMongoDBMockUpdateBuildHierarchyTaskState.Lock()
 	mock.calls.UpdateBuildHierarchyTaskState = append(mock.calls.UpdateBuildHierarchyTaskState, callInfo)
-	mock.lockUpdateBuildHierarchyTaskState.Unlock()
+	lockMongoDBMockUpdateBuildHierarchyTaskState.Unlock()
 	return mock.UpdateBuildHierarchyTaskStateFunc(id, dimension, state)
 }
 
@@ -1460,9 +1499,9 @@ func (mock *MongoDBMock) UpdateBuildHierarchyTaskStateCalls() []struct {
 		Dimension string
 		State     string
 	}
-	mock.lockUpdateBuildHierarchyTaskState.RLock()
+	lockMongoDBMockUpdateBuildHierarchyTaskState.RLock()
 	calls = mock.calls.UpdateBuildHierarchyTaskState
-	mock.lockUpdateBuildHierarchyTaskState.RUnlock()
+	lockMongoDBMockUpdateBuildHierarchyTaskState.RUnlock()
 	return calls
 }
 
@@ -1480,9 +1519,9 @@ func (mock *MongoDBMock) UpdateBuildSearchTaskState(id string, dimension string,
 		Dimension: dimension,
 		State:     state,
 	}
-	mock.lockUpdateBuildSearchTaskState.Lock()
+	lockMongoDBMockUpdateBuildSearchTaskState.Lock()
 	mock.calls.UpdateBuildSearchTaskState = append(mock.calls.UpdateBuildSearchTaskState, callInfo)
-	mock.lockUpdateBuildSearchTaskState.Unlock()
+	lockMongoDBMockUpdateBuildSearchTaskState.Unlock()
 	return mock.UpdateBuildSearchTaskStateFunc(id, dimension, state)
 }
 
@@ -1499,9 +1538,9 @@ func (mock *MongoDBMock) UpdateBuildSearchTaskStateCalls() []struct {
 		Dimension string
 		State     string
 	}
-	mock.lockUpdateBuildSearchTaskState.RLock()
+	lockMongoDBMockUpdateBuildSearchTaskState.RLock()
 	calls = mock.calls.UpdateBuildSearchTaskState
-	mock.lockUpdateBuildSearchTaskState.RUnlock()
+	lockMongoDBMockUpdateBuildSearchTaskState.RUnlock()
 	return calls
 }
 
@@ -1521,9 +1560,9 @@ func (mock *MongoDBMock) UpdateDataset(ctx context.Context, ID string, dataset *
 		Dataset:      dataset,
 		CurrentState: currentState,
 	}
-	mock.lockUpdateDataset.Lock()
+	lockMongoDBMockUpdateDataset.Lock()
 	mock.calls.UpdateDataset = append(mock.calls.UpdateDataset, callInfo)
-	mock.lockUpdateDataset.Unlock()
+	lockMongoDBMockUpdateDataset.Unlock()
 	return mock.UpdateDatasetFunc(ctx, ID, dataset, currentState)
 }
 
@@ -1542,9 +1581,9 @@ func (mock *MongoDBMock) UpdateDatasetCalls() []struct {
 		Dataset      *models.Dataset
 		CurrentState string
 	}
-	mock.lockUpdateDataset.RLock()
+	lockMongoDBMockUpdateDataset.RLock()
 	calls = mock.calls.UpdateDataset
-	mock.lockUpdateDataset.RUnlock()
+	lockMongoDBMockUpdateDataset.RUnlock()
 	return calls
 }
 
@@ -1562,9 +1601,9 @@ func (mock *MongoDBMock) UpdateDatasetWithAssociation(ID string, state string, v
 		State:   state,
 		Version: version,
 	}
-	mock.lockUpdateDatasetWithAssociation.Lock()
+	lockMongoDBMockUpdateDatasetWithAssociation.Lock()
 	mock.calls.UpdateDatasetWithAssociation = append(mock.calls.UpdateDatasetWithAssociation, callInfo)
-	mock.lockUpdateDatasetWithAssociation.Unlock()
+	lockMongoDBMockUpdateDatasetWithAssociation.Unlock()
 	return mock.UpdateDatasetWithAssociationFunc(ID, state, version)
 }
 
@@ -1581,9 +1620,9 @@ func (mock *MongoDBMock) UpdateDatasetWithAssociationCalls() []struct {
 		State   string
 		Version *models.Version
 	}
-	mock.lockUpdateDatasetWithAssociation.RLock()
+	lockMongoDBMockUpdateDatasetWithAssociation.RLock()
 	calls = mock.calls.UpdateDatasetWithAssociation
-	mock.lockUpdateDatasetWithAssociation.RUnlock()
+	lockMongoDBMockUpdateDatasetWithAssociation.RUnlock()
 	return calls
 }
 
@@ -1597,9 +1636,9 @@ func (mock *MongoDBMock) UpdateDimensionNodeIDAndOrder(dimension *models.Dimensi
 	}{
 		Dimension: dimension,
 	}
-	mock.lockUpdateDimensionNodeIDAndOrder.Lock()
+	lockMongoDBMockUpdateDimensionNodeIDAndOrder.Lock()
 	mock.calls.UpdateDimensionNodeIDAndOrder = append(mock.calls.UpdateDimensionNodeIDAndOrder, callInfo)
-	mock.lockUpdateDimensionNodeIDAndOrder.Unlock()
+	lockMongoDBMockUpdateDimensionNodeIDAndOrder.Unlock()
 	return mock.UpdateDimensionNodeIDAndOrderFunc(dimension)
 }
 
@@ -1612,9 +1651,9 @@ func (mock *MongoDBMock) UpdateDimensionNodeIDAndOrderCalls() []struct {
 	var calls []struct {
 		Dimension *models.DimensionOption
 	}
-	mock.lockUpdateDimensionNodeIDAndOrder.RLock()
+	lockMongoDBMockUpdateDimensionNodeIDAndOrder.RLock()
 	calls = mock.calls.UpdateDimensionNodeIDAndOrder
-	mock.lockUpdateDimensionNodeIDAndOrder.RUnlock()
+	lockMongoDBMockUpdateDimensionNodeIDAndOrder.RUnlock()
 	return calls
 }
 
@@ -1630,9 +1669,9 @@ func (mock *MongoDBMock) UpdateImportObservationsTaskState(id string, state stri
 		ID:    id,
 		State: state,
 	}
-	mock.lockUpdateImportObservationsTaskState.Lock()
+	lockMongoDBMockUpdateImportObservationsTaskState.Lock()
 	mock.calls.UpdateImportObservationsTaskState = append(mock.calls.UpdateImportObservationsTaskState, callInfo)
-	mock.lockUpdateImportObservationsTaskState.Unlock()
+	lockMongoDBMockUpdateImportObservationsTaskState.Unlock()
 	return mock.UpdateImportObservationsTaskStateFunc(id, state)
 }
 
@@ -1647,9 +1686,9 @@ func (mock *MongoDBMock) UpdateImportObservationsTaskStateCalls() []struct {
 		ID    string
 		State string
 	}
-	mock.lockUpdateImportObservationsTaskState.RLock()
+	lockMongoDBMockUpdateImportObservationsTaskState.RLock()
 	calls = mock.calls.UpdateImportObservationsTaskState
-	mock.lockUpdateImportObservationsTaskState.RUnlock()
+	lockMongoDBMockUpdateImportObservationsTaskState.RUnlock()
 	return calls
 }
 
@@ -1667,9 +1706,9 @@ func (mock *MongoDBMock) UpdateInstance(ctx context.Context, ID string, instance
 		ID:       ID,
 		Instance: instance,
 	}
-	mock.lockUpdateInstance.Lock()
+	lockMongoDBMockUpdateInstance.Lock()
 	mock.calls.UpdateInstance = append(mock.calls.UpdateInstance, callInfo)
-	mock.lockUpdateInstance.Unlock()
+	lockMongoDBMockUpdateInstance.Unlock()
 	return mock.UpdateInstanceFunc(ctx, ID, instance)
 }
 
@@ -1686,9 +1725,9 @@ func (mock *MongoDBMock) UpdateInstanceCalls() []struct {
 		ID       string
 		Instance *models.Instance
 	}
-	mock.lockUpdateInstance.RLock()
+	lockMongoDBMockUpdateInstance.RLock()
 	calls = mock.calls.UpdateInstance
-	mock.lockUpdateInstance.RUnlock()
+	lockMongoDBMockUpdateInstance.RUnlock()
 	return calls
 }
 
@@ -1704,9 +1743,9 @@ func (mock *MongoDBMock) UpdateObservationInserted(ID string, observationInserte
 		ID:                  ID,
 		ObservationInserted: observationInserted,
 	}
-	mock.lockUpdateObservationInserted.Lock()
+	lockMongoDBMockUpdateObservationInserted.Lock()
 	mock.calls.UpdateObservationInserted = append(mock.calls.UpdateObservationInserted, callInfo)
-	mock.lockUpdateObservationInserted.Unlock()
+	lockMongoDBMockUpdateObservationInserted.Unlock()
 	return mock.UpdateObservationInsertedFunc(ID, observationInserted)
 }
 
@@ -1721,9 +1760,9 @@ func (mock *MongoDBMock) UpdateObservationInsertedCalls() []struct {
 		ID                  string
 		ObservationInserted int64
 	}
-	mock.lockUpdateObservationInserted.RLock()
+	lockMongoDBMockUpdateObservationInserted.RLock()
 	calls = mock.calls.UpdateObservationInserted
-	mock.lockUpdateObservationInserted.RUnlock()
+	lockMongoDBMockUpdateObservationInserted.RUnlock()
 	return calls
 }
 
@@ -1739,9 +1778,9 @@ func (mock *MongoDBMock) UpdateVersion(ID string, version *models.Version) error
 		ID:      ID,
 		Version: version,
 	}
-	mock.lockUpdateVersion.Lock()
+	lockMongoDBMockUpdateVersion.Lock()
 	mock.calls.UpdateVersion = append(mock.calls.UpdateVersion, callInfo)
-	mock.lockUpdateVersion.Unlock()
+	lockMongoDBMockUpdateVersion.Unlock()
 	return mock.UpdateVersionFunc(ID, version)
 }
 
@@ -1756,9 +1795,9 @@ func (mock *MongoDBMock) UpdateVersionCalls() []struct {
 		ID      string
 		Version *models.Version
 	}
-	mock.lockUpdateVersion.RLock()
+	lockMongoDBMockUpdateVersion.RLock()
 	calls = mock.calls.UpdateVersion
-	mock.lockUpdateVersion.RUnlock()
+	lockMongoDBMockUpdateVersion.RUnlock()
 	return calls
 }
 
@@ -1774,9 +1813,9 @@ func (mock *MongoDBMock) UpsertContact(ID string, update interface{}) error {
 		ID:     ID,
 		Update: update,
 	}
-	mock.lockUpsertContact.Lock()
+	lockMongoDBMockUpsertContact.Lock()
 	mock.calls.UpsertContact = append(mock.calls.UpsertContact, callInfo)
-	mock.lockUpsertContact.Unlock()
+	lockMongoDBMockUpsertContact.Unlock()
 	return mock.UpsertContactFunc(ID, update)
 }
 
@@ -1791,9 +1830,9 @@ func (mock *MongoDBMock) UpsertContactCalls() []struct {
 		ID     string
 		Update interface{}
 	}
-	mock.lockUpsertContact.RLock()
+	lockMongoDBMockUpsertContact.RLock()
 	calls = mock.calls.UpsertContact
-	mock.lockUpsertContact.RUnlock()
+	lockMongoDBMockUpsertContact.RUnlock()
 	return calls
 }
 
@@ -1809,9 +1848,9 @@ func (mock *MongoDBMock) UpsertDataset(ID string, datasetDoc *models.DatasetUpda
 		ID:         ID,
 		DatasetDoc: datasetDoc,
 	}
-	mock.lockUpsertDataset.Lock()
+	lockMongoDBMockUpsertDataset.Lock()
 	mock.calls.UpsertDataset = append(mock.calls.UpsertDataset, callInfo)
-	mock.lockUpsertDataset.Unlock()
+	lockMongoDBMockUpsertDataset.Unlock()
 	return mock.UpsertDatasetFunc(ID, datasetDoc)
 }
 
@@ -1826,9 +1865,9 @@ func (mock *MongoDBMock) UpsertDatasetCalls() []struct {
 		ID         string
 		DatasetDoc *models.DatasetUpdate
 	}
-	mock.lockUpsertDataset.RLock()
+	lockMongoDBMockUpsertDataset.RLock()
 	calls = mock.calls.UpsertDataset
-	mock.lockUpsertDataset.RUnlock()
+	lockMongoDBMockUpsertDataset.RUnlock()
 	return calls
 }
 
@@ -1846,9 +1885,9 @@ func (mock *MongoDBMock) UpsertEdition(datasetID string, edition string, edition
 		Edition:    edition,
 		EditionDoc: editionDoc,
 	}
-	mock.lockUpsertEdition.Lock()
+	lockMongoDBMockUpsertEdition.Lock()
 	mock.calls.UpsertEdition = append(mock.calls.UpsertEdition, callInfo)
-	mock.lockUpsertEdition.Unlock()
+	lockMongoDBMockUpsertEdition.Unlock()
 	return mock.UpsertEditionFunc(datasetID, edition, editionDoc)
 }
 
@@ -1865,9 +1904,9 @@ func (mock *MongoDBMock) UpsertEditionCalls() []struct {
 		Edition    string
 		EditionDoc *models.EditionUpdate
 	}
-	mock.lockUpsertEdition.RLock()
+	lockMongoDBMockUpsertEdition.RLock()
 	calls = mock.calls.UpsertEdition
-	mock.lockUpsertEdition.RUnlock()
+	lockMongoDBMockUpsertEdition.RUnlock()
 	return calls
 }
 
@@ -1883,9 +1922,9 @@ func (mock *MongoDBMock) UpsertVersion(ID string, versionDoc *models.Version) er
 		ID:         ID,
 		VersionDoc: versionDoc,
 	}
-	mock.lockUpsertVersion.Lock()
+	lockMongoDBMockUpsertVersion.Lock()
 	mock.calls.UpsertVersion = append(mock.calls.UpsertVersion, callInfo)
-	mock.lockUpsertVersion.Unlock()
+	lockMongoDBMockUpsertVersion.Unlock()
 	return mock.UpsertVersionFunc(ID, versionDoc)
 }
 
@@ -1900,8 +1939,8 @@ func (mock *MongoDBMock) UpsertVersionCalls() []struct {
 		ID         string
 		VersionDoc *models.Version
 	}
-	mock.lockUpsertVersion.RLock()
+	lockMongoDBMockUpsertVersion.RLock()
 	calls = mock.calls.UpsertVersion
-	mock.lockUpsertVersion.RUnlock()
+	lockMongoDBMockUpsertVersion.RUnlock()
 	return calls
 }

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -963,7 +963,7 @@ func (mock *MongoDBMock) GetDatasetsCalls() []struct {
 }
 
 // GetDimensionOptions calls GetDimensionOptionsFunc.
-func (mock *MongoDBMock) GetDimensionOptions(version *models.Version, dimension string, offset int, limit int) ([]*models.PublicDimensionOption, int, error) {
+func (mock *MongoDBMock) GetDimensionOptions(ctx context.Context, version *models.Version, dimension string, offset int, limit int) ([]*models.PublicDimensionOption, int, error) {
 	if mock.GetDimensionOptionsFunc == nil {
 		panic("MongoDBMock.GetDimensionOptionsFunc: method is nil but MongoDB.GetDimensionOptions was just called")
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -45,12 +45,25 @@ func GetQueryParamListValues(queryVars url.Values, varKey string, maxNumItems in
 // utility function to cut a slice according to the provided offset and limit.
 func Slice(full []models.Dimension, offset, limit int) (sliced []models.Dimension) {
 	end := offset + limit
-	if limit == 0 || end > len(full) {
+	if end > len(full) {
 		end = len(full)
 	}
 
 	if offset > len(full) {
 		return []models.Dimension{}
+	}
+	return full[offset:end]
+}
+
+// utility function to cut a slice of *strings according to the provided offset and limit.
+func SliceStr(full []*string, offset, limit int) (sliced []*string) {
+	end := offset + limit
+	if end > len(full) {
+		end = len(full)
+	}
+
+	if offset > len(full) {
+		return []*string{}
 	}
 	return full[offset:end]
 }


### PR DESCRIPTION
### What
Trello card: https://trello.com/c/yOURvD7U/5128-add-pagination-to-endpoints-in-dp-dataset-api

- Wrap handlers with pagination logic:
  - GetDimensionsHandler
  - GetUniqueDimensionAndOptionsHandler
- Refactored dimensions.go handlers into single functions.
- Introduced QueryPage from dp-mongodb for the following queries:
  - GetDatasets
  - GetEditions
  - GetVersions
  - GetDimensionOptions
  - GetInstances
  - GetDimensionsFromInstance (**newly paginated**)
  - GetUniqueDimensionAndOptions (**newly paginated**)
- Make sure all endpoints return empty arrays of items when no item is to be returned, instead of nil pointers. Fixed component testing for `Scenario: GET dimensions with no options in private mode`
- Introduced component testing `instance_dimensions` to test the newly paginated endpoints

### How to review

- Make sure unit tests pass
- Make sure code changes make sense

- (optional - Info only): I tested all paginated endpoints mentioned above (plus get dataset dimensions, which has a slightly different logic) by running `make debug` and validated that they are working with Postman.

### Who can review

Anyone
