### PR TITLE
remove bin file, amend createRequestWithAuth and all the calls to it …

### DIFF
--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -59,12 +59,12 @@ func GetAPIWithMocks(mockedDataStore store.Storer, mockedGeneratedDownloads Down
 	return Setup(testContext, cfg, mux.NewRouter(), store.DataStore{Backend: mockedDataStore}, urlBuilder, mockedGeneratedDownloads, datasetPermissions, permissions)
 }
 
-func createRequestWithAuth(method, URL string, body io.Reader) (*http.Request, error) {
+func createRequestWithAuth(method, URL string, body io.Reader) *http.Request {
 	r := httptest.NewRequest(method, URL, body)
 	ctx := r.Context()
 	ctx = dprequest.SetCaller(ctx, "someone@ons.gov.uk")
 	r = r.WithContext(ctx)
-	return r, nil
+	return r
 }
 
 func TestGetDatasetsReturnsOK(t *testing.T) {
@@ -145,8 +145,7 @@ func TestGetDatasetReturnsOK(t *testing.T) {
 	})
 
 	Convey("When dataset document has only a next sub document and request is authorised return status 200", t, func() {
-		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/123-456", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets/123-456", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -237,8 +236,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 	Convey("A successful request to post dataset returns 201 OK response", t, func() {
 		var b string
 		b = datasetPayload
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -263,7 +261,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 2)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -272,8 +270,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": "", "title": "test"}}`
 
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -298,7 +295,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 2)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -307,8 +304,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": "http://domain.com/path", "title": "test"}}`
 
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -333,7 +329,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 2)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -342,8 +338,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": "/path", "title": "test"}}`
 
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -368,7 +363,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 2)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -377,8 +372,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": "http://domain.com/", "title": "test"}}`
 
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -403,7 +397,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 2)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -412,8 +406,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": "domain.com", "title": "test"}}`
 
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -438,7 +431,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 2)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -449,8 +442,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 	Convey("When the request contain malformed json a bad request status is returned", t, func() {
 		var b string
 		b = "{"
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -475,7 +467,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -483,8 +475,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 	Convey("When the api cannot connect to datastore return an internal server error", t, func() {
 		var b string
 		b = datasetPayload
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -508,7 +499,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -547,8 +538,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 	Convey("When the dataset already exists and a request is sent to create the same dataset return status forbidden", t, func() {
 		var b string
 		b = datasetPayload
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -577,7 +567,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -586,8 +576,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		var b string
 		b = `{"contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"census","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"CensusEthnicity","theme":"population","state":"completed","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","url":"https://www.ons.gov.uk/"},"type":"filterable","nomis_reference_url":"https://www.nomis.co.uk"}`
 
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -610,7 +599,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -619,8 +608,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": ":not a link", "title": "test"}}`
 
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -643,7 +631,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -652,8 +640,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": "http://", "title": "test"}}`
 
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -676,7 +663,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -685,8 +672,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": "http:///path", "title": "test"}}`
 
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -709,7 +695,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -718,8 +704,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		var b string
 		b = `{"contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"census","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"CensusEthnicity","theme":"population","state":"completed","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","url":"https://www.ons.gov.uk/"},"type":"nomis_filterable"}`
 
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -742,7 +727,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -751,8 +736,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		var b string
 		b = `{"contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"census","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"CensusEthnicity","theme":"population","state":"completed","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","url":"https://www.ons.gov.uk/"},"type":""}`
 		res := `{"id":"123123","next":{"contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"census","id":"123123","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"},"editions":{"href":"http://localhost:22000/datasets/123123/editions"},"self":{"href":"http://localhost:22000/datasets/123123"}},"next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department"},"state":"created","theme":"population","title":"CensusEthnicity","type":"filterable"}}`
-		r, err := createRequestWithAuth("POST", "http://localhost:22000/datasets/123123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -776,7 +760,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 2)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -788,8 +772,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 	Convey("A successful request to put dataset returns 200 OK response", t, func() {
 		var b string
 		b = datasetPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -819,7 +802,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 2)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -830,8 +813,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		var b string
 		b = `{"contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"census","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"CensusEthnicity","theme":"population","state":"completed","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","url":"https://www.ons.gov.uk/"},"type":"filterable","nomis_reference_url":"https://www.nomis.co.uk"}`
 
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -854,7 +836,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 1)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -863,8 +845,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": "", "title": "test"}}`
 
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -888,7 +869,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 1)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -897,8 +878,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": "http://domain.com/path", "title": "test"}}`
 
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -922,7 +902,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 1)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -931,8 +911,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": "/path", "title": "test"}}`
 
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -956,7 +935,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 1)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -965,8 +944,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": "http://domain.com/", "title": "test"}}`
 
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -990,7 +968,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 1)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -999,8 +977,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": "domain.com", "title": "test"}}`
 
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -1024,7 +1001,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 1)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1036,8 +1013,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 	Convey("When the request contain malformed json a bad request status is returned", t, func() {
 		var b string
 		b = "{"
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		datasetPermissions := getAuthorisationHandlerMock()
 		permissions := getAuthorisationHandlerMock()
@@ -1064,7 +1040,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1072,8 +1048,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 	Convey("When the api cannot connect to datastore return an internal server error", t, func() {
 		var b string
 		b = versionPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -1104,7 +1079,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 2)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1112,8 +1087,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 	Convey("When the dataset document cannot be found return status not found ", t, func() {
 		var b string
 		b = datasetPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -1140,7 +1114,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1149,8 +1123,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		var b string
 		b = `{"contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"census","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"CensusEthnicity","theme":"population","state":"completed","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","url":"https://www.ons.gov.uk/"},"nomis_reference_url":"https://www.nomis.co.uk"}`
 
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -1175,7 +1148,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1184,8 +1157,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": ":not a link", "title": "test"}}`
 
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -1210,7 +1182,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1219,8 +1191,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": "http://", "title": "test"}}`
 
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -1245,7 +1216,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1254,8 +1225,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		var b string
 		b = `{"contacts": [{"email": "testing@hotmail.com", "name": "John Cox", "telephone": "01623 456789"}], "description": "census", "links": {"access_rights": {"href": "http://ons.gov.uk/accessrights"}}, "title": "CensusEthnicity", "theme": "population", "state": "completed", "next_release": "2016-04-04", "publisher": {"name": "The office of national statistics", "type": "government department", "url": "https://www.ons.gov.uk/"}, "type": "nomis", "nomis_reference_url": "https://www.nomis.co.uk", "qmi": {"href": "http:///path", "title": "test"}}`
 
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -1280,7 +1250,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1324,8 +1294,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 func TestDeleteDatasetReturnsSuccessfully(t *testing.T) {
 	t.Parallel()
 	Convey("A successful request to delete dataset returns 200 OK response", t, func() {
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1354,8 +1323,7 @@ func TestDeleteDatasetReturnsSuccessfully(t *testing.T) {
 	})
 
 	Convey("A successful request to delete dataset with editions returns 200 OK response", t, func() {
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1393,8 +1361,7 @@ func TestDeleteDatasetReturnsSuccessfully(t *testing.T) {
 func TestDeleteDatasetReturnsError(t *testing.T) {
 	t.Parallel()
 	Convey("When a request to delete a published dataset return status forbidden", t, func() {
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1424,8 +1391,7 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 	})
 
 	Convey("When the api cannot connect to datastore return an internal server error", t, func() {
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123", nil)
 
 		w := httptest.NewRecorder()
 
@@ -1455,8 +1421,7 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 	})
 
 	Convey("When the dataset document cannot be found return status not found ", t, func() {
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123", nil)
 
 		w := httptest.NewRecorder()
 
@@ -1487,8 +1452,7 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 	})
 
 	Convey("When the dataset document cannot be queried return status 500 ", t, func() {
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123", nil)
 
 		w := httptest.NewRecorder()
 

--- a/api/dimensions_test.go
+++ b/api/dimensions_test.go
@@ -146,7 +146,6 @@ func TestGetDimensionsReturnsErrors(t *testing.T) {
 }
 
 func TestGetDimensionOptionsReturnsOk(t *testing.T) {
-	t.Parallel()
 
 	Convey("Given a store with a dimension with 5 options", t, func() {
 

--- a/api/metadata_test.go
+++ b/api/metadata_test.go
@@ -81,8 +81,7 @@ func TestGetMetadataReturnsOk(t *testing.T) {
 		datasetDoc := createDatasetDoc()
 		versionDoc := createUnpublishedVersionDoc()
 
-		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/metadata", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/metadata", nil)
 
 		w := httptest.NewRecorder()
 
@@ -303,8 +302,7 @@ func TestGetMetadataReturnsError(t *testing.T) {
 
 		datasetDoc := createDatasetDoc()
 
-		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/metadata", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/metadata", nil)
 
 		w := httptest.NewRecorder()
 
@@ -336,8 +334,7 @@ func TestGetMetadataReturnsError(t *testing.T) {
 
 	Convey("When an edition document for an invalid version is requested returns invalid version error", t, func() {
 
-		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/123/editions/2017/versions/jjj/metadata", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets/123/editions/2017/versions/jjj/metadata", nil)
 
 		w := httptest.NewRecorder()
 
@@ -361,8 +358,7 @@ func TestGetMetadataReturnsError(t *testing.T) {
 
 	Convey("When an edition document for version zero is requested return an invalid version error", t, func() {
 
-		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/123/editions/2017/versions/0/metadata", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets/123/editions/2017/versions/0/metadata", nil)
 
 		w := httptest.NewRecorder()
 
@@ -386,8 +382,7 @@ func TestGetMetadataReturnsError(t *testing.T) {
 
 	Convey("When an edition document for a negative version is requested return an invalid version error", t, func() {
 
-		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/123/editions/2017/versions/-1/metadata", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets/123/editions/2017/versions/-1/metadata", nil)
 
 		w := httptest.NewRecorder()
 

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -509,8 +509,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 
 		var b string
 		b = versionPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -568,7 +567,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -582,8 +581,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 
 		var b string
 		b = versionAssociatedPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -626,7 +624,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -643,8 +641,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 
 		var b string
 		b = versionAssociatedPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -697,7 +694,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 1)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -711,8 +708,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 
 		var b string
 		b = versionPublishedPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -812,7 +808,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 1)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -821,8 +817,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		Convey("And downloads object contains only a csv object", func() {
 			var b string
 			b = `{"downloads": { "csv": { "public": "http://cmd-dev/test-site/cpih01", "size": "12", "href": "http://localhost:8080/cpih01"}}}`
-			r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-			So(err, ShouldBeNil)
+			r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
 			updateVersionDownloadTest(r)
 
@@ -835,13 +830,12 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 		Convey("And downloads object contains only a xls object", func() {
 			var b string
 			b = `{"downloads": { "xls": { "public": "http://cmd-dev/test-site/cpih01", "size": "12", "href": "http://localhost:8080/cpih01"}}}`
-			r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-			So(err, ShouldBeNil)
+			r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
 			updateVersionDownloadTest(r)
 
 			Convey("then the request body has been drained", func() {
-				_, err = r.Body.Read(make([]byte, 1))
+				_, err := r.Body.Read(make([]byte, 1))
 				So(err, ShouldEqual, io.EOF)
 			})
 		})
@@ -966,8 +960,7 @@ func TestPutVersionGenerateDownloadsError(t *testing.T) {
 		}
 
 		Convey("when put version is called with a valid request", func() {
-			r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(versionAssociatedPayload))
-			So(err, ShouldBeNil)
+			r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(versionAssociatedPayload))
 
 			w := httptest.NewRecorder()
 			cfg, err := config.Get()
@@ -1040,8 +1033,7 @@ func TestPutEmptyVersion(t *testing.T) {
 		}
 
 		Convey("when put version is called with an associated version with empty downloads", func() {
-			r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(versionAssociatedPayload))
-			So(err, ShouldBeNil)
+			r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(versionAssociatedPayload))
 
 			w := httptest.NewRecorder()
 
@@ -1084,8 +1076,7 @@ func TestPutEmptyVersion(t *testing.T) {
 		mockDownloadGenerator := &mocks.DownloadsGeneratorMock{}
 
 		Convey("when put version is called with an associated version with empty downloads", func() {
-			r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(versionAssociatedPayload))
-			So(err, ShouldBeNil)
+			r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(versionAssociatedPayload))
 			w := httptest.NewRecorder()
 
 			datasetPermissions := getAuthorisationHandlerMock()
@@ -1138,8 +1129,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		var b string
 		b = "{"
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1166,7 +1156,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1180,8 +1170,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		var b string
 		b = versionPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1208,7 +1197,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1222,8 +1211,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		var b string
 		b = versionPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/-1", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/-1", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1254,7 +1242,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1268,8 +1256,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		var b string
 		b = versionPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/0", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/0", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{}
@@ -1290,7 +1277,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1304,8 +1291,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		var b string
 		b = versionPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/kkk", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/kkk", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{}
@@ -1326,7 +1312,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1340,8 +1326,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		var b string
 		b = versionPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1372,7 +1357,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1386,8 +1371,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		var b string
 		b = versionPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1418,7 +1402,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1432,8 +1416,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		var b string
 		b = versionPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1468,7 +1451,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1521,8 +1504,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		var b string
 		b = versionPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1550,7 +1532,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(permissions.Required.Calls, ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1564,8 +1546,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		var b string
 		b = `{"instance_id":"a1b2c3","edition":"2017","license":"ONS","release_date":"2017-04-04","state":"associated"}`
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1600,7 +1581,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1614,8 +1595,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 
 		var b string
 		b = versionPublishedPayload
-		r, err := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 
@@ -1723,7 +1703,7 @@ func TestPutVersionReturnsError(t *testing.T) {
 		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
-			_, err = r.Body.Read(make([]byte, 1))
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})
@@ -1863,8 +1843,7 @@ func TestDetachVersionReturnOK(t *testing.T) {
 			},
 		}
 
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1922,8 +1901,7 @@ func TestDetachVersionReturnOK(t *testing.T) {
 			},
 		}
 
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -1993,8 +1971,7 @@ func TestDetachVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -2026,8 +2003,7 @@ func TestDetachVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -2059,8 +2035,7 @@ func TestDetachVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -2095,8 +2070,7 @@ func TestDetachVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -2134,8 +2108,7 @@ func TestDetachVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -2173,8 +2146,7 @@ func TestDetachVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -2221,8 +2193,7 @@ func TestDetachVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/1", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -2273,8 +2244,7 @@ func TestDetachVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/kkk", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/kkk", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -2312,8 +2282,7 @@ func TestDetachVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/-1", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/-1", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{}
@@ -2341,8 +2310,7 @@ func TestDetachVersionReturnsError(t *testing.T) {
 			},
 		}
 
-		r, err := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/0", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("DELETE", "http://localhost:22000/datasets/123/editions/2017/versions/0", nil)
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{}

--- a/api/webendpoints_test.go
+++ b/api/webendpoints_test.go
@@ -26,8 +26,7 @@ var testContext = context.Background()
 
 func TestWebSubnetDatasetsEndpoint(t *testing.T) {
 	Convey("When the API is started with private endpoints disabled", t, func() {
-		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets", nil)
 
 		current := &models.Dataset{ID: "1234", Title: "current"}
 		next := &models.Dataset{ID: "4321", Title: "next"}
@@ -69,8 +68,7 @@ func TestWebSubnetDatasetsEndpoint(t *testing.T) {
 
 func TestWebSubnetDatasetEndpoint(t *testing.T) {
 	Convey("When the API is started with private endpoints disabled", t, func() {
-		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234", nil)
 
 		current := &models.Dataset{ID: "1234", Title: "current"}
 		next := &models.Dataset{ID: "1234", Title: "next"}
@@ -101,8 +99,7 @@ func TestWebSubnetDatasetEndpoint(t *testing.T) {
 
 func TestWebSubnetEditionsEndpoint(t *testing.T) {
 	Convey("When the API is started with private endpoints disabled", t, func() {
-		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions", nil)
 
 		edition := models.EditionUpdate{ID: "1234", Current: &models.Edition{State: models.PublishedState}}
 		var editionSearchState, datasetSearchState string
@@ -132,8 +129,7 @@ func TestWebSubnetEditionsEndpoint(t *testing.T) {
 
 func TestWebSubnetEditionEndpoint(t *testing.T) {
 	Convey("When the API is started with private endpoints disabled", t, func() {
-		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234", nil)
 
 		edition := &models.EditionUpdate{ID: "1234", Current: &models.Edition{State: models.PublishedState}}
 		var editionSearchState, datasetSearchState string
@@ -163,8 +159,7 @@ func TestWebSubnetEditionEndpoint(t *testing.T) {
 
 func TestWebSubnetVersionsEndpoint(t *testing.T) {
 	Convey("When the API is started with private endpoints disabled", t, func() {
-		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234/versions", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234/versions", nil)
 
 		var versionSearchState, editionSearchState, datasetSearchState string
 		w := httptest.NewRecorder()
@@ -197,8 +192,7 @@ func TestWebSubnetVersionsEndpoint(t *testing.T) {
 
 func TestWebSubnetVersionEndpoint(t *testing.T) {
 	Convey("When the API is started with private endpoints disabled", t, func() {
-		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234/versions/1234", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234/versions/1234", nil)
 
 		var versionSearchState, editionSearchState, datasetSearchState string
 		w := httptest.NewRecorder()
@@ -235,8 +229,7 @@ func TestWebSubnetVersionEndpoint(t *testing.T) {
 
 func TestWebSubnetDimensionsEndpoint(t *testing.T) {
 	Convey("When the API is started with private endpoints disabled", t, func() {
-		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234/versions/1234/dimensions", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234/versions/1234/dimensions", nil)
 		var versionSearchState string
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
@@ -264,8 +257,7 @@ func TestWebSubnetDimensionsEndpoint(t *testing.T) {
 
 func TestWebSubnetDimensionOptionsEndpoint(t *testing.T) {
 	Convey("When the API is started with private endpoints disabled", t, func() {
-		r, err := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234/versions/1234/dimensions/t/options", nil)
-		So(err, ShouldBeNil)
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets/1234/editions/1234/versions/1234/dimensions/t/options", nil)
 
 		var versionSearchState string
 		w := httptest.NewRecorder()
@@ -327,8 +319,7 @@ func TestPublishedSubnetEndpointsAreDisabled(t *testing.T) {
 
 		for endpoint, expectedStatusCode := range publishSubnetEndpoints {
 			Convey("The following endpoint "+endpoint.URL+"(Method:"+endpoint.Method+") should return 404", func() {
-				r, err := createRequestWithAuth(endpoint.Method, endpoint.URL, nil)
-				So(err, ShouldBeNil)
+				r := createRequestWithAuth(endpoint.Method, endpoint.URL, nil)
 
 				w := httptest.NewRecorder()
 				mockedDataStore := &storetest.StorerMock{}


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
In the PR for release/1.30.0 it was noticed that the function named createRequestWithAuth had beeen amended in such a way that it no longer needed to return an error (the error returned would always be nil).

This fix amends the createRequestWithAuth, so that it no longer returns a redundant error, and also amends any calls to it so that they no longer expect an error to be returned.

This fix also removes a redundant bin file that was noticed in the PR for release/1.30.0 too.

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the code looks correct and that the tests still pass.

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
