### PR TITLE
add local dockefile and reflex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 .vscode
 def.sdmx.json
 vendor/
+.go/

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,9 @@
+FROM golang:1.16-stretch AS base
+
+ENV GOCACHE=/go/.go/cache GOPATH=/go/.go/path TZ=Europe/London
+
+RUN GOBIN=/bin go get github.com/cespare/reflex
+
+# Map between the working directories of dev and live
+RUN ln -s /go /dp-dataset-api
+WORKDIR /dp-dataset-api

--- a/reflex
+++ b/reflex
@@ -1,0 +1,1 @@
+-s -r \.go$ -R ^\.go/ -R ^cmd/ -R _test\.go$ make debug

--- a/reflex
+++ b/reflex
@@ -1,1 +1,3 @@
--s -r \.go$ -R ^\.go/ -R ^cmd/ -R _test\.go$ make debug
+# Watch all files ending in .go, excluding files in `.go` directory or files
+# ending in `_test.go` & run `make debug` when any matching file is changed
+-s -r \.go$ -R ^\.go/ -R _test\.go$ make debug

--- a/service/service.go
+++ b/service/service.go
@@ -314,6 +314,7 @@ func (svc *Service) registerCheckers(ctx context.Context) (err error) {
 			hasErrors = true
 			log.Event(ctx, "error adding check for zebedeee", log.ERROR, log.Error(err))
 		}
+
 		if err = svc.healthCheck.AddCheck("Kafka Generate Downloads Producer", svc.generateDownloadsProducer.Checker); err != nil {
 			hasErrors = true
 			log.Event(ctx, "error adding check for kafka downloads producer", log.ERROR, log.Error(err))


### PR DESCRIPTION
### What

Added a local dockerfile that can be used with reflex and docker-compose for local dev environment.
Added reflex file that defines regex for files to be watched.

### How to review

Make sure service can still be used as normal.

Test docker-compose Cantabular import journey works as a whole: https://github.com/ONSdigital/dp-compose/pull/13

Part of 5 PRs - Might be best if one person reviews all at once as they are designed to work together.

### Who can review

Anyone - If someone wants to review the whole journey that would be best. Minimum requirement test these changes don't stop the service running as it does as-is
