### PR TITLE
Implement `ETag` - `If-Match` for instance endpoints

### DIFF
--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -32,6 +32,7 @@ var (
 	ErrIncorrectStateToDetach            = errors.New("only versions with a state of edition-confirmed or associated can be detached")
 	ErrIndexOutOfRange                   = errors.New("index out of range")
 	ErrInstanceNotFound                  = errors.New("instance not found")
+	ErrInstanceConflict                  = errors.New("instances does not match the expected eTag")
 	ErrInternalServer                    = errors.New("internal error")
 	ErrInsertedObservationsInvalidSyntax = errors.New("inserted observation request parameter not an integer")
 	ErrInvalidQueryParameter             = errors.New("invalid query parameter")
@@ -88,6 +89,7 @@ var (
 
 	ConflictRequestMap = map[error]bool{
 		ErrConflictUpdatingInstance: true,
+		ErrInstanceConflict:         true,
 	}
 
 	ForbiddenMap = map[error]bool{

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -32,7 +32,7 @@ var (
 	ErrIncorrectStateToDetach            = errors.New("only versions with a state of edition-confirmed or associated can be detached")
 	ErrIndexOutOfRange                   = errors.New("index out of range")
 	ErrInstanceNotFound                  = errors.New("instance not found")
-	ErrInstanceConflict                  = errors.New("instances does not match the expected eTag")
+	ErrInstanceConflict                  = errors.New("instance does not match the expected eTag")
 	ErrInternalServer                    = errors.New("internal error")
 	ErrInsertedObservationsInvalidSyntax = errors.New("inserted observation request parameter not an integer")
 	ErrInvalidQueryParameter             = errors.New("invalid query parameter")

--- a/dimension/dimension.go
+++ b/dimension/dimension.go
@@ -41,7 +41,7 @@ func (s *Store) GetDimensionsHandler(w http.ResponseWriter, r *http.Request, lim
 	logData["action"] = GetDimensions
 
 	// Get instance from MongoDB
-	instance, err := s.GetInstance(instanceID)
+	instance, err := s.GetInstance(instanceID, "*")
 	if err != nil {
 		log.Event(ctx, "failed to get instance", log.ERROR, log.Error(err), logData)
 		handleDimensionErr(ctx, w, err, logData)
@@ -80,7 +80,7 @@ func (s *Store) GetUniqueDimensionAndOptionsHandler(w http.ResponseWriter, r *ht
 	logData["action"] = GetUniqueDimensionAndOptionsAction
 
 	// Get instance from MongoDB
-	instance, err := s.GetInstance(instanceID)
+	instance, err := s.GetInstance(instanceID, "*")
 	if err != nil {
 		log.Event(ctx, "failed to get instance", log.ERROR, log.Error(err), logData)
 		handleDimensionErr(ctx, w, err, logData)
@@ -133,39 +133,52 @@ func (s *Store) AddHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.add(ctx, instanceID, option, logData); err != nil {
+	newETag, err := s.add(ctx, instanceID, option, logData, "*")
+	if err != nil {
 		handleDimensionErr(ctx, w, err, logData)
 		return
 	}
 	log.Event(ctx, "added dimension to instance resource", log.INFO, logData)
 
-	// TODO update and get instance ETag
-	setETag(w, instance.ETag)
+	setETag(w, newETag)
 }
 
-func (s *Store) add(ctx context.Context, instanceID string, option *models.CachedDimensionOption, logData log.Data) error {
+func (s *Store) add(ctx context.Context, instanceID string, option *models.CachedDimensionOption, logData log.Data, eTagSelector string) (newETag string, err error) {
+
+	// acquire instance lock so that the instance update and the dimension.options update are atomic
+	lockID, err := s.AcquireInstanceLock(ctx, instanceID)
+	if err != nil {
+		return "", err
+	}
+	defer s.UnlockInstance(lockID)
 
 	// Get instance
-	instance, err := s.GetInstance(instanceID)
+	instance, err := s.GetInstance(instanceID, "*")
 	if err != nil {
 		log.Event(ctx, "failed to get instance", log.ERROR, log.Error(err), logData)
-		return err
+		return "", err
 	}
 
 	// Early return if instance state is invalid
 	if err = models.CheckState("instance", instance.State); err != nil {
 		logData["state"] = instance.State
 		log.Event(ctx, "current instance has an invalid state", log.ERROR, log.Error(err), logData)
-		return err
+		return "", err
+	}
+
+	newETag, err = s.UpdateETagForOptions(instance, option, eTagSelector)
+	if err != nil {
+		log.Event(ctx, "failed to update eTag for an instance", log.ERROR, log.Error(err), logData)
+		return "", err
 	}
 
 	option.InstanceID = instanceID
 	if err := s.AddDimensionToInstance(option); err != nil {
 		log.Event(ctx, "failed to upsert dimension for an instance", log.ERROR, log.Error(err), logData)
-		return err
+		return "", err
 	}
 
-	return nil
+	return newETag, nil
 }
 
 // createPatches manages the creation of an array of patch structs from the provided reader, and validates them
@@ -209,7 +222,7 @@ func (s *Store) PatchOptionHandler(w http.ResponseWriter, r *http.Request) {
 	logData["patch_list"] = patches
 
 	// apply the patches to the dimension option
-	successfulPatches, err := s.patchOption(ctx, instanceID, dimensionName, option, patches, logData)
+	successfulPatches, newETag, err := s.patchOption(ctx, instanceID, dimensionName, option, patches, logData, "*")
 	if err != nil {
 		logData["successful_patches"] = successfulPatches
 		handleDimensionErr(ctx, w, err, logData)
@@ -225,12 +238,12 @@ func (s *Store) PatchOptionHandler(w http.ResponseWriter, r *http.Request) {
 
 	// set content type and write response body
 	setJSONPatchContentType(w)
-	setETag(w, instance.ETag) // TODO update and get instance ETag
+	setETag(w, newETag)
 	writeBody(ctx, w, b, logData)
 	log.Event(ctx, "successfully patched dimension option of an instance resource", log.INFO, logData)
 }
 
-func (s *Store) patchOption(ctx context.Context, instanceID, dimensionName, option string, patches []dprequest.Patch, logData log.Data) (successful []dprequest.Patch, err error) {
+func (s *Store) patchOption(ctx context.Context, instanceID, dimensionName, option string, patches []dprequest.Patch, logData log.Data, eTagSelector string) (successful []dprequest.Patch, newETag string, err error) {
 	// apply patch operations sequentially, stop processing if one patch fails, and return a list of successful patches operations
 	for _, patch := range patches {
 		dimOption := models.DimensionOption{Name: dimensionName, Option: option, InstanceID: instanceID}
@@ -240,28 +253,30 @@ func (s *Store) patchOption(ctx context.Context, instanceID, dimensionName, opti
 		case "/node_id":
 			val, ok := patch.Value.(string)
 			if !ok {
-				return successful, apierrors.ErrInvalidPatch{Msg: "wrong value type for /node_id, expected string"}
+				return successful, "", apierrors.ErrInvalidPatch{Msg: "wrong value type for /node_id, expected string"}
 			}
 			dimOption.NodeID = val
 		case "/order":
 			// json numeric values are always float64
 			v, ok := patch.Value.(float64)
 			if !ok {
-				return successful, apierrors.ErrInvalidPatch{Msg: "wrong value type for /order, expected numeric value (float64)"}
+				return successful, "", apierrors.ErrInvalidPatch{Msg: "wrong value type for /order, expected numeric value (float64)"}
 			}
 			val := int(v)
 			dimOption.Order = &val
 		default:
-			return successful, apierrors.ErrInvalidPatch{Msg: fmt.Sprintf("wrong path: %s", patch.Path)}
+			return successful, "", apierrors.ErrInvalidPatch{Msg: fmt.Sprintf("wrong path: %s", patch.Path)}
 		}
 
-		// update values in database
-		if err := s.updateOption(ctx, dimOption, logData); err != nil {
-			return successful, err
+		// update values in database, updating the instance eTag
+		newETag, err := s.updateOption(ctx, dimOption, logData, eTagSelector)
+		if err != nil {
+			return successful, "", err
 		}
 		successful = append(successful, patch)
+		eTagSelector = newETag
 	}
-	return successful, nil
+	return successful, newETag, nil
 }
 
 // AddNodeIDHandler against a specific option for dimension
@@ -277,39 +292,57 @@ func (s *Store) AddNodeIDHandler(w http.ResponseWriter, r *http.Request) {
 
 	dimOption := models.DimensionOption{Name: dimensionName, Option: option, NodeID: nodeID, InstanceID: instanceID}
 
-	if err := s.updateOption(ctx, dimOption, logData); err != nil {
+	newETag, err := s.updateOption(ctx, dimOption, logData, "*")
+	if err != nil {
 		handleDimensionErr(ctx, w, err, logData)
 		return
 	}
 
 	logData["action"] = AddDimensionAction
 	log.Event(ctx, "added node id to dimension of an instance resource", log.INFO, logData)
-	setETag(w, instance.ETag) // TODO update and get instance ETag
+	setETag(w, newETag)
 }
 
 // updateOption checks that the instance is in a valid state
-// and then updates nodeID and order (if provided) to the provided dimension option
-func (s *Store) updateOption(ctx context.Context, dimOption models.DimensionOption, logData log.Data) error {
+// and then updates nodeID and order (if provided) to the provided dimension option.
+// This method locks the instance resource and updates its eTag value, making it safe to perform concurrent updates.
+func (s *Store) updateOption(ctx context.Context, dimOption models.DimensionOption, logData log.Data, eTagSelector string) (newETag string, err error) {
+
+	// acquire instance lock so that the instance update and the dimension.options update are atomic
+	lockID, err := s.AcquireInstanceLock(ctx, dimOption.InstanceID)
+	if err != nil {
+		return "", err
+	}
+	defer s.UnlockInstance(lockID)
+
 	// Get instance
-	instance, err := s.GetInstance(dimOption.InstanceID)
+	instance, err := s.GetInstance(dimOption.InstanceID, eTagSelector)
 	if err != nil {
 		log.Event(ctx, "failed to get instance", log.ERROR, log.Error(err), logData)
-		return err
+		return "", err
 	}
 
 	// Early return if instance state is invalid
 	if err = models.CheckState("instance", instance.State); err != nil {
 		logData["state"] = instance.State
 		log.Event(ctx, "current instance has an invalid state", log.ERROR, log.Error(err), logData)
-		return err
+		return "", err
 	}
 
+	// Update instance ETag
+	newETag, err = s.UpdateETagForNodeIDAndOrder(instance, dimOption.NodeID, dimOption.Order, eTagSelector)
+	if err != nil {
+		log.Event(ctx, "failed to update ETag for instance", log.ERROR, log.Error(err), logData)
+		return "", err
+	}
+
+	// Update dimension ID and order in dimension.options collection
 	if err := s.UpdateDimensionNodeIDAndOrder(&dimOption); err != nil {
 		log.Event(ctx, "failed to update a dimension of that instance", log.ERROR, log.Error(err), logData)
-		return err
+		return "", err
 	}
 
-	return nil
+	return newETag, nil
 }
 
 func setJSONPatchContentType(w http.ResponseWriter) {

--- a/dimension/dimension.go
+++ b/dimension/dimension.go
@@ -65,6 +65,7 @@ func (s *Store) GetDimensionsHandler(w http.ResponseWriter, r *http.Request, lim
 	}
 
 	log.Event(ctx, "successfully get dimensions for an instance resource", log.INFO, logData)
+	setETag(w, instance.ETag)
 	return dimensions, totalCount, nil
 }
 
@@ -110,6 +111,7 @@ func (s *Store) GetUniqueDimensionAndOptionsHandler(w http.ResponseWriter, r *ht
 	}
 
 	log.Event(ctx, "successfully get unique dimension options for an instance resource", log.INFO, logData)
+	setETag(w, instance.ETag)
 	return slicedOptions, totalCount, nil
 }
 
@@ -136,6 +138,9 @@ func (s *Store) AddHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Event(ctx, "added dimension to instance resource", log.INFO, logData)
+
+	// TODO update and get instance ETag
+	setETag(w, instance.ETag)
 }
 
 func (s *Store) add(ctx context.Context, instanceID string, option *models.CachedDimensionOption, logData log.Data) error {
@@ -220,6 +225,7 @@ func (s *Store) PatchOptionHandler(w http.ResponseWriter, r *http.Request) {
 
 	// set content type and write response body
 	setJSONPatchContentType(w)
+	setETag(w, instance.ETag) // TODO update and get instance ETag
 	writeBody(ctx, w, b, logData)
 	log.Event(ctx, "successfully patched dimension option of an instance resource", log.INFO, logData)
 }
@@ -278,6 +284,7 @@ func (s *Store) AddNodeIDHandler(w http.ResponseWriter, r *http.Request) {
 
 	logData["action"] = AddDimensionAction
 	log.Event(ctx, "added node id to dimension of an instance resource", log.INFO, logData)
+	setETag(w, instance.ETag) // TODO update and get instance ETag
 }
 
 // updateOption checks that the instance is in a valid state
@@ -307,6 +314,10 @@ func (s *Store) updateOption(ctx context.Context, dimOption models.DimensionOpti
 
 func setJSONPatchContentType(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json-patch+json")
+}
+
+func setETag(w http.ResponseWriter, eTag string) {
+	w.Header().Set("ETag", eTag)
 }
 
 func writeBody(ctx context.Context, w http.ResponseWriter, b []byte, data log.Data) {

--- a/dimension/dimension.go
+++ b/dimension/dimension.go
@@ -40,6 +40,13 @@ func (s *Store) GetDimensionsHandler(w http.ResponseWriter, r *http.Request, lim
 	logData := log.Data{"instance_id": instanceID}
 	logData["action"] = GetDimensions
 
+	// acquire instance lock to make sure we read the correct values of dimension options
+	lockID, err := s.AcquireInstanceLock(ctx, instanceID)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer s.UnlockInstance(lockID)
+
 	// Get instance from MongoDB
 	instance, err := s.GetInstance(instanceID, "*")
 	if err != nil {
@@ -78,6 +85,13 @@ func (s *Store) GetUniqueDimensionAndOptionsHandler(w http.ResponseWriter, r *ht
 	dimension := vars["dimension"]
 	logData := log.Data{"instance_id": instanceID, "dimension": dimension}
 	logData["action"] = GetUniqueDimensionAndOptionsAction
+
+	// acquire instance lock to make sure we read the correct values of dimension options
+	lockID, err := s.AcquireInstanceLock(ctx, instanceID)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer s.UnlockInstance(lockID)
 
 	// Get instance from MongoDB
 	instance, err := s.GetInstance(instanceID, "*")

--- a/dimension/helpers.go
+++ b/dimension/helpers.go
@@ -57,6 +57,8 @@ func handleDimensionErr(ctx context.Context, w http.ResponseWriter, err error, d
 			status = http.StatusNotFound
 		case errs.BadRequestMap[err]:
 			status = http.StatusBadRequest
+		case errs.ConflictRequestMap[err]:
+			status = http.StatusConflict
 		default:
 			status = http.StatusInternalServerError
 			err = errs.ErrInternalServer

--- a/features/instance_dimensions.feature
+++ b/features/instance_dimensions.feature
@@ -245,6 +245,14 @@ Feature: Dataset API
             instance not found
             """
 
+    Scenario: GET /instances/test-item-1/dimensions in private mode with the wrong If-Match header value returns conflict
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        And I set the "If-Match" header to "wrongValue"
+        When I GET "/instances/test-item-1/dimensions"
+        Then the HTTP status code should be "409"
+
     Scenario: GET /instances/test-item-1/dimensions/time/options in private mode returns the first page of 20 instance dimensions options
         Given private endpoints are enabled
         And I am identified as "user@ons.gov.uk"
@@ -304,3 +312,11 @@ Feature: Dataset API
             """
             dimension node not found
             """
+
+    Scenario: GET /instances/test-item-1/dimensions/time/options in private mode with the wrong If-Match header value returns conflict
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        And I set the "If-Match" header to "wrongValue"
+        When I GET "/instances/test-item-1/dimensions/time/options"
+        Then the HTTP status code should be "409"

--- a/features/instances.feature
+++ b/features/instances.feature
@@ -205,3 +205,68 @@ Feature: Dataset API
         Given private endpoints are enabled
         When I GET "/instances"
         Then the HTTP status code should be "401"
+
+    Scenario: GET /instances/test-item-1 in private mode returns the correct instance
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I GET "/instances/test-item-1"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "id": "test-item-1",
+                "state": "published",
+                "links": {
+                    "dataset": {
+                        "id": "population-estimates"
+                    },
+                    "job": null
+                },
+                "import_tasks": null,
+                "last_updated": "0001-01-01T00:00:00Z"
+            }
+            """
+
+    Scenario: GET /instances/test-item-1 in private mode returns the correct instance
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I GET "/instances/test-item-1"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "id": "test-item-1",
+                "state": "published",
+                "links": {
+                    "dataset": {
+                        "id": "population-estimates"
+                    },
+                    "job": null
+                },
+                "import_tasks": null,
+                "last_updated": "0001-01-01T00:00:00Z"
+            }
+            """
+
+    Scenario: GET /instances/inexistent in private mode returns a notFound status code
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I GET "/instances/inexistent"
+        Then the HTTP status code should be "404"
+        And I should receive the following response:
+            """
+            instance not found
+            """
+
+    Scenario: GET /instances/test-item-1 in private mode with the wrong If-Match header value returns conflict
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        And I set the "If-Match" header to "wrongValue"
+        When I GET "/instances/test-item-1"
+        Then the HTTP status code should be "409"
+                And I should receive the following response:
+            """
+            instance does not match the expected eTag
+            """

--- a/features/steps/dataset_component.go
+++ b/features/steps/dataset_component.go
@@ -54,7 +54,7 @@ func NewDatasetComponent(mongoFeature *componenttest.MongoFeature, zebedeeURL st
 		URI:         mongoFeature.Server.URI(),
 	}
 
-	if err := mongodb.Init(); err != nil {
+	if err := mongodb.Init(context.Background()); err != nil {
 		return nil, err
 	}
 
@@ -75,7 +75,7 @@ func NewDatasetComponent(mongoFeature *componenttest.MongoFeature, zebedeeURL st
 
 func (f *DatasetComponent) Reset() *DatasetComponent {
 	f.MongoClient.Database = memongo.RandomDatabase()
-	f.MongoClient.Init()
+	f.MongoClient.Init(context.Background())
 	f.Config.EnablePrivateEndpoints = false
 	return f
 }

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
@@ -309,6 +310,7 @@ github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/mongo-go/testdb v0.0.0-20190724200850-a72a12eee610 h1:tNI2PtIri0WEQONCJnhrOquQTZDfd2worapaCSUKES0=
 github.com/mongo-go/testdb v0.0.0-20190724200850-a72a12eee610/go.mod h1:xyZcxcSxyRLfj4CDZzyycsGRcwfpY07ncmD2keFr548=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -370,6 +372,7 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
+github.com/square/mongo-lock v0.0.0-20191001051310-282c90e422d0 h1:Ae3eHg4QrqbpLdF/Y6jeREKvgqlgrftOglYY4RHdv9s=
 github.com/square/mongo-lock v0.0.0-20191001051310-282c90e422d0/go.mod h1:wR5++/O5fpa0UtI+9T8gKIi5jjl10va/EIEMRySqic4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/instance/dimensions.go
+++ b/instance/dimensions.go
@@ -26,8 +26,7 @@ func (s *Store) UpdateDimension(w http.ResponseWriter, r *http.Request) {
 
 	log.Event(ctx, "update instance dimension: update instance dimension", log.INFO, logData)
 
-	// if err := func() error {
-	instance, err := s.GetInstance(instanceID)
+	instance, err := s.GetInstance(instanceID, "*")
 	if err != nil {
 		log.Event(ctx, "update instance dimension: Failed to GET instance", log.ERROR, log.Error(err), logData)
 		handleInstanceErr(ctx, err, w, logData)
@@ -91,7 +90,8 @@ func (s *Store) UpdateDimension(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update instance
-	if err = s.UpdateInstance(ctx, instanceID, instanceUpdate); err != nil {
+	newETag, err := s.UpdateInstance(ctx, instance, instanceUpdate, "*")
+	if err != nil {
 		log.Event(ctx, "update instance dimension: failed to update instance with new dimension label/description", log.ERROR, log.Error(err), logData)
 		handleInstanceErr(ctx, err, w, logData)
 		return
@@ -99,6 +99,5 @@ func (s *Store) UpdateDimension(w http.ResponseWriter, r *http.Request) {
 
 	log.Event(ctx, "updated instance dimension: request successful", log.INFO, logData)
 
-	// TODO set ETag from updated instance!!!
-	setETag(w, instance.ETag)
+	setETag(w, newETag)
 }

--- a/instance/dimensions.go
+++ b/instance/dimensions.go
@@ -22,11 +22,12 @@ func (s *Store) UpdateDimension(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	instanceID := vars["instance_id"]
 	dimension := vars["dimension"]
+	eTag := getIfMatch(r)
 	logData := log.Data{"instance_id": instanceID, "dimension": dimension}
 
 	log.Event(ctx, "update instance dimension: update instance dimension", log.INFO, logData)
 
-	instance, err := s.GetInstance(instanceID, "*")
+	instance, err := s.GetInstance(instanceID, eTag)
 	if err != nil {
 		log.Event(ctx, "update instance dimension: Failed to GET instance", log.ERROR, log.Error(err), logData)
 		handleInstanceErr(ctx, err, w, logData)
@@ -90,7 +91,7 @@ func (s *Store) UpdateDimension(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update instance
-	newETag, err := s.UpdateInstance(ctx, instance, instanceUpdate, "*")
+	newETag, err := s.UpdateInstance(ctx, instance, instanceUpdate, eTag)
 	if err != nil {
 		log.Event(ctx, "update instance dimension: failed to update instance with new dimension label/description", log.ERROR, log.Error(err), logData)
 		handleInstanceErr(ctx, err, w, logData)

--- a/instance/dimensions_external_test.go
+++ b/instance/dimensions_external_test.go
@@ -47,6 +47,8 @@ func Test_UpdateDimensionReturnsOk(t *testing.T) {
 				datasetAPI.Router.ServeHTTP(w, r)
 
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get("ETag"), ShouldEqual, testETag)
+
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
 				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
@@ -97,6 +99,7 @@ func Test_UpdateDimensionReturnsInternalError(t *testing.T) {
 			Convey("Then return status internal error (500)", func() {
 				body := strings.NewReader(`{"label":"ages"}`)
 				r, err := createRequestWithToken("PUT", "http://localhost:22000/instances/123/dimensions/age", body)
+				r.Header.Set("If-Match", testIfMatch)
 				So(err, ShouldBeNil)
 				w := httptest.NewRecorder()
 

--- a/instance/dimensions_external_test.go
+++ b/instance/dimensions_external_test.go
@@ -14,6 +14,8 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const testETag = "testETag"
+
 func Test_UpdateDimensionReturnsOk(t *testing.T) {
 	t.Parallel()
 	Convey("Given a PUT request to update a dimension on an instance resource", t, func() {
@@ -25,13 +27,13 @@ func Test_UpdateDimensionReturnsOk(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState,
 							InstanceID: "123",
 							Dimensions: []models.Dimension{{Name: "age", ID: "age"}}}, nil
 					},
-					UpdateInstanceFunc: func(ctx context.Context, id string, i *models.Instance) error {
-						return nil
+					UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -61,11 +63,11 @@ func Test_UpdateDimensionReturnsInternalError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return nil, errs.ErrInternalServer
 					},
-					UpdateInstanceFunc: func(ctx context.Context, id string, i *models.Instance) error {
-						return nil
+					UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -93,11 +95,11 @@ func Test_UpdateDimensionReturnsInternalError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: "gobbly gook"}, nil
 					},
-					UpdateInstanceFunc: func(ctx context.Context, id string, i *models.Instance) error {
-						return nil
+					UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 				datasetPermissions := mocks.NewAuthHandlerMock()
@@ -123,7 +125,7 @@ func Test_UpdateDimensionReturnsInternalError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.PublishedState}, nil
 					},
 				}
@@ -150,7 +152,7 @@ func Test_UpdateDimensionReturnsInternalError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return nil, errs.ErrInstanceNotFound
 					},
 				}
@@ -178,13 +180,13 @@ func Test_UpdateDimensionReturnsInternalError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState,
 							InstanceID: "123",
 							Dimensions: []models.Dimension{{Name: "age", ID: "age"}}}, nil
 					},
-					UpdateInstanceFunc: func(ctx context.Context, id string, i *models.Instance) error {
-						return nil
+					UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -212,7 +214,7 @@ func Test_UpdateDimensionReturnsInternalError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.CompletedState}, nil
 					},
 				}

--- a/instance/event.go
+++ b/instance/event.go
@@ -35,6 +35,7 @@ func (s *Store) AddEvent(w http.ResponseWriter, r *http.Request) {
 
 	vars := mux.Vars(r)
 	instanceID := vars["instance_id"]
+	eTag := getIfMatch(r)
 	data := log.Data{"instance_id": instanceID, "action": AddInstanceEventAction}
 
 	event, err := unmarshalEvent(r.Body)
@@ -50,14 +51,14 @@ func (s *Store) AddEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	instance, err := s.GetInstance(instanceID, "*")
+	instance, err := s.GetInstance(instanceID, eTag)
 	if err != nil {
 		log.Event(ctx, "add instance event: failed to get instance from datastore", log.ERROR, log.Error(err), data)
 		handleInstanceErr(ctx, err, w, data)
 		return
 	}
 
-	newETag, err := s.AddEventToInstance(instance, event, "*")
+	newETag, err := s.AddEventToInstance(instance, event, eTag)
 	if err != nil {
 		log.Event(ctx, "add instance event: failed to add event to instance in datastore", log.ERROR, log.Error(err), data)
 		handleInstanceErr(ctx, err, w, data)

--- a/instance/event.go
+++ b/instance/event.go
@@ -50,13 +50,20 @@ func (s *Store) AddEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.AddEventToInstance(instanceID, event); err != nil {
+	instance, err := s.GetInstance(instanceID, "*")
+	if err != nil {
+		log.Event(ctx, "add instance event: failed to get instance from datastore", log.ERROR, log.Error(err), data)
+		handleInstanceErr(ctx, err, w, data)
+		return
+	}
+
+	newETag, err := s.AddEventToInstance(instance, event, "*")
+	if err != nil {
 		log.Event(ctx, "add instance event: failed to add event to instance in datastore", log.ERROR, log.Error(err), data)
 		handleInstanceErr(ctx, err, w, data)
 		return
 	}
 
 	log.Event(ctx, "add instance event: request successful", log.INFO, data)
-	// TODO get instance update ETag!
-	setETag(w, instance.ETag)
+	setETag(w, newETag)
 }

--- a/instance/event_external_test.go
+++ b/instance/event_external_test.go
@@ -1,243 +1,196 @@
 package instance_test
 
-// import . "github.com/smartystreets/goconvey/convey"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
 
-// func TestAddEventReturnsOk(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Given a valid request to add an event to instance resource", t, func() {
-// 		Convey("When the request is made", func() {
-// 			Convey(`Then the instance is successfully updated with the event and a
-// 				response status ok (200) is returned`, func() {
-// 				body := strings.NewReader(`{"message": "321", "type": "error", "message_offset":"00", "time":"2017-08-25T15:09:11.829+01:00" }`)
-// 				r, err := createRequestWithToken("POST", "http://localhost:21800/instances/123/events", body)
-// 				So(err, ShouldBeNil)
-// 				w := httptest.NewRecorder()
-//
-// 				mockedDataStore := &storetest.StorerMock{
-// 					AddEventToInstanceFunc: func(id string, event *models.Event) error {
-// 						return nil
-// 					},
-// 				}
-//
-// 				auditor := auditortest.New()
-// 				datasetAPI := getAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditor, &mocks.ObservationStoreMock{})
-// 				datasetAPI.Router.ServeHTTP(w, r)
-//
-// 				So(w.Code, ShouldEqual, http.StatusOK)
-// 				So(len(mockedDataStore.AddEventToInstanceCalls()), ShouldEqual, 1)
-//
-// 				auditor.AssertRecordCalls(
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Attempted, common.Params{"caller_identity": "someone@ons.gov.uk", "instance_id": "123"}),
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Successful, common.Params{"instance_id": "123"}),
-// 				)
-// 			})
-// 		})
-// 	})
-// }
-//
-// func TestAddEventToInstanceReturnsBadRequest(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Given a request to add an event to an instance resource contains an invalid body", t, func() {
-// 		Convey("When the request is made", func() {
-// 			Convey("Then the request fails and the response returns status bad requets (400)", func() {
-// 				body := strings.NewReader(`{`)
-// 				r, err := createRequestWithToken("POST", "http://localhost:21800/instances/123/events", body)
-// 				So(err, ShouldBeNil)
-// 				w := httptest.NewRecorder()
-// 				mockedDataStore := &storetest.StorerMock{}
-//
-// 				auditor := auditortest.New()
-// 				datasetAPI := getAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditor, &mocks.ObservationStoreMock{})
-// 				datasetAPI.Router.ServeHTTP(w, r)
-//
-// 				So(w.Code, ShouldEqual, http.StatusBadRequest)
-// 				So(w.Body.String(), ShouldContainSubstring, errs.ErrUnableToParseJSON.Error())
-// 				So(len(mockedDataStore.AddEventToInstanceCalls()), ShouldEqual, 0)
-//
-// 				auditor.AssertRecordCalls(
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Attempted, common.Params{"caller_identity": "someone@ons.gov.uk", "instance_id": "123"}),
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Unsuccessful, common.Params{"instance_id": "123"}),
-// 				)
-// 			})
-// 		})
-// 	})
-//
-// 	Convey("Given a request to add an event to an instance resource is missing the field `time` in request body", t, func() {
-// 		Convey("When the request is made", func() {
-// 			Convey("Then the request fails and the response returns status bad requets (400)", func() {
-// 				body := strings.NewReader(`{"message": "321", "type": "error", "message_offset":"00" }`)
-// 				r, err := createRequestWithToken("POST", "http://localhost:21800/instances/123/events", body)
-// 				So(err, ShouldBeNil)
-// 				w := httptest.NewRecorder()
-// 				mockedDataStore := &storetest.StorerMock{}
-//
-// 				auditor := auditortest.New()
-// 				datasetAPI := getAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditor, &mocks.ObservationStoreMock{})
-// 				datasetAPI.Router.ServeHTTP(w, r)
-//
-// 				So(w.Code, ShouldEqual, http.StatusBadRequest)
-// 				So(w.Body.String(), ShouldContainSubstring, errs.ErrMissingParameters.Error())
-// 				So(len(mockedDataStore.AddEventToInstanceCalls()), ShouldEqual, 0)
-//
-// 				auditor.AssertRecordCalls(
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Attempted, common.Params{"caller_identity": "someone@ons.gov.uk", "instance_id": "123"}),
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Unsuccessful, common.Params{"instance_id": "123"}),
-// 				)
-// 			})
-// 		})
-// 	})
-// }
-//
-// func TestAddEventToInstanceReturnsNotFound(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Given a valid request is made to add an instance event", t, func() {
-// 		Convey("When the instance does not exist", func() {
-// 			Convey("Then the request fails and the response returns status not found (404)", func() {
-// 				body := strings.NewReader(`{"message": "321", "type": "error", "message_offset":"00", "time":"2017-08-25T15:09:11.829+01:00" }`)
-// 				r, err := createRequestWithToken("POST", "http://localhost:21800/instances/123/events", body)
-// 				So(err, ShouldBeNil)
-// 				w := httptest.NewRecorder()
-//
-// 				mockedDataStore := &storetest.StorerMock{
-// 					AddEventToInstanceFunc: func(id string, event *models.Event) error {
-// 						return errs.ErrInstanceNotFound
-// 					},
-// 				}
-//
-// 				auditor := auditortest.New()
-// 				datasetAPI := getAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditor, &mocks.ObservationStoreMock{})
-// 				datasetAPI.Router.ServeHTTP(w, r)
-//
-// 				So(w.Code, ShouldEqual, http.StatusNotFound)
-// 				So(w.Body.String(), ShouldContainSubstring, errs.ErrInstanceNotFound.Error())
-// 				So(len(mockedDataStore.AddEventToInstanceCalls()), ShouldEqual, 1)
-//
-// 				auditor.AssertRecordCalls(
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Attempted, common.Params{"caller_identity": "someone@ons.gov.uk", "instance_id": "123"}),
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Unsuccessful, common.Params{"instance_id": "123"}),
-// 				)
-// 			})
-// 		})
-// 	})
-// }
-//
-// func TestAddEventToInstanceReturnsInternalError(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Given a valid request to add instance event", t, func() {
-// 		Convey("When service is unable to connect to datastore", func() {
-// 			Convey("Then response return status internal server error (500)", func() {
-// 				body := strings.NewReader(`{"message": "321", "type": "error", "message_offset":"00", "time":"2017-08-25T15:09:11.829+01:00" }`)
-// 				r, err := createRequestWithToken("POST", "http://localhost:21800/instances/123/events", body)
-// 				So(err, ShouldBeNil)
-// 				w := httptest.NewRecorder()
-//
-// 				mockedDataStore := &storetest.StorerMock{
-// 					AddEventToInstanceFunc: func(id string, event *models.Event) error {
-// 						return errs.ErrInternalServer
-// 					},
-// 				}
-//
-// 				auditor := auditortest.New()
-// 				datasetAPI := getAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditor, &mocks.ObservationStoreMock{})
-// 				datasetAPI.Router.ServeHTTP(w, r)
-//
-// 				So(w.Code, ShouldEqual, http.StatusInternalServerError)
-// 				So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
-// 				So(len(mockedDataStore.AddEventToInstanceCalls()), ShouldEqual, 1)
-//
-// 				auditor.AssertRecordCalls(
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Attempted, common.Params{"caller_identity": "someone@ons.gov.uk", "instance_id": "123"}),
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Unsuccessful, common.Params{"instance_id": "123"}),
-// 				)
-// 			})
-// 		})
-// 	})
-// }
-//
-// func TestAddInstanceEventAuditErrors(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Given audit action attempted returns an error", t, func() {
-//
-// 		auditor := auditortest.NewErroring(instance.AddInstanceEventAction, audit.Attempted)
-//
-// 		Convey("When add instance event is called", func() {
-// 			body := strings.NewReader(`{"message": "321", "type": "error", "message_offset":"00", "time":"2017-08-25T15:09:11.829+01:00" }`)
-// 			r, err := createRequestWithToken("POST", "http://localhost:21800/instances/123/events", body)
-// 			So(err, ShouldBeNil)
-// 			w := httptest.NewRecorder()
-//
-// 			mockedDataStore := &storetest.StorerMock{}
-//
-// 			datasetAPI := getAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditor, &mocks.ObservationStoreMock{})
-// 			datasetAPI.Router.ServeHTTP(w, r)
-//
-// 			Convey("Then a 500 status is returned", func() {
-// 				So(w.Code, ShouldEqual, http.StatusInternalServerError)
-// 				So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
-// 				So(len(mockedDataStore.AddEventToInstanceCalls()), ShouldEqual, 0)
-//
-// 				auditParams := common.Params{"caller_identity": "someone@ons.gov.uk", "instance_id": "123"}
-// 				auditor.AssertRecordCalls(
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Attempted, auditParams),
-// 				)
-// 			})
-// 		})
-// 	})
-//
-// 	Convey("Given audit action unsuccessful returns an error", t, func() {
-// 		auditor := auditortest.NewErroring(instance.AddInstanceEventAction, audit.Unsuccessful)
-//
-// 		Convey("When add instance event returns an error", func() {
-// 			r, err := createRequestWithToken("POST", "http://localhost:21800/instances/123/events", strings.NewReader(`{}`))
-// 			So(err, ShouldBeNil)
-// 			w := httptest.NewRecorder()
-//
-// 			mockedDataStore := &storetest.StorerMock{}
-//
-// 			datasetAPI := getAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditor, &mocks.ObservationStoreMock{})
-// 			datasetAPI.Router.ServeHTTP(w, r)
-//
-// 			Convey("Then a 500 status is returned", func() {
-// 				So(w.Code, ShouldEqual, http.StatusInternalServerError)
-// 				So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
-// 				So(len(mockedDataStore.AddEventToInstanceCalls()), ShouldEqual, 0)
-//
-// 				auditor.AssertRecordCalls(
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Attempted, common.Params{"caller_identity": "someone@ons.gov.uk", "instance_id": "123"}),
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Unsuccessful, common.Params{"instance_id": "123"}),
-// 				)
-// 			})
-// 		})
-// 	})
-//
-// 	Convey("given audit action successful returns an error", t, func() {
-// 		auditor := auditortest.NewErroring(instance.AddInstanceEventAction, audit.Successful)
-//
-// 		Convey("when get instances is called", func() {
-// 			body := strings.NewReader(`{"message": "321", "type": "error", "message_offset":"00", "time":"2017-08-25T15:09:11.829+01:00" }`)
-// 			r, err := createRequestWithToken("POST", "http://localhost:21800/instances/123/events", body)
-// 			So(err, ShouldBeNil)
-// 			w := httptest.NewRecorder()
-//
-// 			mockedDataStore := &storetest.StorerMock{
-// 				AddEventToInstanceFunc: func(id string, event *models.Event) error {
-// 					return nil
-// 				},
-// 			}
-//
-// 			datasetAPI := getAPIWithMockedDatastore(mockedDataStore, &mocks.DownloadsGeneratorMock{}, auditor, &mocks.ObservationStoreMock{})
-// 			datasetAPI.Router.ServeHTTP(w, r)
-//
-// 			Convey("then a 500 status is returned", func() {
-// 				So(w.Code, ShouldEqual, http.StatusInternalServerError)
-// 				So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
-// 				So(len(mockedDataStore.AddEventToInstanceCalls()), ShouldEqual, 1)
-//
-// 				auditor.AssertRecordCalls(
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Attempted, common.Params{"caller_identity": "someone@ons.gov.uk", "instance_id": "123"}),
-// 					auditortest.NewExpectation(instance.AddInstanceEventAction, audit.Successful, common.Params{"instance_id": "123"}),
-// 				)
-// 			})
-// 		})
-// 	})
-// }
+	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
+	"github.com/ONSdigital/dp-dataset-api/mocks"
+	"github.com/ONSdigital/dp-dataset-api/models"
+	storetest "github.com/ONSdigital/dp-dataset-api/store/datastoretest"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestAddEventReturnsOk(t *testing.T) {
+	t.Parallel()
+	Convey("Given a valid request to add an event to instance resource", t, func() {
+		Convey("When the request is made", func() {
+			Convey(`Then the instance is successfully updated with the event and a
+				response status ok (200) is returned`, func() {
+				body := strings.NewReader(`{"message": "321", "type": "error", "message_offset":"00", "time":"2017-08-25T15:09:11.829+01:00" }`)
+				r, err := createRequestWithToken("POST", "http://localhost:21800/instances/123/events", body)
+				r.Header.Set("If-Match", testIfMatch)
+				So(err, ShouldBeNil)
+				w := httptest.NewRecorder()
+
+				mockedDataStore := &storetest.StorerMock{
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
+						return &models.Instance{
+							InstanceID: ID,
+							State:      models.CompletedState,
+						}, nil
+					},
+					AddEventToInstanceFunc: func(currentInstance *models.Instance, event *models.Event, eTagSelector string) (string, error) {
+						return testETag, nil
+					},
+				}
+
+				datasetPermissions := mocks.NewAuthHandlerMock()
+				permissions := mocks.NewAuthHandlerMock()
+				datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
+				datasetAPI.Router.ServeHTTP(w, r)
+
+				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get("ETag"), ShouldEqual, testETag)
+				So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
+				So(mockedDataStore.GetInstanceCalls()[0].ETagSelector, ShouldEqual, testIfMatch)
+				So(mockedDataStore.GetInstanceCalls()[0].ID, ShouldEqual, "123")
+				So(mockedDataStore.AddEventToInstanceCalls(), ShouldHaveLength, 1)
+				So(mockedDataStore.AddEventToInstanceCalls()[0].ETagSelector, ShouldEqual, testIfMatch)
+			})
+		})
+	})
+}
+
+func TestAddEventToInstanceReturnsBadRequest(t *testing.T) {
+	t.Parallel()
+	Convey("Given a request to add an event to an instance resource contains an invalid body", t, func() {
+		Convey("When the request is made", func() {
+			Convey("Then the request fails and the response returns status bad requets (400)", func() {
+				body := strings.NewReader(`{`)
+				r, err := createRequestWithToken("POST", "http://localhost:21800/instances/123/events", body)
+				So(err, ShouldBeNil)
+				w := httptest.NewRecorder()
+
+				mockedDataStore := &storetest.StorerMock{}
+
+				datasetPermissions := mocks.NewAuthHandlerMock()
+				permissions := mocks.NewAuthHandlerMock()
+				datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
+				datasetAPI.Router.ServeHTTP(w, r)
+
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+				So(w.Body.String(), ShouldContainSubstring, errs.ErrUnableToParseJSON.Error())
+			})
+		})
+	})
+
+	Convey("Given a request to add an event to an instance resource is missing the field `time` in request body", t, func() {
+		Convey("When the request is made", func() {
+			Convey("Then the request fails and the response returns status bad requets (400)", func() {
+				body := strings.NewReader(`{"message": "321", "type": "error", "message_offset":"00" }`)
+				r, err := createRequestWithToken("POST", "http://localhost:21800/instances/123/events", body)
+				So(err, ShouldBeNil)
+				w := httptest.NewRecorder()
+				mockedDataStore := &storetest.StorerMock{}
+
+				datasetPermissions := mocks.NewAuthHandlerMock()
+				permissions := mocks.NewAuthHandlerMock()
+				datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
+				datasetAPI.Router.ServeHTTP(w, r)
+
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+				So(w.Body.String(), ShouldContainSubstring, errs.ErrMissingParameters.Error())
+				So(len(mockedDataStore.AddEventToInstanceCalls()), ShouldEqual, 0)
+			})
+		})
+	})
+}
+
+func TestAddEventToInstanceReturnsNotFound(t *testing.T) {
+	t.Parallel()
+	Convey("Given a valid request is made to add an instance event", t, func() {
+		Convey("When the instance does not exist", func() {
+			Convey("Then the request fails and the response returns status not found (404)", func() {
+				body := strings.NewReader(`{"message": "321", "type": "error", "message_offset":"00", "time":"2017-08-25T15:09:11.829+01:00" }`)
+				r, err := createRequestWithToken("POST", "http://localhost:21800/instances/123/events", body)
+				So(err, ShouldBeNil)
+				w := httptest.NewRecorder()
+
+				mockedDataStore := &storetest.StorerMock{
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
+						return nil, errs.ErrInstanceNotFound
+					},
+				}
+
+				datasetPermissions := mocks.NewAuthHandlerMock()
+				permissions := mocks.NewAuthHandlerMock()
+				datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
+				datasetAPI.Router.ServeHTTP(w, r)
+
+				So(w.Code, ShouldEqual, http.StatusNotFound)
+				So(w.Body.String(), ShouldContainSubstring, errs.ErrInstanceNotFound.Error())
+				So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
+			})
+		})
+	})
+}
+
+func TestAddEventToInstanceReturnsInternalError(t *testing.T) {
+	t.Parallel()
+	Convey("Given a valid request to add instance event", t, func() {
+		Convey("When service is unable to connect to datastore", func() {
+			Convey("Then response return status internal server error (500)", func() {
+				body := strings.NewReader(`{"message": "321", "type": "error", "message_offset":"00", "time":"2017-08-25T15:09:11.829+01:00" }`)
+				r, err := createRequestWithToken("POST", "http://localhost:21800/instances/123/events", body)
+				So(err, ShouldBeNil)
+				w := httptest.NewRecorder()
+
+				mockedDataStore := &storetest.StorerMock{
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
+						return &models.Instance{
+							InstanceID: ID,
+							State:      models.CompletedState,
+						}, nil
+					},
+					AddEventToInstanceFunc: func(currentInstance *models.Instance, event *models.Event, eTagSelector string) (string, error) {
+						return "", errs.ErrInternalServer
+					},
+				}
+
+				datasetPermissions := mocks.NewAuthHandlerMock()
+				permissions := mocks.NewAuthHandlerMock()
+				datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
+				datasetAPI.Router.ServeHTTP(w, r)
+
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
+				So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
+				So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
+				So(mockedDataStore.AddEventToInstanceCalls(), ShouldHaveLength, 1)
+			})
+		})
+	})
+}
+
+func TestAddInstanceConflict(t *testing.T) {
+	t.Parallel()
+	Convey("Given a valid request to add an event to instance resource", t, func() {
+		Convey("When the request is made with an If-Match header that does not match the instance eTag", func() {
+			Convey("Then response return status conflict (409)", func() {
+				body := strings.NewReader(`{"message": "321", "type": "error", "message_offset":"00", "time":"2017-08-25T15:09:11.829+01:00" }`)
+				r, err := createRequestWithToken("POST", "http://localhost:21800/instances/123/events", body)
+				r.Header.Set("If-Match", "wrong")
+				So(err, ShouldBeNil)
+				w := httptest.NewRecorder()
+
+				mockedDataStore := &storetest.StorerMock{
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
+						return nil, errs.ErrInstanceConflict
+					},
+				}
+
+				datasetPermissions := mocks.NewAuthHandlerMock()
+				permissions := mocks.NewAuthHandlerMock()
+				datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
+				datasetAPI.Router.ServeHTTP(w, r)
+
+				So(w.Code, ShouldEqual, http.StatusConflict)
+				So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
+				So(mockedDataStore.GetInstanceCalls()[0].ETagSelector, ShouldEqual, "wrong")
+				So(mockedDataStore.GetInstanceCalls()[0].ID, ShouldEqual, "123")
+			})
+		})
+	})
+}

--- a/instance/import.go
+++ b/instance/import.go
@@ -25,25 +25,22 @@ func (s *Store) UpdateObservations(w http.ResponseWriter, r *http.Request) {
 	insert := vars["inserted_observations"]
 	logData := log.Data{"instance_id": instanceID, "inserted_observations": insert}
 
-	if err := func() error {
-		observations, err := strconv.ParseInt(insert, 10, 64)
-		if err != nil {
-			log.Event(ctx, "update imported observations: failed to parse inserted_observations string to int", log.ERROR, log.Error(err), logData)
-			return errs.ErrInsertedObservationsInvalidSyntax
-		}
+	observations, err := strconv.ParseInt(insert, 10, 64)
+	if err != nil {
+		log.Event(ctx, "update imported observations: failed to parse inserted_observations string to int", log.ERROR, log.Error(err), logData)
+		handleInstanceErr(ctx, errs.ErrInsertedObservationsInvalidSyntax, w, logData)
+		return
+	}
 
-		if err = s.UpdateObservationInserted(instanceID, observations); err != nil {
-			log.Event(ctx, "update imported observations: store.UpdateObservationInserted returned an error", log.ERROR, log.Error(err), logData)
-			return err
-		}
-
-		return nil
-	}(); err != nil {
+	if err = s.UpdateObservationInserted(instanceID, observations); err != nil {
+		log.Event(ctx, "update imported observations: store.UpdateObservationInserted returned an error", log.ERROR, log.Error(err), logData)
 		handleInstanceErr(ctx, err, w, logData)
 		return
 	}
 
 	log.Event(ctx, "update imported observations: request successful", log.INFO, logData)
+	// TODO update and return instance Etag
+	setETag(w, instance.ETag)
 }
 
 // UpdateImportTask updates any task in the request body against an instance
@@ -57,101 +54,106 @@ func (s *Store) UpdateImportTask(w http.ResponseWriter, r *http.Request) {
 	logData := log.Data{"instance_id": instanceID}
 	defer r.Body.Close()
 
-	updateErr := func() *taskError {
-		tasks, err := unmarshalImportTasks(r.Body)
-		if err != nil {
-			log.Event(ctx, "failed to unmarshal request body to UpdateImportTasks model", log.ERROR, log.Error(err), logData)
-			return &taskError{err, http.StatusBadRequest}
-		}
-
-		validationErrs := make([]error, 0)
-		var hasImportTasks bool
-
-		if tasks.ImportObservations != nil {
-			hasImportTasks = true
-			if tasks.ImportObservations.State != "" {
-				if tasks.ImportObservations.State != models.CompletedState {
-					validationErrs = append(validationErrs, fmt.Errorf("bad request - invalid task state value for import observations: %v", tasks.ImportObservations.State))
-				} else {
-					if err := s.UpdateImportObservationsTaskState(instanceID, tasks.ImportObservations.State); err != nil {
-						log.Event(ctx, "failed to update import observations task state", log.ERROR, log.Error(err), logData)
-						return &taskError{err, http.StatusInternalServerError}
-					}
-				}
-			} else {
-				validationErrs = append(validationErrs, errors.New("bad request - invalid import observation task, must include state"))
-			}
-		}
-
-		if tasks.BuildHierarchyTasks != nil {
-			hasImportTasks = true
-			var hasHierarchyImportTask bool
-			for _, task := range tasks.BuildHierarchyTasks {
-				hasHierarchyImportTask = true
-				if err := models.ValidateImportTask(task.GenericTaskDetails); err != nil {
-					validationErrs = append(validationErrs, err)
-				} else {
-					if err := s.UpdateBuildHierarchyTaskState(instanceID, task.DimensionName, task.State); err != nil {
-						if err.Error() == errs.ErrNotFound.Error() {
-							notFoundErr := task.DimensionName + " hierarchy import task does not exist"
-							log.Event(ctx, notFoundErr, log.ERROR, log.Error(err), logData)
-							return &taskError{errors.New(notFoundErr), http.StatusNotFound}
-						}
-						log.Event(ctx, "failed to update build hierarchy task state", log.ERROR, log.Error(err), logData)
-						return &taskError{err, http.StatusInternalServerError}
-					}
-				}
-			}
-			if !hasHierarchyImportTask {
-				validationErrs = append(validationErrs, errors.New("bad request - missing hierarchy task"))
-			}
-		}
-
-		if tasks.BuildSearchIndexTasks != nil {
-			hasImportTasks = true
-			var hasSearchIndexImportTask bool
-			for _, task := range tasks.BuildSearchIndexTasks {
-				hasSearchIndexImportTask = true
-				if err := models.ValidateImportTask(task.GenericTaskDetails); err != nil {
-					validationErrs = append(validationErrs, err)
-				} else {
-					if err := s.UpdateBuildSearchTaskState(instanceID, task.DimensionName, task.State); err != nil {
-						if err.Error() == "not found" {
-							notFoundErr := task.DimensionName + " search index import task does not exist"
-							log.Event(ctx, notFoundErr, log.ERROR, log.Error(err), logData)
-							return &taskError{errors.New(notFoundErr), http.StatusNotFound}
-						}
-						log.Event(ctx, "failed to update build hierarchy task state", log.ERROR, log.Error(err), logData)
-						return &taskError{err, http.StatusInternalServerError}
-					}
-				}
-			}
-			if !hasSearchIndexImportTask {
-				validationErrs = append(validationErrs, errors.New("bad request - missing search index task"))
-			}
-		}
-
-		if !hasImportTasks {
-			validationErrs = append(validationErrs, errors.New("bad request - request body does not contain any import tasks"))
-		}
-
-		if len(validationErrs) > 0 {
-			for _, err := range validationErrs {
-				log.Event(ctx, "validation error", log.ERROR, log.Error(err), logData)
-			}
-			// todo: add all validation errors to the response
-			return &taskError{validationErrs[0], http.StatusBadRequest}
-		}
-		return nil
-	}()
-
-	if updateErr != nil {
+	handleError := func(updateErr *taskError) {
 		log.Event(ctx, "updateImportTask endpoint: request unsuccessful", log.ERROR, log.Error(updateErr), logData)
 		http.Error(w, updateErr.Error(), updateErr.status)
+	}
+
+	tasks, err := unmarshalImportTasks(r.Body)
+	if err != nil {
+		log.Event(ctx, "failed to unmarshal request body to UpdateImportTasks model", log.ERROR, log.Error(err), logData)
+		handleError(&taskError{err, http.StatusBadRequest})
+		return
+	}
+
+	validationErrs := make([]error, 0)
+	var hasImportTasks bool
+
+	if tasks.ImportObservations != nil {
+		hasImportTasks = true
+		if tasks.ImportObservations.State != "" {
+			if tasks.ImportObservations.State != models.CompletedState {
+				validationErrs = append(validationErrs, fmt.Errorf("bad request - invalid task state value for import observations: %v", tasks.ImportObservations.State))
+			} else {
+				if err := s.UpdateImportObservationsTaskState(instanceID, tasks.ImportObservations.State); err != nil {
+					log.Event(ctx, "failed to update import observations task state", log.ERROR, log.Error(err), logData)
+					handleError(&taskError{err, http.StatusInternalServerError})
+					return
+				}
+			}
+		} else {
+			validationErrs = append(validationErrs, errors.New("bad request - invalid import observation task, must include state"))
+		}
+	}
+
+	if tasks.BuildHierarchyTasks != nil {
+		hasImportTasks = true
+		var hasHierarchyImportTask bool
+		for _, task := range tasks.BuildHierarchyTasks {
+			hasHierarchyImportTask = true
+			if err := models.ValidateImportTask(task.GenericTaskDetails); err != nil {
+				validationErrs = append(validationErrs, err)
+			} else {
+				if err := s.UpdateBuildHierarchyTaskState(instanceID, task.DimensionName, task.State); err != nil {
+					if err.Error() == errs.ErrNotFound.Error() {
+						notFoundErr := task.DimensionName + " hierarchy import task does not exist"
+						log.Event(ctx, notFoundErr, log.ERROR, log.Error(err), logData)
+						handleError(&taskError{errors.New(notFoundErr), http.StatusNotFound})
+						return
+					}
+					log.Event(ctx, "failed to update build hierarchy task state", log.ERROR, log.Error(err), logData)
+					handleError(&taskError{err, http.StatusInternalServerError})
+					return
+				}
+			}
+		}
+		if !hasHierarchyImportTask {
+			validationErrs = append(validationErrs, errors.New("bad request - missing hierarchy task"))
+		}
+	}
+
+	if tasks.BuildSearchIndexTasks != nil {
+		hasImportTasks = true
+		var hasSearchIndexImportTask bool
+		for _, task := range tasks.BuildSearchIndexTasks {
+			hasSearchIndexImportTask = true
+			if err := models.ValidateImportTask(task.GenericTaskDetails); err != nil {
+				validationErrs = append(validationErrs, err)
+			} else {
+				if err := s.UpdateBuildSearchTaskState(instanceID, task.DimensionName, task.State); err != nil {
+					if err.Error() == "not found" {
+						notFoundErr := task.DimensionName + " search index import task does not exist"
+						log.Event(ctx, notFoundErr, log.ERROR, log.Error(err), logData)
+						handleError(&taskError{errors.New(notFoundErr), http.StatusNotFound})
+						return
+					}
+					log.Event(ctx, "failed to update build hierarchy task state", log.ERROR, log.Error(err), logData)
+					handleError(&taskError{err, http.StatusInternalServerError})
+					return
+				}
+			}
+		}
+		if !hasSearchIndexImportTask {
+			validationErrs = append(validationErrs, errors.New("bad request - missing search index task"))
+		}
+	}
+
+	if !hasImportTasks {
+		validationErrs = append(validationErrs, errors.New("bad request - request body does not contain any import tasks"))
+	}
+
+	if len(validationErrs) > 0 {
+		for _, err := range validationErrs {
+			log.Event(ctx, "validation error", log.ERROR, log.Error(err), logData)
+		}
+		// todo: add all validation errors to the response
+		handleError(&taskError{validationErrs[0], http.StatusBadRequest})
 		return
 	}
 
 	log.Event(ctx, "updateImportTask endpoint: request successful", log.INFO, logData)
+	// TODO update and return instance ETag
+	setETag(w, instance.ETag)
 }
 
 func unmarshalImportTasks(reader io.Reader) (*models.InstanceImportTasks, error) {

--- a/instance/import_external_test.go
+++ b/instance/import_external_test.go
@@ -25,11 +25,11 @@ func Test_InsertedObservationsReturnsOk(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateObservationInsertedFunc: func(id string, ob int64) error {
-						return nil
+					UpdateObservationInsertedFunc: func(id *models.Instance, ob int64, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -42,7 +42,7 @@ func Test_InsertedObservationsReturnsOk(t *testing.T) {
 				So(w.Code, ShouldEqual, http.StatusOK)
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateObservationInsertedCalls()), ShouldEqual, 1)
 			})
 		})
@@ -59,7 +59,7 @@ func Test_InsertedObservationsReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return nil, errs.ErrInternalServer
 					},
 				}
@@ -88,11 +88,11 @@ func Test_InsertedObservationsReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateObservationInsertedFunc: func(id string, ob int64) error {
-						return errs.ErrInstanceNotFound
+					UpdateObservationInsertedFunc: func(id *models.Instance, ob int64, eTagSelector string) (string, error) {
+						return "", errs.ErrInstanceNotFound
 					},
 				}
 				datasetPermissions := mocks.NewAuthHandlerMock()
@@ -107,7 +107,7 @@ func Test_InsertedObservationsReturnsError(t *testing.T) {
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
 
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateObservationInsertedCalls()), ShouldEqual, 1)
 			})
 		})
@@ -118,7 +118,7 @@ func Test_InsertedObservationsReturnsError(t *testing.T) {
 				So(err, ShouldBeNil)
 				w := httptest.NewRecorder()
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.SubmittedState}, nil
 					},
 				}
@@ -153,11 +153,11 @@ func Test_UpdateImportTask_UpdateImportObservationsReturnsOk(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.CreatedState}, nil
 					},
-					UpdateImportObservationsTaskStateFunc: func(id string, state string) error {
-						return nil
+					UpdateImportObservationsTaskStateFunc: func(currentInstance *models.Instance, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -170,7 +170,7 @@ func Test_UpdateImportTask_UpdateImportObservationsReturnsOk(t *testing.T) {
 				So(w.Code, ShouldEqual, http.StatusOK)
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 			})
@@ -189,7 +189,7 @@ func Test_UpdateImportTaskRetrunsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return nil, errs.ErrInternalServer
 					},
 				}
@@ -220,7 +220,7 @@ func Test_UpdateImportTaskRetrunsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return nil, errs.ErrInstanceNotFound
 					},
 				}
@@ -251,11 +251,11 @@ func Test_UpdateImportTaskRetrunsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.PublishedState}, nil
 					},
-					UpdateInstanceFunc: func(ctx context.Context, id string, i *models.Instance) error {
-						return nil
+					UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -288,11 +288,11 @@ func Test_UpdateImportTask_UpdateImportObservationsReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateImportObservationsTaskStateFunc: func(id string, state string) error {
-						return nil
+					UpdateImportObservationsTaskStateFunc: func(currentInstance *models.Instance, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -322,11 +322,11 @@ func Test_UpdateImportTask_UpdateImportObservationsReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateImportObservationsTaskStateFunc: func(id string, state string) error {
-						return nil
+					UpdateImportObservationsTaskStateFunc: func(currentInstance *models.Instance, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -341,7 +341,7 @@ func Test_UpdateImportTask_UpdateImportObservationsReturnsError(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 			})
@@ -355,11 +355,11 @@ func Test_UpdateImportTask_UpdateImportObservationsReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateImportObservationsTaskStateFunc: func(id string, state string) error {
-						return nil
+					UpdateImportObservationsTaskStateFunc: func(currentInstance *models.Instance, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 				datasetPermissions := mocks.NewAuthHandlerMock()
@@ -373,7 +373,7 @@ func Test_UpdateImportTask_UpdateImportObservationsReturnsError(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 			})
@@ -387,11 +387,11 @@ func Test_UpdateImportTask_UpdateImportObservationsReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateImportObservationsTaskStateFunc: func(id string, state string) error {
-						return errs.ErrInternalServer
+					UpdateImportObservationsTaskStateFunc: func(currentInstance *models.Instance, state string, eTagSelector string) (string, error) {
+						return "", errs.ErrInternalServer
 					},
 				}
 
@@ -406,7 +406,7 @@ func Test_UpdateImportTask_UpdateImportObservationsReturnsError(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 1)
 			})
 		})
@@ -424,11 +424,11 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
-						return nil
+					UpdateBuildHierarchyTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -458,11 +458,11 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
-						return nil
+					UpdateBuildHierarchyTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -477,7 +477,7 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 0)
@@ -493,11 +493,11 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
-						return nil
+					UpdateBuildHierarchyTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -512,7 +512,7 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 0)
@@ -527,11 +527,11 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
-						return nil
+					UpdateBuildHierarchyTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -546,7 +546,7 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 0)
@@ -561,11 +561,11 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
-						return nil
+					UpdateBuildHierarchyTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -580,7 +580,7 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 0)
@@ -595,11 +595,11 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
-						return nil
+					UpdateBuildHierarchyTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -614,7 +614,7 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 0)
@@ -629,11 +629,11 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
-						return errors.New("not found")
+					UpdateBuildHierarchyTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return "", errors.New("not found")
 					},
 				}
 
@@ -648,7 +648,7 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 0)
@@ -663,11 +663,11 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
-						return errors.New("internal error")
+					UpdateBuildHierarchyTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return "", errors.New("internal error")
 					},
 				}
 
@@ -682,7 +682,7 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsError(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 0)
@@ -702,11 +702,11 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsOk(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.EditionConfirmedState}, nil
 					},
-					UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
-						return nil
+					UpdateBuildHierarchyTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -719,7 +719,7 @@ func Test_UpdateImportTask_BuildHierarchyTaskReturnsOk(t *testing.T) {
 				So(w.Code, ShouldEqual, http.StatusOK)
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 1)
 			})
@@ -738,11 +738,11 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.CreatedState}, nil
 					},
-					UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
-						return nil
+					UpdateBuildSearchTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -772,11 +772,11 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.CreatedState}, nil
 					},
-					UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
-						return nil
+					UpdateBuildSearchTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -791,7 +791,7 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 0)
@@ -806,11 +806,11 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.CreatedState}, nil
 					},
-					UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
-						return nil
+					UpdateBuildSearchTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 				datasetPermissions := mocks.NewAuthHandlerMock()
@@ -824,7 +824,7 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 0)
@@ -839,11 +839,11 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.CreatedState}, nil
 					},
-					UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
-						return nil
+					UpdateBuildSearchTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -858,7 +858,7 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 0)
@@ -873,11 +873,11 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.CreatedState}, nil
 					},
-					UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
-						return nil
+					UpdateBuildSearchTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -892,7 +892,7 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 0)
@@ -907,11 +907,11 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.CreatedState}, nil
 					},
-					UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
-						return nil
+					UpdateBuildSearchTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -926,7 +926,7 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 0)
@@ -941,11 +941,11 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.CreatedState}, nil
 					},
-					UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
-						return errors.New("not found")
+					UpdateBuildSearchTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return "", errors.New("not found")
 					},
 				}
 
@@ -960,7 +960,7 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 1)
@@ -975,11 +975,11 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.CreatedState}, nil
 					},
-					UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
-						return errors.New("internal error")
+					UpdateBuildSearchTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return "", errors.New("internal error")
 					},
 				}
 
@@ -994,7 +994,7 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexTask_Failure(t *testing.T) {
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 1)
@@ -1014,11 +1014,11 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexReturnsOk(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.CreatedState}, nil
 					},
-					UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
-						return nil
+					UpdateBuildSearchTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -1031,7 +1031,7 @@ func Test_UpdateImportTask_UpdateBuildSearchIndexReturnsOk(t *testing.T) {
 				So(w.Code, ShouldEqual, http.StatusOK)
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
-				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateImportObservationsTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildHierarchyTaskStateCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateBuildSearchTaskStateCalls()), ShouldEqual, 1)

--- a/instance/instance_editions_external_test.go
+++ b/instance/instance_editions_external_test.go
@@ -43,7 +43,7 @@ func Test_UpdateInstanceToEditionConfirmedReturnsOk(t *testing.T) {
 				}
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return currentInstanceTest_Data, nil
 					},
 					GetEditionFunc: func(datasetID string, edition string, state string) (*models.EditionUpdate, error) {
@@ -55,8 +55,8 @@ func Test_UpdateInstanceToEditionConfirmedReturnsOk(t *testing.T) {
 					GetNextVersionFunc: func(string, string) (int, error) {
 						return 1, nil
 					},
-					UpdateInstanceFunc: func(ctx context.Context, id string, i *models.Instance) error {
-						return nil
+					UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 					AddVersionDetailsToInstanceFunc: func(ctx context.Context, instanceID string, datasetID string, edition string, version int) error {
 						return nil
@@ -113,7 +113,7 @@ func Test_UpdateInstanceToEditionConfirmedReturnsError(t *testing.T) {
 				}
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return currentInstanceTest_Data, nil
 					},
 					GetEditionFunc: func(datasetID string, edition string, state string) (*models.EditionUpdate, error) {
@@ -125,8 +125,8 @@ func Test_UpdateInstanceToEditionConfirmedReturnsError(t *testing.T) {
 					GetNextVersionFunc: func(string, string) (int, error) {
 						return 1, nil
 					},
-					UpdateInstanceFunc: func(ctx context.Context, id string, i *models.Instance) error {
-						return nil
+					UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 					AddVersionDetailsToInstanceFunc: func(ctx context.Context, instanceID string, datasetID string, edition string, version int) error {
 						return errors.New("boom")
@@ -168,11 +168,11 @@ func Test_UpdateInstanceToEditionConfirmedReturnsError(t *testing.T) {
 				}
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return currentInstanceTest_Data, nil
 					},
-					UpdateInstanceFunc: func(ctx context.Context, id string, i *models.Instance) error {
-						return nil
+					UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 				datasetPermissions := mocks.NewAuthHandlerMock()

--- a/instance/instance_editions_external_test.go
+++ b/instance/instance_editions_external_test.go
@@ -198,6 +198,13 @@ func Test_UpdateInstanceToEditionConfirmedReturnsError(t *testing.T) {
 	})
 }
 
+func validateLock(mockedDataStore *storetest.StorerMock, expectedInstanceID string) {
+	So(mockedDataStore.AcquireInstanceLockCalls(), ShouldHaveLength, 1)
+	So(mockedDataStore.AcquireInstanceLockCalls()[0].InstanceID, ShouldEqual, "123")
+	So(mockedDataStore.UnlockInstanceCalls(), ShouldHaveLength, 1)
+	So(mockedDataStore.UnlockInstanceCalls()[0].LockID, ShouldEqual, testLockID)
+}
+
 func storeMockWithLock(instance *models.Instance, expectFirstGetUnlocked bool) (*storetest.StorerMock, *bool) {
 	isLocked := false
 	numGetCall := 0

--- a/instance/instance_editions_external_test.go
+++ b/instance/instance_editions_external_test.go
@@ -15,6 +15,8 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const testLockID = "testLock"
+
 func Test_UpdateInstanceToEditionConfirmedReturnsOk(t *testing.T) {
 	Convey("Given a PUT request to update an instance resource", t, func() {
 		Convey("When the requested state change is to 'edition-confirmed'", func() {
@@ -42,25 +44,26 @@ func Test_UpdateInstanceToEditionConfirmedReturnsOk(t *testing.T) {
 					State: models.CompletedState,
 				}
 
-				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
-						return currentInstanceTest_Data, nil
-					},
-					GetEditionFunc: func(datasetID string, edition string, state string) (*models.EditionUpdate, error) {
-						return nil, errs.ErrEditionNotFound
-					},
-					UpsertEditionFunc: func(datasetID, edition string, editionDoc *models.EditionUpdate) error {
-						return nil
-					},
-					GetNextVersionFunc: func(string, string) (int, error) {
-						return 1, nil
-					},
-					UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
-						return testETag, nil
-					},
-					AddVersionDetailsToInstanceFunc: func(ctx context.Context, instanceID string, datasetID string, edition string, version int) error {
-						return nil
-					},
+				mockedDataStore, isLocked := storeMockWithLock(currentInstanceTest_Data, true)
+				mockedDataStore.GetEditionFunc = func(datasetID string, edition string, state string) (*models.EditionUpdate, error) {
+					So(*isLocked, ShouldBeTrue)
+					return nil, errs.ErrEditionNotFound
+				}
+				mockedDataStore.UpsertEditionFunc = func(datasetID, edition string, editionDoc *models.EditionUpdate) error {
+					So(*isLocked, ShouldBeTrue)
+					return nil
+				}
+				mockedDataStore.GetNextVersionFunc = func(string, string) (int, error) {
+					So(*isLocked, ShouldBeTrue)
+					return 1, nil
+				}
+				mockedDataStore.UpdateInstanceFunc = func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
+					So(*isLocked, ShouldBeTrue)
+					return testETag, nil
+				}
+				mockedDataStore.AddVersionDetailsToInstanceFunc = func(ctx context.Context, instanceID string, datasetID string, edition string, version int) error {
+					So(*isLocked, ShouldBeTrue)
+					return nil
 				}
 				datasetPermissions := mocks.NewAuthHandlerMock()
 				permissions := mocks.NewAuthHandlerMock()
@@ -77,6 +80,7 @@ func Test_UpdateInstanceToEditionConfirmedReturnsOk(t *testing.T) {
 				//	So(len(mockedDataStore.GetNextVersionCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.UpdateInstanceCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.AddVersionDetailsToInstanceCalls()), ShouldEqual, 1)
+				So(*isLocked, ShouldBeFalse)
 			})
 		})
 	})
@@ -112,25 +116,26 @@ func Test_UpdateInstanceToEditionConfirmedReturnsError(t *testing.T) {
 					State: models.CompletedState,
 				}
 
-				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
-						return currentInstanceTest_Data, nil
-					},
-					GetEditionFunc: func(datasetID string, edition string, state string) (*models.EditionUpdate, error) {
-						return nil, errs.ErrEditionNotFound
-					},
-					UpsertEditionFunc: func(datasetID, edition string, editionDoc *models.EditionUpdate) error {
-						return nil
-					},
-					GetNextVersionFunc: func(string, string) (int, error) {
-						return 1, nil
-					},
-					UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
-						return testETag, nil
-					},
-					AddVersionDetailsToInstanceFunc: func(ctx context.Context, instanceID string, datasetID string, edition string, version int) error {
-						return errors.New("boom")
-					},
+				mockedDataStore, isLocked := storeMockWithLock(currentInstanceTest_Data, true)
+				mockedDataStore.GetEditionFunc = func(datasetID string, edition string, state string) (*models.EditionUpdate, error) {
+					So(*isLocked, ShouldBeTrue)
+					return nil, errs.ErrEditionNotFound
+				}
+				mockedDataStore.UpsertEditionFunc = func(datasetID, edition string, editionDoc *models.EditionUpdate) error {
+					So(*isLocked, ShouldBeTrue)
+					return nil
+				}
+				mockedDataStore.GetNextVersionFunc = func(string, string) (int, error) {
+					So(*isLocked, ShouldBeTrue)
+					return 1, nil
+				}
+				mockedDataStore.UpdateInstanceFunc = func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
+					So(*isLocked, ShouldBeTrue)
+					return testETag, nil
+				}
+				mockedDataStore.AddVersionDetailsToInstanceFunc = func(ctx context.Context, instanceID string, datasetID string, edition string, version int) error {
+					So(*isLocked, ShouldBeTrue)
+					return errors.New("boom")
 				}
 
 				datasetPermissions := mocks.NewAuthHandlerMock()
@@ -147,6 +152,7 @@ func Test_UpdateInstanceToEditionConfirmedReturnsError(t *testing.T) {
 				So(len(mockedDataStore.UpsertEditionCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.AddVersionDetailsToInstanceCalls()), ShouldEqual, 1)
 				So(len(mockedDataStore.UpdateInstanceCalls()), ShouldEqual, 0)
+				So(*isLocked, ShouldBeFalse)
 			})
 		})
 
@@ -167,13 +173,10 @@ func Test_UpdateInstanceToEditionConfirmedReturnsError(t *testing.T) {
 					State: models.EditionConfirmedState,
 				}
 
-				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
-						return currentInstanceTest_Data, nil
-					},
-					UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
-						return testETag, nil
-					},
+				mockedDataStore, isLocked := storeMockWithLock(currentInstanceTest_Data, true)
+				mockedDataStore.UpdateInstanceFunc = func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
+					So(*&isLocked, ShouldBeTrue)
+					return testETag, nil
 				}
 				datasetPermissions := mocks.NewAuthHandlerMock()
 				permissions := mocks.NewAuthHandlerMock()
@@ -189,7 +192,34 @@ func Test_UpdateInstanceToEditionConfirmedReturnsError(t *testing.T) {
 				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 2)
 				So(len(mockedDataStore.UpdateInstanceCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.AddVersionDetailsToInstanceCalls()), ShouldEqual, 0)
+				So(*isLocked, ShouldBeFalse)
 			})
 		})
 	})
+}
+
+func storeMockWithLock(instance *models.Instance, expectFirstGetUnlocked bool) (*storetest.StorerMock, *bool) {
+	isLocked := false
+	numGetCall := 0
+	return &storetest.StorerMock{
+		AcquireInstanceLockFunc: func(ctx context.Context, instanceID string) (string, error) {
+			isLocked = true
+			return testLockID, nil
+		},
+		UnlockInstanceFunc: func(lockID string) error {
+			isLocked = false
+			return nil
+		},
+		GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
+			if expectFirstGetUnlocked {
+				if numGetCall > 0 {
+					So(isLocked, ShouldBeTrue)
+				} else {
+					So(isLocked, ShouldBeFalse)
+				}
+			}
+			numGetCall++
+			return instance, nil
+		},
+	}, &isLocked
 }

--- a/instance/instance_external_test.go
+++ b/instance/instance_external_test.go
@@ -208,7 +208,7 @@ func Test_GetInstanceReturnsOK(t *testing.T) {
 				So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 				So(mockedDataStore.GetInstanceCalls()[0].ID, ShouldEqual, "123")
 				So(mockedDataStore.GetInstanceCalls()[0].ETagSelector, ShouldEqual, testIfMatch)
-				So(w.Header().Get("eTag"), ShouldEqual, testETag)
+				So(w.Header().Get("ETag"), ShouldEqual, testETag)
 			})
 		})
 	})
@@ -336,7 +336,9 @@ func Test_AddInstanceReturnsCreated(t *testing.T) {
 
 				mockedDataStore := &storetest.StorerMock{
 					AddInstanceFunc: func(*models.Instance) (*models.Instance, error) {
-						return &models.Instance{}, nil
+						return &models.Instance{
+							ETag: testETag,
+						}, nil
 					},
 				}
 
@@ -346,6 +348,7 @@ func Test_AddInstanceReturnsCreated(t *testing.T) {
 				datasetAPI.Router.ServeHTTP(w, r)
 
 				So(w.Code, ShouldEqual, http.StatusCreated)
+				So(w.Header().Get("ETag"), ShouldEqual, testETag)
 				So(len(mockedDataStore.AddInstanceCalls()), ShouldEqual, 1)
 
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
@@ -460,6 +463,7 @@ func Test_UpdateInstanceReturnsOk(t *testing.T) {
 						},
 					},
 					State: models.CreatedState,
+					ETag:  testETag,
 				}, true)
 
 				mockedDataStore.UpdateInstanceFunc = func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
@@ -473,6 +477,7 @@ func Test_UpdateInstanceReturnsOk(t *testing.T) {
 				datasetAPI.Router.ServeHTTP(w, r)
 
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get("ETag"), ShouldEqual, testETag)
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
 				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 3)

--- a/instance/instance_external_test.go
+++ b/instance/instance_external_test.go
@@ -189,7 +189,7 @@ func Test_GetInstanceReturnsOK(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(ID string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: models.CreatedState}, nil
 					},
 				}
@@ -219,7 +219,7 @@ func Test_GetInstanceReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(ID string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return nil, errs.ErrInternalServer
 					},
 				}
@@ -245,7 +245,7 @@ func Test_GetInstanceReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(ID string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: "gobbledygook"}, nil
 					},
 				}
@@ -270,7 +270,7 @@ func Test_GetInstanceReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(ID string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return nil, errs.ErrInstanceNotFound
 					},
 				}
@@ -421,7 +421,7 @@ func Test_UpdateInstanceReturnsOk(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{
 							Links: &models.InstanceLinks{
 								Dataset: &models.LinkObject{
@@ -436,8 +436,8 @@ func Test_UpdateInstanceReturnsOk(t *testing.T) {
 							State: models.CreatedState,
 						}, nil
 					},
-					UpdateInstanceFunc: func(ctx context.Context, id string, i *models.Instance) error {
-						return nil
+					UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -469,7 +469,7 @@ func Test_UpdateInstanceReturnsError(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return nil, errs.ErrInternalServer
 					},
 				}
@@ -497,7 +497,7 @@ func Test_UpdateInstanceReturnsError(t *testing.T) {
 				So(err, ShouldBeNil)
 				w := httptest.NewRecorder()
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: "gobbledygook"}, nil
 					},
 				}
@@ -525,7 +525,7 @@ func Test_UpdateInstanceReturnsError(t *testing.T) {
 				So(err, ShouldBeNil)
 				w := httptest.NewRecorder()
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: "completed"}, nil
 					},
 				}
@@ -553,11 +553,11 @@ func Test_UpdateInstanceReturnsError(t *testing.T) {
 				So(err, ShouldBeNil)
 				w := httptest.NewRecorder()
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return &models.Instance{State: "completed"}, nil
 					},
-					UpdateInstanceFunc: func(ctx context.Context, id string, i *models.Instance) error {
-						return nil
+					UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
+						return testETag, nil
 					},
 				}
 
@@ -586,7 +586,7 @@ func Test_UpdateInstanceReturnsError(t *testing.T) {
 				So(err, ShouldBeNil)
 				w := httptest.NewRecorder()
 				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(id string) (*models.Instance, error) {
+					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 						return nil, errs.ErrInstanceNotFound
 					},
 				}

--- a/instance/instance_external_test.go
+++ b/instance/instance_external_test.go
@@ -179,36 +179,60 @@ func Test_GetInstancesReturnsError(t *testing.T) {
 
 func Test_GetInstanceReturnsOK(t *testing.T) {
 	t.Parallel()
-	Convey("Given a GET request to retrieve an instance resource is made", t, func() {
-		Convey("When the request is authorised", func() {
-			Convey("Then return status ok (200)", func() {
-				r, err := createRequestWithToken("GET", "http://localhost:21800/instances/123", nil)
-				r.Header.Set("If-Match", testIfMatch)
-				So(err, ShouldBeNil)
-				w := httptest.NewRecorder()
 
-				mockedDataStore := &storetest.StorerMock{
-					GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
-						return &models.Instance{
-							State: models.CreatedState,
-							ETag:  testETag,
-						}, nil
-					},
-				}
+	Convey("Given a dataset API with a successful store mock and auth", t, func() {
+		mockedDataStore := &storetest.StorerMock{
+			GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
+				return &models.Instance{
+					State: models.CreatedState,
+					ETag:  testETag,
+				}, nil
+			},
+		}
+		datasetPermissions := mocks.NewAuthHandlerMock()
+		permissions := mocks.NewAuthHandlerMock()
+		datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
 
-				datasetPermissions := mocks.NewAuthHandlerMock()
-				permissions := mocks.NewAuthHandlerMock()
+		Convey("When a GET request to retrieve an instance resource is made, with a valid If-Match header", func() {
+			r, err := createRequestWithToken("GET", "http://localhost:21800/instances/123", nil)
+			r.Header.Set("If-Match", testIfMatch)
+			So(err, ShouldBeNil)
+			w := httptest.NewRecorder()
 
-				datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
-				datasetAPI.Router.ServeHTTP(w, r)
+			datasetAPI.Router.ServeHTTP(w, r)
 
+			Convey("Then the response status is 200 OK, with the expected ETag header", func() {
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get("ETag"), ShouldEqual, testETag)
+			})
+
+			Convey("Then the expected functions are called", func() {
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
 				So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
 				So(mockedDataStore.GetInstanceCalls()[0].ID, ShouldEqual, "123")
 				So(mockedDataStore.GetInstanceCalls()[0].ETagSelector, ShouldEqual, testIfMatch)
+			})
+		})
+
+		Convey("When a GET request to retrieve an instance resource is made, without an If-Match header", func() {
+			r, err := createRequestWithToken("GET", "http://localhost:21800/instances/123", nil)
+			So(err, ShouldBeNil)
+			w := httptest.NewRecorder()
+
+			datasetAPI.Router.ServeHTTP(w, r)
+
+			Convey("Then the response status is 200 OK, with the expected ETag header", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
 				So(w.Header().Get("ETag"), ShouldEqual, testETag)
+			})
+
+			Convey("Then the expected functions are called, with the '*' wildchar when validting the provided If-Match value", func() {
+				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
+				So(permissions.Required.Calls, ShouldEqual, 1)
+				So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
+				So(mockedDataStore.GetInstanceCalls()[0].ID, ShouldEqual, "123")
+				So(mockedDataStore.GetInstanceCalls()[0].ETagSelector, ShouldEqual, AnyETag)
 			})
 		})
 	})
@@ -442,54 +466,101 @@ func Test_AddInstanceReturnsError(t *testing.T) {
 
 func Test_UpdateInstanceReturnsOk(t *testing.T) {
 	t.Parallel()
-	Convey("Given a PUT request to update state of an instance resource is made", t, func() {
-		Convey("When the requested state change is to 'submitted'", func() {
-			Convey("Then return status ok (200)", func() {
-				body := strings.NewReader(`{"state":"submitted"}`)
-				r, err := createRequestWithToken("PUT", "http://localhost:21800/instances/123", body)
-				r.Header.Set("If-Match", testIfMatch)
-				So(err, ShouldBeNil)
-				w := httptest.NewRecorder()
 
-				mockedDataStore, isLocked := storeMockWithLock(&models.Instance{
-					Links: &models.InstanceLinks{
-						Dataset: &models.LinkObject{
-							ID:   "234",
-							HRef: "example.com/234",
-						},
-						Self: &models.LinkObject{
-							ID:   "123",
-							HRef: "example.com/123",
-						},
-					},
-					State: models.CreatedState,
-					ETag:  testETag,
-				}, true)
+	Convey("Given a dataset API with a successful store mock and auth", t, func() {
+		mockedDataStore, isLocked := storeMockWithLock(&models.Instance{
+			InstanceID: "123",
+			Links: &models.InstanceLinks{
+				Dataset: &models.LinkObject{
+					ID:   "234",
+					HRef: "example.com/234",
+				},
+				Self: &models.LinkObject{
+					ID:   "123",
+					HRef: "example.com/123",
+				},
+			},
+			State: models.CreatedState,
+			ETag:  testETag,
+		}, true)
 
-				mockedDataStore.UpdateInstanceFunc = func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
-					So(*isLocked, ShouldBeTrue)
-					return testETag, nil
-				}
+		mockedDataStore.UpdateInstanceFunc = func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
+			So(*isLocked, ShouldBeTrue)
+			return testETag, nil
+		}
 
-				datasetPermissions := mocks.NewAuthHandlerMock()
-				permissions := mocks.NewAuthHandlerMock()
-				datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
-				datasetAPI.Router.ServeHTTP(w, r)
+		datasetPermissions := mocks.NewAuthHandlerMock()
+		permissions := mocks.NewAuthHandlerMock()
+		datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
 
+		Convey("When a PUT request to update state of an instance resource to 'submitted' is made with a valid If-Match header", func() {
+			body := strings.NewReader(`{"state":"submitted"}`)
+			r, err := createRequestWithToken("PUT", "http://localhost:21800/instances/123", body)
+			r.Header.Set("If-Match", testIfMatch)
+			So(err, ShouldBeNil)
+			w := httptest.NewRecorder()
+			datasetAPI.Router.ServeHTTP(w, r)
+
+			Convey("Then the response status is 200 OK, with the expected ETag header", func() {
 				So(w.Code, ShouldEqual, http.StatusOK)
 				So(w.Header().Get("ETag"), ShouldEqual, testETag)
+			})
+
+			Convey("Then the expected functions are called", func() {
 				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
 				So(permissions.Required.Calls, ShouldEqual, 1)
 				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 3)
 				So(mockedDataStore.GetInstanceCalls()[0].ID, ShouldEqual, "123")
 				So(mockedDataStore.GetInstanceCalls()[0].ETagSelector, ShouldEqual, testIfMatch)
+				So(mockedDataStore.GetInstanceCalls()[1].ID, ShouldEqual, "123")
+				So(mockedDataStore.GetInstanceCalls()[1].ETagSelector, ShouldEqual, testIfMatch)
+				So(mockedDataStore.GetInstanceCalls()[2].ID, ShouldEqual, "123")
+				So(mockedDataStore.GetInstanceCalls()[2].ETagSelector, ShouldEqual, testETag)
 				So(len(mockedDataStore.UpdateInstanceCalls()), ShouldEqual, 1)
 				So(mockedDataStore.UpdateInstanceCalls()[0].ETagSelector, ShouldEqual, testIfMatch)
-				So(len(mockedDataStore.AddVersionDetailsToInstanceCalls()), ShouldEqual, 0)
+				So(mockedDataStore.UpdateInstanceCalls()[0].CurrentInstance.InstanceID, ShouldEqual, "123")
+				So(mockedDataStore.UpdateInstanceCalls()[0].UpdatedInstance.State, ShouldEqual, models.SubmittedState)
+			})
+
+			Convey("Then the mongoDB instance lock is acquired and released as expected", func() {
+				validateLock(mockedDataStore, "123")
 				So(*isLocked, ShouldBeFalse)
 			})
 		})
 
+		Convey("When a PUT request to update state of an instance resource to 'submitted' is made without an If-Match header", func() {
+			body := strings.NewReader(`{"state":"submitted"}`)
+			r, err := createRequestWithToken("PUT", "http://localhost:21800/instances/123", body)
+			So(err, ShouldBeNil)
+			w := httptest.NewRecorder()
+			datasetAPI.Router.ServeHTTP(w, r)
+
+			Convey("Then the response status is 200 OK, with the expected ETag header", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get("ETag"), ShouldEqual, testETag)
+			})
+
+			Convey("Then the expected functions are called", func() {
+				So(datasetPermissions.Required.Calls, ShouldEqual, 0)
+				So(permissions.Required.Calls, ShouldEqual, 1)
+				So(len(mockedDataStore.GetInstanceCalls()), ShouldEqual, 3)
+				So(mockedDataStore.GetInstanceCalls()[0].ID, ShouldEqual, "123")
+				So(mockedDataStore.GetInstanceCalls()[0].ETagSelector, ShouldEqual, AnyETag)
+				So(mockedDataStore.GetInstanceCalls()[1].ID, ShouldEqual, "123")
+				So(mockedDataStore.GetInstanceCalls()[1].ETagSelector, ShouldEqual, AnyETag)
+				So(mockedDataStore.GetInstanceCalls()[2].ID, ShouldEqual, "123")
+				So(mockedDataStore.GetInstanceCalls()[2].ETagSelector, ShouldEqual, testETag)
+				So(len(mockedDataStore.UpdateInstanceCalls()), ShouldEqual, 1)
+				So(mockedDataStore.UpdateInstanceCalls()[0].ETagSelector, ShouldEqual, AnyETag)
+				So(mockedDataStore.UpdateInstanceCalls()[0].CurrentInstance.InstanceID, ShouldEqual, "123")
+				So(mockedDataStore.UpdateInstanceCalls()[0].UpdatedInstance.State, ShouldEqual, models.SubmittedState)
+			})
+
+			Convey("Then the mongoDB instance lock is acquired and released as expected", func() {
+				validateLock(mockedDataStore, "123")
+				So(*isLocked, ShouldBeFalse)
+			})
+		})
 	})
 }
 

--- a/models/instance_test.go
+++ b/models/instance_test.go
@@ -253,3 +253,118 @@ func TestValidateImportTask(t *testing.T) {
 		})
 	})
 }
+
+func TestInstanceHash(t *testing.T) {
+
+	testInstance := func() Instance {
+		return Instance{
+			InstanceID: "myInstance",
+			Edition:    "myEdition",
+			State:      CreatedState,
+			Version:    1,
+			Dimensions: []Dimension{
+				{
+					HRef: "http://dimensions.co.uk/dim1",
+					Name: "dim1",
+				},
+				{
+					HRef: "http://dimensions.co.uk/dim2",
+					Name: "dim2",
+				},
+			},
+			ImportTasks: &InstanceImportTasks{
+				BuildHierarchyTasks: []*BuildHierarchyTask{
+					{DimensionID: "dim1"},
+				},
+				BuildSearchIndexTasks: []*BuildSearchIndexTask{
+					{GenericTaskDetails{
+						DimensionName: "dim2",
+						State:         CreatedState,
+					}},
+				},
+				ImportObservations: &ImportObservationsTask{
+					InsertedObservations: 7,
+					State:                CreatedState,
+				},
+			},
+		}
+	}
+
+	Convey("Given an instance with some data", t, func() {
+		instance := testInstance()
+
+		Convey("We can generate a valid hash", func() {
+			h, err := instance.Hash(nil)
+			So(err, ShouldBeNil)
+			So(len(h), ShouldEqual, 40)
+
+			Convey("Then hashing it twice, produces the same result", func() {
+				hash, err := instance.Hash(nil)
+				So(err, ShouldBeNil)
+				So(hash, ShouldEqual, h)
+			})
+
+			Convey("Then storing the hash as its ETag value and hashing it again, produces the same result (field is ignored) and ETag field is preserved", func() {
+				instance.ETag = h
+				hash, err := instance.Hash(nil)
+				So(err, ShouldBeNil)
+				So(hash, ShouldEqual, h)
+				So(instance.ETag, ShouldEqual, h)
+			})
+
+			Convey("Then another instance with exactly the same data will resolve to the same hash", func() {
+				instance2 := testInstance()
+				hash, err := instance2.Hash(nil)
+				So(err, ShouldBeNil)
+				So(hash, ShouldEqual, h)
+			})
+
+			Convey("Then if a instance value is modified, its hash changes", func() {
+				instance.State = CompletedState
+				hash, err := instance.Hash(nil)
+				So(err, ShouldBeNil)
+				So(hash, ShouldNotEqual, h)
+			})
+
+			Convey("Then if a dimension is added to the instance, its hash changes", func() {
+				instance.Dimensions = append(instance.Dimensions, Dimension{Name: "dim3"})
+				hash, err := instance.Hash(nil)
+				So(err, ShouldBeNil)
+				So(hash, ShouldNotEqual, h)
+			})
+
+			Convey("Then if a dimension is removed from the instance, its hash changes", func() {
+				instance.Dimensions = []Dimension{
+					{
+						HRef: "http://dimensions.co.uk/dim1",
+						Name: "dim1",
+					},
+				}
+				hash, err := instance.Hash(nil)
+				So(err, ShouldBeNil)
+				So(hash, ShouldNotEqual, h)
+			})
+
+			Convey("Then if a BuildHierarchyTasks changes, its hash changes", func() {
+				instance.ImportTasks.BuildHierarchyTasks[0].State = CompletedState
+				hash, err := instance.Hash(nil)
+				So(err, ShouldBeNil)
+				So(hash, ShouldNotEqual, h)
+			})
+
+			Convey("Then if a BuildSearchIndexTasks changes, its hash changes", func() {
+				instance.ImportTasks.BuildSearchIndexTasks[0].State = CompletedState
+				hash, err := instance.Hash(nil)
+				So(err, ShouldBeNil)
+				So(hash, ShouldNotEqual, h)
+			})
+
+			Convey("Then if the ImportObservations changes, its hash changes", func() {
+				instance.ImportTasks.ImportObservations.State = CompletedState
+				hash, err := instance.Hash(nil)
+				So(err, ShouldBeNil)
+				So(hash, ShouldNotEqual, h)
+			})
+		})
+	})
+}

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -2,76 +2,16 @@ package mongo
 
 import (
 	"context"
-	"errors"
 
 	"sync"
 	"time"
 
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/models"
-	"github.com/ONSdigital/dp-healthcheck/healthcheck"
-	dpmongo "github.com/ONSdigital/dp-mongodb"
-	dpMongoHealth "github.com/ONSdigital/dp-mongodb/health"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 )
-
-// Mongo represents a simplistic MongoDB configuration.
-type Mongo struct {
-	CodeListURL    string
-	Collection     string
-	Database       string
-	DatasetURL     string
-	Session        *mgo.Session
-	URI            string
-	lastPingTime   time.Time
-	lastPingResult error
-	healthClient   *dpMongoHealth.CheckMongoClient
-}
-
-const (
-	editionsCollection = "editions"
-)
-
-// Init creates a new mgo.Session with a strong consistency and a write mode of "majortiy"; and initialises the mongo health client.
-func (m *Mongo) Init() (err error) {
-	if m.Session != nil {
-		return errors.New("session already exists")
-	}
-
-	// Create session
-	if m.Session, err = mgo.Dial(m.URI); err != nil {
-		return err
-	}
-	m.Session.EnsureSafe(&mgo.Safe{WMode: "majority"})
-	m.Session.SetMode(mgo.Strong, true)
-
-	databaseCollectionBuilder := make(map[dpMongoHealth.Database][]dpMongoHealth.Collection)
-	databaseCollectionBuilder[(dpMongoHealth.Database)(m.Database)] = []dpMongoHealth.Collection{(dpMongoHealth.Collection)(m.Collection), (dpMongoHealth.Collection)(editionsCollection), (dpMongoHealth.Collection)(instanceCollection), (dpMongoHealth.Collection)(dimensionOptions)}
-
-	// Create client and healthclient from session
-	client := dpMongoHealth.NewClientWithCollections(m.Session, databaseCollectionBuilder)
-	m.healthClient = &dpMongoHealth.CheckMongoClient{
-		Client:      *client,
-		Healthcheck: client.Healthcheck,
-	}
-
-	return nil
-}
-
-// Close represents mongo session closing within the context deadline
-func (m *Mongo) Close(ctx context.Context) error {
-	if m.Session == nil {
-		return errors.New("cannot close a mongoDB connection without a valid session")
-	}
-	return dpmongo.Close(ctx, m.Session)
-}
-
-// Checker is called by the healthcheck library to check the health state of this mongoDB instance
-func (m *Mongo) Checker(ctx context.Context, state *healthcheck.CheckState) error {
-	return m.healthClient.Checker(ctx, state)
-}
 
 // GetDatasets retrieves all dataset documents
 func (m *Mongo) GetDatasets(ctx context.Context, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {

--- a/mongo/dimension_store.go
+++ b/mongo/dimension_store.go
@@ -12,7 +12,6 @@ import (
 	"github.com/globalsign/mgo/bson"
 )
 
-const dimensionOptions = "dimension.options"
 const maxIDs = 1000
 
 // GetDimensionsFromInstance returns a list of dimensions and their options for an instance resource.

--- a/mongo/etag.go
+++ b/mongo/etag.go
@@ -26,14 +26,6 @@ func newETagForAddEvent(currentInstance *models.Instance, event *models.Event) (
 	return currentInstance.Hash(b)
 }
 
-func newETagForNodeIDAndOrder(currentInstance *models.Instance, nodeID string, order *int) (eTag string, err error) {
-	b := []byte(nodeID)
-	if order != nil {
-		b = []byte(fmt.Sprintf("%s%d", nodeID, &order))
-	}
-	return currentInstance.Hash(b)
-}
-
 func newETagForObservationsInserted(currentInstance *models.Instance, observationInserted int64) (eTag string, err error) {
 	b := []byte(fmt.Sprintf("observationInserted%d", observationInserted))
 	return currentInstance.Hash(b)
@@ -52,4 +44,20 @@ func newETagForHierarchyTaskStateUpdate(currentInstance *models.Instance, dimens
 func newETagForBuildSearchTaskStateUpdate(currentInstance *models.Instance, dimension, state string) (eTag string, err error) {
 	b := []byte(fmt.Sprintf("buildSearchTask_dimension%sstate%s", dimension, state))
 	return currentInstance.Hash(b)
+}
+
+func newETagForNodeIDAndOrder(currentInstance *models.Instance, nodeID string, order *int) (eTag string, err error) {
+	b := []byte(nodeID)
+	if order != nil {
+		b = []byte(fmt.Sprintf("%s%d", nodeID, &order))
+	}
+	return currentInstance.Hash(b)
+}
+
+func newETagForAddDimensionOption(currentInstance *models.Instance, option *models.CachedDimensionOption) (eTag string, err error) {
+	optionBytes, err := bson.Marshal(option)
+	if err != nil {
+		return "", err
+	}
+	return currentInstance.Hash(optionBytes)
 }

--- a/mongo/etag.go
+++ b/mongo/etag.go
@@ -1,0 +1,55 @@
+package mongo
+
+import (
+	"fmt"
+
+	"github.com/ONSdigital/dp-dataset-api/models"
+	"github.com/globalsign/mgo/bson"
+)
+
+// AnyETag represents the wildchar that corresponds to not check the ETag value for update requests
+const AnyETag = "*"
+
+func newETagForUpdate(currentInstance *models.Instance, update *models.Instance) (eTag string, err error) {
+	b, err := bson.Marshal(update)
+	if err != nil {
+		return "", err
+	}
+	return currentInstance.Hash(b)
+}
+
+func newETagForAddEvent(currentInstance *models.Instance, event *models.Event) (eTag string, err error) {
+	b, err := bson.Marshal(event)
+	if err != nil {
+		return "", err
+	}
+	return currentInstance.Hash(b)
+}
+
+func newETagForNodeIDAndOrder(currentInstance *models.Instance, nodeID string, order *int) (eTag string, err error) {
+	b := []byte(nodeID)
+	if order != nil {
+		b = []byte(fmt.Sprintf("%s%d", nodeID, &order))
+	}
+	return currentInstance.Hash(b)
+}
+
+func newETagForObservationsInserted(currentInstance *models.Instance, observationInserted int64) (eTag string, err error) {
+	b := []byte(fmt.Sprintf("observationInserted%d", observationInserted))
+	return currentInstance.Hash(b)
+}
+
+func newETagForStateUpdate(currentInstance *models.Instance, state string) (eTag string, err error) {
+	b := []byte(fmt.Sprintf("state%s", state))
+	return currentInstance.Hash(b)
+}
+
+func newETagForHierarchyTaskStateUpdate(currentInstance *models.Instance, dimension, state string) (eTag string, err error) {
+	b := []byte(fmt.Sprintf("hierarchyTask_dimension%sstate%s", dimension, state))
+	return currentInstance.Hash(b)
+}
+
+func newETagForBuildSearchTaskStateUpdate(currentInstance *models.Instance, dimension, state string) (eTag string, err error) {
+	b := []byte(fmt.Sprintf("buildSearchTask_dimension%sstate%s", dimension, state))
+	return currentInstance.Hash(b)
+}

--- a/mongo/etag_test.go
+++ b/mongo/etag_test.go
@@ -1,0 +1,275 @@
+package mongo
+
+import (
+	"testing"
+
+	"github.com/ONSdigital/dp-dataset-api/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func testInstance() *models.Instance {
+	i := &models.Instance{
+		CollectionID: "testCollection",
+		Dimensions:   []models.Dimension{{Name: "dim1"}, {Name: "dim2"}},
+		Edition:      "testEdition",
+		InstanceID:   "123",
+		State:        models.CreatedState,
+	}
+	eTag0, err := i.Hash(nil)
+	So(err, ShouldBeNil)
+	i.ETag = eTag0
+	return i
+}
+
+func TestNewETagForUpdate(t *testing.T) {
+
+	Convey("Given an instance", t, func() {
+
+		currentInstance := testInstance()
+
+		update := &models.Instance{
+			State: models.CompletedState,
+		}
+
+		Convey("getNewETagForUpdate returns an eTag that is different from the original instance ETag", func() {
+			eTag1, err := newETagForUpdate(currentInstance, update)
+			So(err, ShouldBeNil)
+			So(eTag1, ShouldNotEqual, currentInstance.ETag)
+
+			Convey("Applying the same update to a different filter results in a different ETag", func() {
+				instance2 := testInstance()
+				instance2.InstanceID = "otherInstance"
+				eTag2, err := newETagForUpdate(instance2, update)
+				So(err, ShouldBeNil)
+				So(eTag2, ShouldNotEqual, eTag1)
+			})
+
+			Convey("Applying a different update to the same filter results in a different ETag", func() {
+				update2 := &models.Instance{
+					InstanceID: "anotherInstanceID",
+				}
+				eTag3, err := newETagForUpdate(currentInstance, update2)
+				So(err, ShouldBeNil)
+				So(eTag3, ShouldNotEqual, eTag1)
+			})
+		})
+	})
+}
+
+func TestNewETagForAddEvent(t *testing.T) {
+
+	Convey("Given an instance", t, func() {
+
+		currentInstance := testInstance()
+
+		event := models.Event{
+			Message: "testEvent",
+		}
+
+		Convey("newETagForAddEvent returns an eTag that is different from the original instance ETag", func() {
+			eTag1, err := newETagForAddEvent(currentInstance, &event)
+			So(err, ShouldBeNil)
+			So(eTag1, ShouldNotEqual, currentInstance.ETag)
+
+			Convey("Applying the same update to a different instance results in a different ETag", func() {
+				instance2 := testInstance()
+				instance2.InstanceID = "otherInstance"
+				eTag2, err := newETagForAddEvent(instance2, &event)
+				So(err, ShouldBeNil)
+				So(eTag2, ShouldNotEqual, eTag1)
+			})
+
+			Convey("Applying a different update to the same filter results in a different ETag", func() {
+				event = models.Event{
+					Message: "anotherEvent",
+				}
+				eTag3, err := newETagForAddEvent(currentInstance, &event)
+				So(err, ShouldBeNil)
+				So(eTag3, ShouldNotEqual, eTag1)
+			})
+		})
+	})
+}
+
+func TestNewETagForObservationsInserted(t *testing.T) {
+
+	Convey("Given an instance", t, func() {
+
+		currentInstance := testInstance()
+
+		var obsInserted int64 = 12345
+
+		Convey("newETagForObservationsInserted returns an eTag that is different from the original instance ETag", func() {
+			eTag1, err := newETagForObservationsInserted(currentInstance, obsInserted)
+			So(err, ShouldBeNil)
+			So(eTag1, ShouldNotEqual, currentInstance.ETag)
+
+			Convey("Applying the same update to a different instance results in a different ETag", func() {
+				instance2 := testInstance()
+				instance2.InstanceID = "otherInstance"
+				eTag2, err := newETagForObservationsInserted(instance2, obsInserted)
+				So(err, ShouldBeNil)
+				So(eTag2, ShouldNotEqual, eTag1)
+			})
+
+			Convey("Applying a different update to the same filter results in a different ETag", func() {
+				obsInserted = 54321
+				eTag3, err := newETagForObservationsInserted(currentInstance, obsInserted)
+				So(err, ShouldBeNil)
+				So(eTag3, ShouldNotEqual, eTag1)
+			})
+		})
+	})
+}
+
+func TestNewETagForStateUpdate(t *testing.T) {
+
+	Convey("Given an instance", t, func() {
+
+		currentInstance := testInstance()
+
+		Convey("newETagForStateUpdate returns an eTag that is different from the original instance ETag", func() {
+			eTag1, err := newETagForStateUpdate(currentInstance, models.CompletedState)
+			So(err, ShouldBeNil)
+			So(eTag1, ShouldNotEqual, currentInstance.ETag)
+
+			Convey("Applying the same update to a different instance results in a different ETag", func() {
+				instance2 := testInstance()
+				instance2.InstanceID = "otherInstance"
+				eTag2, err := newETagForStateUpdate(instance2, models.CompletedState)
+				So(err, ShouldBeNil)
+				So(eTag2, ShouldNotEqual, eTag1)
+			})
+
+			Convey("Applying a different update to the same filter results in a different ETag", func() {
+				eTag3, err := newETagForStateUpdate(currentInstance, models.DetachedState)
+				So(err, ShouldBeNil)
+				So(eTag3, ShouldNotEqual, eTag1)
+			})
+		})
+	})
+}
+
+func TestNewETagForHierarchyTaskStateUpdate(t *testing.T) {
+
+	Convey("Given an instance", t, func() {
+
+		currentInstance := testInstance()
+		dimension := "dim1"
+
+		Convey("newETagForHierarchyTaskStateUpdate returns an eTag that is different from the original instance ETag", func() {
+			eTag1, err := newETagForHierarchyTaskStateUpdate(currentInstance, dimension, models.CompletedState)
+			So(err, ShouldBeNil)
+			So(eTag1, ShouldNotEqual, currentInstance.ETag)
+
+			Convey("Applying the same update to a different instance results in a different ETag", func() {
+				instance2 := testInstance()
+				instance2.InstanceID = "otherInstance"
+				eTag2, err := newETagForHierarchyTaskStateUpdate(instance2, dimension, models.CompletedState)
+				So(err, ShouldBeNil)
+				So(eTag2, ShouldNotEqual, eTag1)
+			})
+
+			Convey("Applying a different update to the same filter results in a different ETag", func() {
+				eTag3, err := newETagForHierarchyTaskStateUpdate(currentInstance, dimension, models.DetachedState)
+				So(err, ShouldBeNil)
+				So(eTag3, ShouldNotEqual, eTag1)
+			})
+		})
+	})
+}
+
+func TestNewETagForBuildSearchTaskStateUpdate(t *testing.T) {
+
+	Convey("Given an instance", t, func() {
+
+		currentInstance := testInstance()
+		dimension := "dim1"
+
+		Convey("newETagForBuildSearchTaskStateUpdate returns an eTag that is different from the original instance ETag", func() {
+			eTag1, err := newETagForBuildSearchTaskStateUpdate(currentInstance, dimension, models.CompletedState)
+			So(err, ShouldBeNil)
+			So(eTag1, ShouldNotEqual, currentInstance.ETag)
+
+			Convey("Applying the same update to a different instance results in a different ETag", func() {
+				instance2 := testInstance()
+				instance2.InstanceID = "otherInstance"
+				eTag2, err := newETagForBuildSearchTaskStateUpdate(instance2, dimension, models.CompletedState)
+				So(err, ShouldBeNil)
+				So(eTag2, ShouldNotEqual, eTag1)
+			})
+
+			Convey("Applying a different update to the same filter results in a different ETag", func() {
+				eTag3, err := newETagForBuildSearchTaskStateUpdate(currentInstance, dimension, models.DetachedState)
+				So(err, ShouldBeNil)
+				So(eTag3, ShouldNotEqual, eTag1)
+			})
+		})
+	})
+}
+
+func TestNewETagForNodeIDAndOrder(t *testing.T) {
+
+	Convey("Given an instance", t, func() {
+
+		currentInstance := testInstance()
+		nodeID := "testNode"
+		order := 2
+
+		Convey("newETagForNodeIDAndOrder returns an eTag that is different from the original instance ETag", func() {
+			eTag1, err := newETagForNodeIDAndOrder(currentInstance, nodeID, &order)
+			So(err, ShouldBeNil)
+			So(eTag1, ShouldNotEqual, currentInstance.ETag)
+
+			Convey("Applying the same update to a different instance results in a different ETag", func() {
+				instance2 := testInstance()
+				instance2.InstanceID = "otherInstance"
+				eTag2, err := newETagForNodeIDAndOrder(instance2, nodeID, &order)
+				So(err, ShouldBeNil)
+				So(eTag2, ShouldNotEqual, eTag1)
+			})
+
+			Convey("Applying a different update to the same filter results in a different ETag", func() {
+				eTag3, err := newETagForNodeIDAndOrder(currentInstance, nodeID, nil)
+				So(err, ShouldBeNil)
+				So(eTag3, ShouldNotEqual, eTag1)
+			})
+		})
+	})
+}
+
+func TestNewETagForAddDimensionOption(t *testing.T) {
+
+	Convey("Given an instance", t, func() {
+
+		currentInstance := testInstance()
+		option := models.CachedDimensionOption{
+			Code: "testCode",
+			Name: "testName",
+		}
+
+		Convey("newETagForAddDimensionOption returns an eTag that is different from the original instance ETag", func() {
+			eTag1, err := newETagForAddDimensionOption(currentInstance, &option)
+			So(err, ShouldBeNil)
+			So(eTag1, ShouldNotEqual, currentInstance.ETag)
+
+			Convey("Applying the same update to a different instance results in a different ETag", func() {
+				instance2 := testInstance()
+				instance2.InstanceID = "otherInstance"
+				eTag2, err := newETagForAddDimensionOption(instance2, &option)
+				So(err, ShouldBeNil)
+				So(eTag2, ShouldNotEqual, eTag1)
+			})
+
+			Convey("Applying a different update to the same filter results in a different ETag", func() {
+				option := models.CachedDimensionOption{
+					Code: "anotherCode",
+					Name: "anotherName",
+				}
+				eTag3, err := newETagForAddDimensionOption(currentInstance, &option)
+				So(err, ShouldBeNil)
+				So(eTag3, ShouldNotEqual, eTag1)
+			})
+		})
+	})
+}

--- a/mongo/instance_store.go
+++ b/mongo/instance_store.go
@@ -316,7 +316,10 @@ func (m *Mongo) UpdateObservationInserted(currentInstance *models.Instance, obse
 	err = s.DB(m.Database).C(instanceCollection).Update(sel,
 		bson.M{
 			"$inc": bson.M{"import_tasks.import_observations.total_inserted_observations": observationInserted},
-			"$set": bson.M{"last_updated": time.Now().UTC(), "e_tag": newETag},
+			"$set": bson.M{
+				"last_updated": time.Now().UTC(),
+				"e_tag":        newETag,
+			},
 		},
 	)
 
@@ -346,7 +349,10 @@ func (m *Mongo) UpdateImportObservationsTaskState(currentInstance *models.Instan
 
 	err = s.DB(m.Database).C(instanceCollection).Update(sel,
 		bson.M{
-			"$set":         bson.M{"import_tasks.import_observations.state": state, "e_tag": newETag},
+			"$set": bson.M{
+				"import_tasks.import_observations.state": state,
+				"e_tag":                                  newETag,
+			},
 			"$currentDate": bson.M{"last_updated": true},
 		},
 	)

--- a/mongo/instance_test.go
+++ b/mongo/instance_test.go
@@ -1,0 +1,31 @@
+package mongo
+
+import (
+	"testing"
+
+	"github.com/globalsign/mgo/bson"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestSelector(t *testing.T) {
+
+	Convey("Given some testing values to provide as selector paramters", t, func() {
+		var testInstanceID string = "instanceID"
+		var testETag string = "testETag"
+		var testMongoTimestamp bson.MongoTimestamp = 1234567890
+
+		Convey("Then, providing a zero timestamp and any eTag generates a selector that only queries by id", func() {
+			s := selector(testInstanceID, 0, AnyETag)
+			So(s, ShouldResemble, bson.M{"id": testInstanceID})
+		})
+
+		Convey("Then, providing values for timestamp, and eTag generates a selector that queries by filterID, timestamp and eTag", func() {
+			s := selector(testInstanceID, testMongoTimestamp, testETag)
+			So(s, ShouldResemble, bson.M{
+				"id":               testInstanceID,
+				"unique_timestamp": testMongoTimestamp,
+				"e_tag":            testETag,
+			})
+		})
+	})
+}

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -1,0 +1,75 @@
+package mongo
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+	dpmongo "github.com/ONSdigital/dp-mongodb"
+	dpMongoLock "github.com/ONSdigital/dp-mongodb/dplock"
+	dpMongoHealth "github.com/ONSdigital/dp-mongodb/health"
+	"github.com/globalsign/mgo"
+)
+
+// Mongo represents a simplistic MongoDB configuration.
+type Mongo struct {
+	CodeListURL    string
+	Collection     string
+	Database       string
+	DatasetURL     string
+	Session        *mgo.Session
+	URI            string
+	lastPingTime   time.Time
+	lastPingResult error
+	healthClient   *dpMongoHealth.CheckMongoClient
+	lockClient     *dpMongoLock.Lock
+}
+
+const (
+	editionsCollection     = "editions"
+	instanceCollection     = "instances"
+	instanceLockCollection = "instances_locks"
+	dimensionOptions       = "dimension.options"
+)
+
+// Init creates a new mgo.Session with a strong consistency and a write mode of "majortiy"; and initialises the mongo health client.
+func (m *Mongo) Init(ctx context.Context) (err error) {
+	if m.Session != nil {
+		return errors.New("session already exists")
+	}
+
+	// Create session
+	if m.Session, err = mgo.Dial(m.URI); err != nil {
+		return err
+	}
+	m.Session.EnsureSafe(&mgo.Safe{WMode: "majority"})
+	m.Session.SetMode(mgo.Strong, true)
+
+	databaseCollectionBuilder := make(map[dpMongoHealth.Database][]dpMongoHealth.Collection)
+	databaseCollectionBuilder[(dpMongoHealth.Database)(m.Database)] = []dpMongoHealth.Collection{(dpMongoHealth.Collection)(m.Collection), (dpMongoHealth.Collection)(editionsCollection), (dpMongoHealth.Collection)(instanceCollection), (dpMongoHealth.Collection)(instanceLockCollection), (dpMongoHealth.Collection)(dimensionOptions)}
+
+	// Create client and healthclient from session
+	client := dpMongoHealth.NewClientWithCollections(m.Session, databaseCollectionBuilder)
+	m.healthClient = &dpMongoHealth.CheckMongoClient{
+		Client:      *client,
+		Healthcheck: client.Healthcheck,
+	}
+
+	// Create MongoDB lock client, which also starts the purger loop
+	m.lockClient = dpMongoLock.New(ctx, m.Session, m.Database, instanceCollection)
+	return nil
+}
+
+// Close represents mongo session closing within the context deadline
+func (m *Mongo) Close(ctx context.Context) error {
+	if m.Session == nil {
+		return errors.New("cannot close a mongoDB connection without a valid session")
+	}
+	return dpmongo.Close(ctx, m.Session)
+}
+
+// Checker is called by the healthcheck library to check the health state of this mongoDB instance
+func (m *Mongo) Checker(ctx context.Context, state *healthcheck.CheckState) error {
+	return m.healthClient.Checker(ctx, state)
+}

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -129,7 +129,7 @@ func (e *Init) DoGetMongoDB(ctx context.Context, cfg *config.Configuration) (sto
 		DatasetURL:  cfg.DatasetAPIURL,
 		URI:         cfg.MongoConfig.BindAddr,
 	}
-	if err := mongodb.Init(); err != nil {
+	if err := mongodb.Init(ctx); err != nil {
 		return nil, err
 	}
 	log.Event(ctx, "listening to mongo db session", log.INFO, log.Data{"URI": mongodb.URI})

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -20,7 +20,7 @@ type DataStore struct {
 // dataMongoDB represents the required methos to access data from mongoDB
 type dataMongoDB interface {
 	AddDimensionToInstance(dimension *models.CachedDimensionOption) error
-	AddEventToInstance(instanceID string, event *models.Event) error
+	AddEventToInstance(currentInstance *models.Instance, event *models.Event, eTagSelector string) (newETag string, err error)
 	AddInstance(instance *models.Instance) (*models.Instance, error)
 	CheckDatasetExists(ID, state string) error
 	CheckEditionExists(ID, editionID, state string) error
@@ -33,7 +33,7 @@ type dataMongoDB interface {
 	GetEdition(ID, editionID, state string) (*models.EditionUpdate, error)
 	GetEditions(ctx context.Context, ID, state string, offset, limit int, authorised bool) ([]*models.EditionUpdate, int, error)
 	GetInstances(ctx context.Context, states []string, datasets []string, offset, limit int) ([]*models.Instance, int, error)
-	GetInstance(ID string) (*models.Instance, error)
+	GetInstance(ID, eTagSelector string) (*models.Instance, error)
 	GetNextVersion(datasetID, editionID string) (int, error)
 	GetVersion(datasetID, editionID string, version int, state string) (*models.Version, error)
 	GetUniqueDimensionAndOptions(ctx context.Context, ID, dimension string, offset, limit int) ([]*string, int, error)
@@ -41,11 +41,13 @@ type dataMongoDB interface {
 	UpdateDataset(ctx context.Context, ID string, dataset *models.Dataset, currentState string) error
 	UpdateDatasetWithAssociation(ID, state string, version *models.Version) error
 	UpdateDimensionNodeIDAndOrder(dimension *models.DimensionOption) error
-	UpdateInstance(ctx context.Context, ID string, instance *models.Instance) error
-	UpdateObservationInserted(ID string, observationInserted int64) error
-	UpdateImportObservationsTaskState(id, state string) error
-	UpdateBuildHierarchyTaskState(id, dimension, state string) error
-	UpdateBuildSearchTaskState(id, dimension, state string) error
+	UpdateInstance(ctx context.Context, currentInstance, updatedInstance *models.Instance, eTagSelector string) (newETag string, err error)
+	UpdateObservationInserted(currentInstance *models.Instance, observationInserted int64, eTagSelector string) (newETag string, err error)
+	UpdateImportObservationsTaskState(currentInstance *models.Instance, state, eTagSelector string) (newETag string, err error)
+	UpdateBuildHierarchyTaskState(currentInstance *models.Instance, dimension, state, eTagSelector string) (newETag string, err error)
+	UpdateBuildSearchTaskState(currentInstance *models.Instance, dimension, state, eTagSelector string) (newETag string, err error)
+	UpdateETagForNodeIDAndOrder(currentInstance *models.Instance, nodeID string, order *int, eTagSelector string) (newETag string, err error)
+	UpdateETagForOptions(currentInstance *models.Instance, option *models.CachedDimensionOption, eTagSelector string) (newETag string, err error)
 	UpdateVersion(ID string, version *models.Version) error
 	UpsertContact(ID string, update interface{}) error
 	UpsertDataset(ID string, datasetDoc *models.DatasetUpdate) error
@@ -53,6 +55,8 @@ type dataMongoDB interface {
 	UpsertVersion(ID string, versionDoc *models.Version) error
 	DeleteDataset(ID string) error
 	DeleteEdition(ID string) error
+	AcquireInstanceLock(ctx context.Context, instanceID string) (lockID string, err error)
+	UnlockInstance(lockID string) error
 }
 
 // MongoDB represents all the required methods from mongo DB

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -11,6 +11,49 @@ import (
 	"sync"
 )
 
+var (
+	lockStorerMockAcquireInstanceLock               sync.RWMutex
+	lockStorerMockAddDimensionToInstance            sync.RWMutex
+	lockStorerMockAddEventToInstance                sync.RWMutex
+	lockStorerMockAddInstance                       sync.RWMutex
+	lockStorerMockAddVersionDetailsToInstance       sync.RWMutex
+	lockStorerMockCheckDatasetExists                sync.RWMutex
+	lockStorerMockCheckEditionExists                sync.RWMutex
+	lockStorerMockDeleteDataset                     sync.RWMutex
+	lockStorerMockDeleteEdition                     sync.RWMutex
+	lockStorerMockGetDataset                        sync.RWMutex
+	lockStorerMockGetDatasets                       sync.RWMutex
+	lockStorerMockGetDimensionOptions               sync.RWMutex
+	lockStorerMockGetDimensionOptionsFromIDs        sync.RWMutex
+	lockStorerMockGetDimensions                     sync.RWMutex
+	lockStorerMockGetDimensionsFromInstance         sync.RWMutex
+	lockStorerMockGetEdition                        sync.RWMutex
+	lockStorerMockGetEditions                       sync.RWMutex
+	lockStorerMockGetInstance                       sync.RWMutex
+	lockStorerMockGetInstances                      sync.RWMutex
+	lockStorerMockGetNextVersion                    sync.RWMutex
+	lockStorerMockGetUniqueDimensionAndOptions      sync.RWMutex
+	lockStorerMockGetVersion                        sync.RWMutex
+	lockStorerMockGetVersions                       sync.RWMutex
+	lockStorerMockSetInstanceIsPublished            sync.RWMutex
+	lockStorerMockUnlockInstance                    sync.RWMutex
+	lockStorerMockUpdateBuildHierarchyTaskState     sync.RWMutex
+	lockStorerMockUpdateBuildSearchTaskState        sync.RWMutex
+	lockStorerMockUpdateDataset                     sync.RWMutex
+	lockStorerMockUpdateDatasetWithAssociation      sync.RWMutex
+	lockStorerMockUpdateDimensionNodeIDAndOrder     sync.RWMutex
+	lockStorerMockUpdateETagForNodeIDAndOrder       sync.RWMutex
+	lockStorerMockUpdateETagForOptions              sync.RWMutex
+	lockStorerMockUpdateImportObservationsTaskState sync.RWMutex
+	lockStorerMockUpdateInstance                    sync.RWMutex
+	lockStorerMockUpdateObservationInserted         sync.RWMutex
+	lockStorerMockUpdateVersion                     sync.RWMutex
+	lockStorerMockUpsertContact                     sync.RWMutex
+	lockStorerMockUpsertDataset                     sync.RWMutex
+	lockStorerMockUpsertEdition                     sync.RWMutex
+	lockStorerMockUpsertVersion                     sync.RWMutex
+)
+
 // Ensure, that StorerMock does implement store.Storer.
 // If this is not the case, regenerate this file with moq.
 var _ store.Storer = &StorerMock{}
@@ -21,10 +64,13 @@ var _ store.Storer = &StorerMock{}
 //
 //         // make and configure a mocked store.Storer
 //         mockedStorer := &StorerMock{
+//             AcquireInstanceLockFunc: func(ctx context.Context, instanceID string) (string, error) {
+// 	               panic("mock out the AcquireInstanceLock method")
+//             },
 //             AddDimensionToInstanceFunc: func(dimension *models.CachedDimensionOption) error {
 // 	               panic("mock out the AddDimensionToInstance method")
 //             },
-//             AddEventToInstanceFunc: func(instanceID string, event *models.Event) error {
+//             AddEventToInstanceFunc: func(currentInstance *models.Instance, event *models.Event, eTagSelector string) (string, error) {
 // 	               panic("mock out the AddEventToInstance method")
 //             },
 //             AddInstanceFunc: func(instance *models.Instance) (*models.Instance, error) {
@@ -69,7 +115,7 @@ var _ store.Storer = &StorerMock{}
 //             GetEditionsFunc: func(ctx context.Context, ID string, state string, offset int, limit int, authorised bool) ([]*models.EditionUpdate, int, error) {
 // 	               panic("mock out the GetEditions method")
 //             },
-//             GetInstanceFunc: func(ID string) (*models.Instance, error) {
+//             GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 // 	               panic("mock out the GetInstance method")
 //             },
 //             GetInstancesFunc: func(ctx context.Context, states []string, datasets []string, offset int, limit int) ([]*models.Instance, int, error) {
@@ -90,10 +136,13 @@ var _ store.Storer = &StorerMock{}
 //             SetInstanceIsPublishedFunc: func(ctx context.Context, instanceID string) error {
 // 	               panic("mock out the SetInstanceIsPublished method")
 //             },
-//             UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
+//             UnlockInstanceFunc: func(lockID string) error {
+// 	               panic("mock out the UnlockInstance method")
+//             },
+//             UpdateBuildHierarchyTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
 // 	               panic("mock out the UpdateBuildHierarchyTaskState method")
 //             },
-//             UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
+//             UpdateBuildSearchTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
 // 	               panic("mock out the UpdateBuildSearchTaskState method")
 //             },
 //             UpdateDatasetFunc: func(ctx context.Context, ID string, dataset *models.Dataset, currentState string) error {
@@ -105,13 +154,19 @@ var _ store.Storer = &StorerMock{}
 //             UpdateDimensionNodeIDAndOrderFunc: func(dimension *models.DimensionOption) error {
 // 	               panic("mock out the UpdateDimensionNodeIDAndOrder method")
 //             },
-//             UpdateImportObservationsTaskStateFunc: func(id string, state string) error {
+//             UpdateETagForNodeIDAndOrderFunc: func(currentInstance *models.Instance, nodeID string, order *int, eTagSelector string) (string, error) {
+// 	               panic("mock out the UpdateETagForNodeIDAndOrder method")
+//             },
+//             UpdateETagForOptionsFunc: func(currentInstance *models.Instance, option *models.CachedDimensionOption, eTagSelector string) (string, error) {
+// 	               panic("mock out the UpdateETagForOptions method")
+//             },
+//             UpdateImportObservationsTaskStateFunc: func(currentInstance *models.Instance, state string, eTagSelector string) (string, error) {
 // 	               panic("mock out the UpdateImportObservationsTaskState method")
 //             },
-//             UpdateInstanceFunc: func(ctx context.Context, ID string, instance *models.Instance) error {
+//             UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
 // 	               panic("mock out the UpdateInstance method")
 //             },
-//             UpdateObservationInsertedFunc: func(ID string, observationInserted int64) error {
+//             UpdateObservationInsertedFunc: func(currentInstance *models.Instance, observationInserted int64, eTagSelector string) (string, error) {
 // 	               panic("mock out the UpdateObservationInserted method")
 //             },
 //             UpdateVersionFunc: func(ID string, version *models.Version) error {
@@ -136,11 +191,14 @@ var _ store.Storer = &StorerMock{}
 //
 //     }
 type StorerMock struct {
+	// AcquireInstanceLockFunc mocks the AcquireInstanceLock method.
+	AcquireInstanceLockFunc func(ctx context.Context, instanceID string) (string, error)
+
 	// AddDimensionToInstanceFunc mocks the AddDimensionToInstance method.
 	AddDimensionToInstanceFunc func(dimension *models.CachedDimensionOption) error
 
 	// AddEventToInstanceFunc mocks the AddEventToInstance method.
-	AddEventToInstanceFunc func(instanceID string, event *models.Event) error
+	AddEventToInstanceFunc func(currentInstance *models.Instance, event *models.Event, eTagSelector string) (string, error)
 
 	// AddInstanceFunc mocks the AddInstance method.
 	AddInstanceFunc func(instance *models.Instance) (*models.Instance, error)
@@ -185,7 +243,7 @@ type StorerMock struct {
 	GetEditionsFunc func(ctx context.Context, ID string, state string, offset int, limit int, authorised bool) ([]*models.EditionUpdate, int, error)
 
 	// GetInstanceFunc mocks the GetInstance method.
-	GetInstanceFunc func(ID string) (*models.Instance, error)
+	GetInstanceFunc func(ID string, eTagSelector string) (*models.Instance, error)
 
 	// GetInstancesFunc mocks the GetInstances method.
 	GetInstancesFunc func(ctx context.Context, states []string, datasets []string, offset int, limit int) ([]*models.Instance, int, error)
@@ -205,11 +263,14 @@ type StorerMock struct {
 	// SetInstanceIsPublishedFunc mocks the SetInstanceIsPublished method.
 	SetInstanceIsPublishedFunc func(ctx context.Context, instanceID string) error
 
+	// UnlockInstanceFunc mocks the UnlockInstance method.
+	UnlockInstanceFunc func(lockID string) error
+
 	// UpdateBuildHierarchyTaskStateFunc mocks the UpdateBuildHierarchyTaskState method.
-	UpdateBuildHierarchyTaskStateFunc func(id string, dimension string, state string) error
+	UpdateBuildHierarchyTaskStateFunc func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error)
 
 	// UpdateBuildSearchTaskStateFunc mocks the UpdateBuildSearchTaskState method.
-	UpdateBuildSearchTaskStateFunc func(id string, dimension string, state string) error
+	UpdateBuildSearchTaskStateFunc func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error)
 
 	// UpdateDatasetFunc mocks the UpdateDataset method.
 	UpdateDatasetFunc func(ctx context.Context, ID string, dataset *models.Dataset, currentState string) error
@@ -220,14 +281,20 @@ type StorerMock struct {
 	// UpdateDimensionNodeIDAndOrderFunc mocks the UpdateDimensionNodeIDAndOrder method.
 	UpdateDimensionNodeIDAndOrderFunc func(dimension *models.DimensionOption) error
 
+	// UpdateETagForNodeIDAndOrderFunc mocks the UpdateETagForNodeIDAndOrder method.
+	UpdateETagForNodeIDAndOrderFunc func(currentInstance *models.Instance, nodeID string, order *int, eTagSelector string) (string, error)
+
+	// UpdateETagForOptionsFunc mocks the UpdateETagForOptions method.
+	UpdateETagForOptionsFunc func(currentInstance *models.Instance, option *models.CachedDimensionOption, eTagSelector string) (string, error)
+
 	// UpdateImportObservationsTaskStateFunc mocks the UpdateImportObservationsTaskState method.
-	UpdateImportObservationsTaskStateFunc func(id string, state string) error
+	UpdateImportObservationsTaskStateFunc func(currentInstance *models.Instance, state string, eTagSelector string) (string, error)
 
 	// UpdateInstanceFunc mocks the UpdateInstance method.
-	UpdateInstanceFunc func(ctx context.Context, ID string, instance *models.Instance) error
+	UpdateInstanceFunc func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error)
 
 	// UpdateObservationInsertedFunc mocks the UpdateObservationInserted method.
-	UpdateObservationInsertedFunc func(ID string, observationInserted int64) error
+	UpdateObservationInsertedFunc func(currentInstance *models.Instance, observationInserted int64, eTagSelector string) (string, error)
 
 	// UpdateVersionFunc mocks the UpdateVersion method.
 	UpdateVersionFunc func(ID string, version *models.Version) error
@@ -246,6 +313,13 @@ type StorerMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// AcquireInstanceLock holds details about calls to the AcquireInstanceLock method.
+		AcquireInstanceLock []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// InstanceID is the instanceID argument value.
+			InstanceID string
+		}
 		// AddDimensionToInstance holds details about calls to the AddDimensionToInstance method.
 		AddDimensionToInstance []struct {
 			// Dimension is the dimension argument value.
@@ -253,10 +327,12 @@ type StorerMock struct {
 		}
 		// AddEventToInstance holds details about calls to the AddEventToInstance method.
 		AddEventToInstance []struct {
-			// InstanceID is the instanceID argument value.
-			InstanceID string
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
 			// Event is the event argument value.
 			Event *models.Event
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// AddInstance holds details about calls to the AddInstance method.
 		AddInstance []struct {
@@ -386,6 +462,8 @@ type StorerMock struct {
 		GetInstance []struct {
 			// ID is the ID argument value.
 			ID string
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// GetInstances holds details about calls to the GetInstances method.
 		GetInstances []struct {
@@ -453,23 +531,32 @@ type StorerMock struct {
 			// InstanceID is the instanceID argument value.
 			InstanceID string
 		}
+		// UnlockInstance holds details about calls to the UnlockInstance method.
+		UnlockInstance []struct {
+			// LockID is the lockID argument value.
+			LockID string
+		}
 		// UpdateBuildHierarchyTaskState holds details about calls to the UpdateBuildHierarchyTaskState method.
 		UpdateBuildHierarchyTaskState []struct {
-			// ID is the id argument value.
-			ID string
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
 			// Dimension is the dimension argument value.
 			Dimension string
 			// State is the state argument value.
 			State string
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// UpdateBuildSearchTaskState holds details about calls to the UpdateBuildSearchTaskState method.
 		UpdateBuildSearchTaskState []struct {
-			// ID is the id argument value.
-			ID string
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
 			// Dimension is the dimension argument value.
 			Dimension string
 			// State is the state argument value.
 			State string
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// UpdateDataset holds details about calls to the UpdateDataset method.
 		UpdateDataset []struct {
@@ -496,28 +583,54 @@ type StorerMock struct {
 			// Dimension is the dimension argument value.
 			Dimension *models.DimensionOption
 		}
+		// UpdateETagForNodeIDAndOrder holds details about calls to the UpdateETagForNodeIDAndOrder method.
+		UpdateETagForNodeIDAndOrder []struct {
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
+			// NodeID is the nodeID argument value.
+			NodeID string
+			// Order is the order argument value.
+			Order *int
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
+		}
+		// UpdateETagForOptions holds details about calls to the UpdateETagForOptions method.
+		UpdateETagForOptions []struct {
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
+			// Option is the option argument value.
+			Option *models.CachedDimensionOption
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
+		}
 		// UpdateImportObservationsTaskState holds details about calls to the UpdateImportObservationsTaskState method.
 		UpdateImportObservationsTaskState []struct {
-			// ID is the id argument value.
-			ID string
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
 			// State is the state argument value.
 			State string
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// UpdateInstance holds details about calls to the UpdateInstance method.
 		UpdateInstance []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// ID is the ID argument value.
-			ID string
-			// Instance is the instance argument value.
-			Instance *models.Instance
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
+			// UpdatedInstance is the updatedInstance argument value.
+			UpdatedInstance *models.Instance
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// UpdateObservationInserted holds details about calls to the UpdateObservationInserted method.
 		UpdateObservationInserted []struct {
-			// ID is the ID argument value.
-			ID string
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
 			// ObservationInserted is the observationInserted argument value.
 			ObservationInserted int64
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// UpdateVersion holds details about calls to the UpdateVersion method.
 		UpdateVersion []struct {
@@ -557,42 +670,41 @@ type StorerMock struct {
 			VersionDoc *models.Version
 		}
 	}
-	lockAddDimensionToInstance            sync.RWMutex
-	lockAddEventToInstance                sync.RWMutex
-	lockAddInstance                       sync.RWMutex
-	lockAddVersionDetailsToInstance       sync.RWMutex
-	lockCheckDatasetExists                sync.RWMutex
-	lockCheckEditionExists                sync.RWMutex
-	lockDeleteDataset                     sync.RWMutex
-	lockDeleteEdition                     sync.RWMutex
-	lockGetDataset                        sync.RWMutex
-	lockGetDatasets                       sync.RWMutex
-	lockGetDimensionOptions               sync.RWMutex
-	lockGetDimensionOptionsFromIDs        sync.RWMutex
-	lockGetDimensions                     sync.RWMutex
-	lockGetDimensionsFromInstance         sync.RWMutex
-	lockGetEdition                        sync.RWMutex
-	lockGetEditions                       sync.RWMutex
-	lockGetInstance                       sync.RWMutex
-	lockGetInstances                      sync.RWMutex
-	lockGetNextVersion                    sync.RWMutex
-	lockGetUniqueDimensionAndOptions      sync.RWMutex
-	lockGetVersion                        sync.RWMutex
-	lockGetVersions                       sync.RWMutex
-	lockSetInstanceIsPublished            sync.RWMutex
-	lockUpdateBuildHierarchyTaskState     sync.RWMutex
-	lockUpdateBuildSearchTaskState        sync.RWMutex
-	lockUpdateDataset                     sync.RWMutex
-	lockUpdateDatasetWithAssociation      sync.RWMutex
-	lockUpdateDimensionNodeIDAndOrder     sync.RWMutex
-	lockUpdateImportObservationsTaskState sync.RWMutex
-	lockUpdateInstance                    sync.RWMutex
-	lockUpdateObservationInserted         sync.RWMutex
-	lockUpdateVersion                     sync.RWMutex
-	lockUpsertContact                     sync.RWMutex
-	lockUpsertDataset                     sync.RWMutex
-	lockUpsertEdition                     sync.RWMutex
-	lockUpsertVersion                     sync.RWMutex
+}
+
+// AcquireInstanceLock calls AcquireInstanceLockFunc.
+func (mock *StorerMock) AcquireInstanceLock(ctx context.Context, instanceID string) (string, error) {
+	if mock.AcquireInstanceLockFunc == nil {
+		panic("StorerMock.AcquireInstanceLockFunc: method is nil but Storer.AcquireInstanceLock was just called")
+	}
+	callInfo := struct {
+		Ctx        context.Context
+		InstanceID string
+	}{
+		Ctx:        ctx,
+		InstanceID: instanceID,
+	}
+	lockStorerMockAcquireInstanceLock.Lock()
+	mock.calls.AcquireInstanceLock = append(mock.calls.AcquireInstanceLock, callInfo)
+	lockStorerMockAcquireInstanceLock.Unlock()
+	return mock.AcquireInstanceLockFunc(ctx, instanceID)
+}
+
+// AcquireInstanceLockCalls gets all the calls that were made to AcquireInstanceLock.
+// Check the length with:
+//     len(mockedStorer.AcquireInstanceLockCalls())
+func (mock *StorerMock) AcquireInstanceLockCalls() []struct {
+	Ctx        context.Context
+	InstanceID string
+} {
+	var calls []struct {
+		Ctx        context.Context
+		InstanceID string
+	}
+	lockStorerMockAcquireInstanceLock.RLock()
+	calls = mock.calls.AcquireInstanceLock
+	lockStorerMockAcquireInstanceLock.RUnlock()
+	return calls
 }
 
 // AddDimensionToInstance calls AddDimensionToInstanceFunc.
@@ -605,9 +717,9 @@ func (mock *StorerMock) AddDimensionToInstance(dimension *models.CachedDimension
 	}{
 		Dimension: dimension,
 	}
-	mock.lockAddDimensionToInstance.Lock()
+	lockStorerMockAddDimensionToInstance.Lock()
 	mock.calls.AddDimensionToInstance = append(mock.calls.AddDimensionToInstance, callInfo)
-	mock.lockAddDimensionToInstance.Unlock()
+	lockStorerMockAddDimensionToInstance.Unlock()
 	return mock.AddDimensionToInstanceFunc(dimension)
 }
 
@@ -620,44 +732,48 @@ func (mock *StorerMock) AddDimensionToInstanceCalls() []struct {
 	var calls []struct {
 		Dimension *models.CachedDimensionOption
 	}
-	mock.lockAddDimensionToInstance.RLock()
+	lockStorerMockAddDimensionToInstance.RLock()
 	calls = mock.calls.AddDimensionToInstance
-	mock.lockAddDimensionToInstance.RUnlock()
+	lockStorerMockAddDimensionToInstance.RUnlock()
 	return calls
 }
 
 // AddEventToInstance calls AddEventToInstanceFunc.
-func (mock *StorerMock) AddEventToInstance(instanceID string, event *models.Event) error {
+func (mock *StorerMock) AddEventToInstance(currentInstance *models.Instance, event *models.Event, eTagSelector string) (string, error) {
 	if mock.AddEventToInstanceFunc == nil {
 		panic("StorerMock.AddEventToInstanceFunc: method is nil but Storer.AddEventToInstance was just called")
 	}
 	callInfo := struct {
-		InstanceID string
-		Event      *models.Event
+		CurrentInstance *models.Instance
+		Event           *models.Event
+		ETagSelector    string
 	}{
-		InstanceID: instanceID,
-		Event:      event,
+		CurrentInstance: currentInstance,
+		Event:           event,
+		ETagSelector:    eTagSelector,
 	}
-	mock.lockAddEventToInstance.Lock()
+	lockStorerMockAddEventToInstance.Lock()
 	mock.calls.AddEventToInstance = append(mock.calls.AddEventToInstance, callInfo)
-	mock.lockAddEventToInstance.Unlock()
-	return mock.AddEventToInstanceFunc(instanceID, event)
+	lockStorerMockAddEventToInstance.Unlock()
+	return mock.AddEventToInstanceFunc(currentInstance, event, eTagSelector)
 }
 
 // AddEventToInstanceCalls gets all the calls that were made to AddEventToInstance.
 // Check the length with:
 //     len(mockedStorer.AddEventToInstanceCalls())
 func (mock *StorerMock) AddEventToInstanceCalls() []struct {
-	InstanceID string
-	Event      *models.Event
+	CurrentInstance *models.Instance
+	Event           *models.Event
+	ETagSelector    string
 } {
 	var calls []struct {
-		InstanceID string
-		Event      *models.Event
+		CurrentInstance *models.Instance
+		Event           *models.Event
+		ETagSelector    string
 	}
-	mock.lockAddEventToInstance.RLock()
+	lockStorerMockAddEventToInstance.RLock()
 	calls = mock.calls.AddEventToInstance
-	mock.lockAddEventToInstance.RUnlock()
+	lockStorerMockAddEventToInstance.RUnlock()
 	return calls
 }
 
@@ -671,9 +787,9 @@ func (mock *StorerMock) AddInstance(instance *models.Instance) (*models.Instance
 	}{
 		Instance: instance,
 	}
-	mock.lockAddInstance.Lock()
+	lockStorerMockAddInstance.Lock()
 	mock.calls.AddInstance = append(mock.calls.AddInstance, callInfo)
-	mock.lockAddInstance.Unlock()
+	lockStorerMockAddInstance.Unlock()
 	return mock.AddInstanceFunc(instance)
 }
 
@@ -686,9 +802,9 @@ func (mock *StorerMock) AddInstanceCalls() []struct {
 	var calls []struct {
 		Instance *models.Instance
 	}
-	mock.lockAddInstance.RLock()
+	lockStorerMockAddInstance.RLock()
 	calls = mock.calls.AddInstance
-	mock.lockAddInstance.RUnlock()
+	lockStorerMockAddInstance.RUnlock()
 	return calls
 }
 
@@ -710,9 +826,9 @@ func (mock *StorerMock) AddVersionDetailsToInstance(ctx context.Context, instanc
 		Edition:    edition,
 		Version:    version,
 	}
-	mock.lockAddVersionDetailsToInstance.Lock()
+	lockStorerMockAddVersionDetailsToInstance.Lock()
 	mock.calls.AddVersionDetailsToInstance = append(mock.calls.AddVersionDetailsToInstance, callInfo)
-	mock.lockAddVersionDetailsToInstance.Unlock()
+	lockStorerMockAddVersionDetailsToInstance.Unlock()
 	return mock.AddVersionDetailsToInstanceFunc(ctx, instanceID, datasetID, edition, version)
 }
 
@@ -733,9 +849,9 @@ func (mock *StorerMock) AddVersionDetailsToInstanceCalls() []struct {
 		Edition    string
 		Version    int
 	}
-	mock.lockAddVersionDetailsToInstance.RLock()
+	lockStorerMockAddVersionDetailsToInstance.RLock()
 	calls = mock.calls.AddVersionDetailsToInstance
-	mock.lockAddVersionDetailsToInstance.RUnlock()
+	lockStorerMockAddVersionDetailsToInstance.RUnlock()
 	return calls
 }
 
@@ -751,9 +867,9 @@ func (mock *StorerMock) CheckDatasetExists(ID string, state string) error {
 		ID:    ID,
 		State: state,
 	}
-	mock.lockCheckDatasetExists.Lock()
+	lockStorerMockCheckDatasetExists.Lock()
 	mock.calls.CheckDatasetExists = append(mock.calls.CheckDatasetExists, callInfo)
-	mock.lockCheckDatasetExists.Unlock()
+	lockStorerMockCheckDatasetExists.Unlock()
 	return mock.CheckDatasetExistsFunc(ID, state)
 }
 
@@ -768,9 +884,9 @@ func (mock *StorerMock) CheckDatasetExistsCalls() []struct {
 		ID    string
 		State string
 	}
-	mock.lockCheckDatasetExists.RLock()
+	lockStorerMockCheckDatasetExists.RLock()
 	calls = mock.calls.CheckDatasetExists
-	mock.lockCheckDatasetExists.RUnlock()
+	lockStorerMockCheckDatasetExists.RUnlock()
 	return calls
 }
 
@@ -788,9 +904,9 @@ func (mock *StorerMock) CheckEditionExists(ID string, editionID string, state st
 		EditionID: editionID,
 		State:     state,
 	}
-	mock.lockCheckEditionExists.Lock()
+	lockStorerMockCheckEditionExists.Lock()
 	mock.calls.CheckEditionExists = append(mock.calls.CheckEditionExists, callInfo)
-	mock.lockCheckEditionExists.Unlock()
+	lockStorerMockCheckEditionExists.Unlock()
 	return mock.CheckEditionExistsFunc(ID, editionID, state)
 }
 
@@ -807,9 +923,9 @@ func (mock *StorerMock) CheckEditionExistsCalls() []struct {
 		EditionID string
 		State     string
 	}
-	mock.lockCheckEditionExists.RLock()
+	lockStorerMockCheckEditionExists.RLock()
 	calls = mock.calls.CheckEditionExists
-	mock.lockCheckEditionExists.RUnlock()
+	lockStorerMockCheckEditionExists.RUnlock()
 	return calls
 }
 
@@ -823,9 +939,9 @@ func (mock *StorerMock) DeleteDataset(ID string) error {
 	}{
 		ID: ID,
 	}
-	mock.lockDeleteDataset.Lock()
+	lockStorerMockDeleteDataset.Lock()
 	mock.calls.DeleteDataset = append(mock.calls.DeleteDataset, callInfo)
-	mock.lockDeleteDataset.Unlock()
+	lockStorerMockDeleteDataset.Unlock()
 	return mock.DeleteDatasetFunc(ID)
 }
 
@@ -838,9 +954,9 @@ func (mock *StorerMock) DeleteDatasetCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	mock.lockDeleteDataset.RLock()
+	lockStorerMockDeleteDataset.RLock()
 	calls = mock.calls.DeleteDataset
-	mock.lockDeleteDataset.RUnlock()
+	lockStorerMockDeleteDataset.RUnlock()
 	return calls
 }
 
@@ -854,9 +970,9 @@ func (mock *StorerMock) DeleteEdition(ID string) error {
 	}{
 		ID: ID,
 	}
-	mock.lockDeleteEdition.Lock()
+	lockStorerMockDeleteEdition.Lock()
 	mock.calls.DeleteEdition = append(mock.calls.DeleteEdition, callInfo)
-	mock.lockDeleteEdition.Unlock()
+	lockStorerMockDeleteEdition.Unlock()
 	return mock.DeleteEditionFunc(ID)
 }
 
@@ -869,9 +985,9 @@ func (mock *StorerMock) DeleteEditionCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	mock.lockDeleteEdition.RLock()
+	lockStorerMockDeleteEdition.RLock()
 	calls = mock.calls.DeleteEdition
-	mock.lockDeleteEdition.RUnlock()
+	lockStorerMockDeleteEdition.RUnlock()
 	return calls
 }
 
@@ -885,9 +1001,9 @@ func (mock *StorerMock) GetDataset(ID string) (*models.DatasetUpdate, error) {
 	}{
 		ID: ID,
 	}
-	mock.lockGetDataset.Lock()
+	lockStorerMockGetDataset.Lock()
 	mock.calls.GetDataset = append(mock.calls.GetDataset, callInfo)
-	mock.lockGetDataset.Unlock()
+	lockStorerMockGetDataset.Unlock()
 	return mock.GetDatasetFunc(ID)
 }
 
@@ -900,9 +1016,9 @@ func (mock *StorerMock) GetDatasetCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	mock.lockGetDataset.RLock()
+	lockStorerMockGetDataset.RLock()
 	calls = mock.calls.GetDataset
-	mock.lockGetDataset.RUnlock()
+	lockStorerMockGetDataset.RUnlock()
 	return calls
 }
 
@@ -922,9 +1038,9 @@ func (mock *StorerMock) GetDatasets(ctx context.Context, offset int, limit int, 
 		Limit:      limit,
 		Authorised: authorised,
 	}
-	mock.lockGetDatasets.Lock()
+	lockStorerMockGetDatasets.Lock()
 	mock.calls.GetDatasets = append(mock.calls.GetDatasets, callInfo)
-	mock.lockGetDatasets.Unlock()
+	lockStorerMockGetDatasets.Unlock()
 	return mock.GetDatasetsFunc(ctx, offset, limit, authorised)
 }
 
@@ -943,9 +1059,9 @@ func (mock *StorerMock) GetDatasetsCalls() []struct {
 		Limit      int
 		Authorised bool
 	}
-	mock.lockGetDatasets.RLock()
+	lockStorerMockGetDatasets.RLock()
 	calls = mock.calls.GetDatasets
-	mock.lockGetDatasets.RUnlock()
+	lockStorerMockGetDatasets.RUnlock()
 	return calls
 }
 
@@ -967,9 +1083,9 @@ func (mock *StorerMock) GetDimensionOptions(ctx context.Context, version *models
 		Offset:    offset,
 		Limit:     limit,
 	}
-	mock.lockGetDimensionOptions.Lock()
+	lockStorerMockGetDimensionOptions.Lock()
 	mock.calls.GetDimensionOptions = append(mock.calls.GetDimensionOptions, callInfo)
-	mock.lockGetDimensionOptions.Unlock()
+	lockStorerMockGetDimensionOptions.Unlock()
 	return mock.GetDimensionOptionsFunc(ctx, version, dimension, offset, limit)
 }
 
@@ -990,9 +1106,9 @@ func (mock *StorerMock) GetDimensionOptionsCalls() []struct {
 		Offset    int
 		Limit     int
 	}
-	mock.lockGetDimensionOptions.RLock()
+	lockStorerMockGetDimensionOptions.RLock()
 	calls = mock.calls.GetDimensionOptions
-	mock.lockGetDimensionOptions.RUnlock()
+	lockStorerMockGetDimensionOptions.RUnlock()
 	return calls
 }
 
@@ -1010,9 +1126,9 @@ func (mock *StorerMock) GetDimensionOptionsFromIDs(version *models.Version, dime
 		Dimension: dimension,
 		Ids:       ids,
 	}
-	mock.lockGetDimensionOptionsFromIDs.Lock()
+	lockStorerMockGetDimensionOptionsFromIDs.Lock()
 	mock.calls.GetDimensionOptionsFromIDs = append(mock.calls.GetDimensionOptionsFromIDs, callInfo)
-	mock.lockGetDimensionOptionsFromIDs.Unlock()
+	lockStorerMockGetDimensionOptionsFromIDs.Unlock()
 	return mock.GetDimensionOptionsFromIDsFunc(version, dimension, ids)
 }
 
@@ -1029,9 +1145,9 @@ func (mock *StorerMock) GetDimensionOptionsFromIDsCalls() []struct {
 		Dimension string
 		Ids       []string
 	}
-	mock.lockGetDimensionOptionsFromIDs.RLock()
+	lockStorerMockGetDimensionOptionsFromIDs.RLock()
 	calls = mock.calls.GetDimensionOptionsFromIDs
-	mock.lockGetDimensionOptionsFromIDs.RUnlock()
+	lockStorerMockGetDimensionOptionsFromIDs.RUnlock()
 	return calls
 }
 
@@ -1047,9 +1163,9 @@ func (mock *StorerMock) GetDimensions(datasetID string, versionID string) ([]bso
 		DatasetID: datasetID,
 		VersionID: versionID,
 	}
-	mock.lockGetDimensions.Lock()
+	lockStorerMockGetDimensions.Lock()
 	mock.calls.GetDimensions = append(mock.calls.GetDimensions, callInfo)
-	mock.lockGetDimensions.Unlock()
+	lockStorerMockGetDimensions.Unlock()
 	return mock.GetDimensionsFunc(datasetID, versionID)
 }
 
@@ -1064,9 +1180,9 @@ func (mock *StorerMock) GetDimensionsCalls() []struct {
 		DatasetID string
 		VersionID string
 	}
-	mock.lockGetDimensions.RLock()
+	lockStorerMockGetDimensions.RLock()
 	calls = mock.calls.GetDimensions
-	mock.lockGetDimensions.RUnlock()
+	lockStorerMockGetDimensions.RUnlock()
 	return calls
 }
 
@@ -1086,9 +1202,9 @@ func (mock *StorerMock) GetDimensionsFromInstance(ctx context.Context, ID string
 		Offset: offset,
 		Limit:  limit,
 	}
-	mock.lockGetDimensionsFromInstance.Lock()
+	lockStorerMockGetDimensionsFromInstance.Lock()
 	mock.calls.GetDimensionsFromInstance = append(mock.calls.GetDimensionsFromInstance, callInfo)
-	mock.lockGetDimensionsFromInstance.Unlock()
+	lockStorerMockGetDimensionsFromInstance.Unlock()
 	return mock.GetDimensionsFromInstanceFunc(ctx, ID, offset, limit)
 }
 
@@ -1107,9 +1223,9 @@ func (mock *StorerMock) GetDimensionsFromInstanceCalls() []struct {
 		Offset int
 		Limit  int
 	}
-	mock.lockGetDimensionsFromInstance.RLock()
+	lockStorerMockGetDimensionsFromInstance.RLock()
 	calls = mock.calls.GetDimensionsFromInstance
-	mock.lockGetDimensionsFromInstance.RUnlock()
+	lockStorerMockGetDimensionsFromInstance.RUnlock()
 	return calls
 }
 
@@ -1127,9 +1243,9 @@ func (mock *StorerMock) GetEdition(ID string, editionID string, state string) (*
 		EditionID: editionID,
 		State:     state,
 	}
-	mock.lockGetEdition.Lock()
+	lockStorerMockGetEdition.Lock()
 	mock.calls.GetEdition = append(mock.calls.GetEdition, callInfo)
-	mock.lockGetEdition.Unlock()
+	lockStorerMockGetEdition.Unlock()
 	return mock.GetEditionFunc(ID, editionID, state)
 }
 
@@ -1146,9 +1262,9 @@ func (mock *StorerMock) GetEditionCalls() []struct {
 		EditionID string
 		State     string
 	}
-	mock.lockGetEdition.RLock()
+	lockStorerMockGetEdition.RLock()
 	calls = mock.calls.GetEdition
-	mock.lockGetEdition.RUnlock()
+	lockStorerMockGetEdition.RUnlock()
 	return calls
 }
 
@@ -1172,9 +1288,9 @@ func (mock *StorerMock) GetEditions(ctx context.Context, ID string, state string
 		Limit:      limit,
 		Authorised: authorised,
 	}
-	mock.lockGetEditions.Lock()
+	lockStorerMockGetEditions.Lock()
 	mock.calls.GetEditions = append(mock.calls.GetEditions, callInfo)
-	mock.lockGetEditions.Unlock()
+	lockStorerMockGetEditions.Unlock()
 	return mock.GetEditionsFunc(ctx, ID, state, offset, limit, authorised)
 }
 
@@ -1197,40 +1313,44 @@ func (mock *StorerMock) GetEditionsCalls() []struct {
 		Limit      int
 		Authorised bool
 	}
-	mock.lockGetEditions.RLock()
+	lockStorerMockGetEditions.RLock()
 	calls = mock.calls.GetEditions
-	mock.lockGetEditions.RUnlock()
+	lockStorerMockGetEditions.RUnlock()
 	return calls
 }
 
 // GetInstance calls GetInstanceFunc.
-func (mock *StorerMock) GetInstance(ID string) (*models.Instance, error) {
+func (mock *StorerMock) GetInstance(ID string, eTagSelector string) (*models.Instance, error) {
 	if mock.GetInstanceFunc == nil {
 		panic("StorerMock.GetInstanceFunc: method is nil but Storer.GetInstance was just called")
 	}
 	callInfo := struct {
-		ID string
+		ID           string
+		ETagSelector string
 	}{
-		ID: ID,
+		ID:           ID,
+		ETagSelector: eTagSelector,
 	}
-	mock.lockGetInstance.Lock()
+	lockStorerMockGetInstance.Lock()
 	mock.calls.GetInstance = append(mock.calls.GetInstance, callInfo)
-	mock.lockGetInstance.Unlock()
-	return mock.GetInstanceFunc(ID)
+	lockStorerMockGetInstance.Unlock()
+	return mock.GetInstanceFunc(ID, eTagSelector)
 }
 
 // GetInstanceCalls gets all the calls that were made to GetInstance.
 // Check the length with:
 //     len(mockedStorer.GetInstanceCalls())
 func (mock *StorerMock) GetInstanceCalls() []struct {
-	ID string
+	ID           string
+	ETagSelector string
 } {
 	var calls []struct {
-		ID string
+		ID           string
+		ETagSelector string
 	}
-	mock.lockGetInstance.RLock()
+	lockStorerMockGetInstance.RLock()
 	calls = mock.calls.GetInstance
-	mock.lockGetInstance.RUnlock()
+	lockStorerMockGetInstance.RUnlock()
 	return calls
 }
 
@@ -1252,9 +1372,9 @@ func (mock *StorerMock) GetInstances(ctx context.Context, states []string, datas
 		Offset:   offset,
 		Limit:    limit,
 	}
-	mock.lockGetInstances.Lock()
+	lockStorerMockGetInstances.Lock()
 	mock.calls.GetInstances = append(mock.calls.GetInstances, callInfo)
-	mock.lockGetInstances.Unlock()
+	lockStorerMockGetInstances.Unlock()
 	return mock.GetInstancesFunc(ctx, states, datasets, offset, limit)
 }
 
@@ -1275,9 +1395,9 @@ func (mock *StorerMock) GetInstancesCalls() []struct {
 		Offset   int
 		Limit    int
 	}
-	mock.lockGetInstances.RLock()
+	lockStorerMockGetInstances.RLock()
 	calls = mock.calls.GetInstances
-	mock.lockGetInstances.RUnlock()
+	lockStorerMockGetInstances.RUnlock()
 	return calls
 }
 
@@ -1293,9 +1413,9 @@ func (mock *StorerMock) GetNextVersion(datasetID string, editionID string) (int,
 		DatasetID: datasetID,
 		EditionID: editionID,
 	}
-	mock.lockGetNextVersion.Lock()
+	lockStorerMockGetNextVersion.Lock()
 	mock.calls.GetNextVersion = append(mock.calls.GetNextVersion, callInfo)
-	mock.lockGetNextVersion.Unlock()
+	lockStorerMockGetNextVersion.Unlock()
 	return mock.GetNextVersionFunc(datasetID, editionID)
 }
 
@@ -1310,9 +1430,9 @@ func (mock *StorerMock) GetNextVersionCalls() []struct {
 		DatasetID string
 		EditionID string
 	}
-	mock.lockGetNextVersion.RLock()
+	lockStorerMockGetNextVersion.RLock()
 	calls = mock.calls.GetNextVersion
-	mock.lockGetNextVersion.RUnlock()
+	lockStorerMockGetNextVersion.RUnlock()
 	return calls
 }
 
@@ -1334,9 +1454,9 @@ func (mock *StorerMock) GetUniqueDimensionAndOptions(ctx context.Context, ID str
 		Offset:    offset,
 		Limit:     limit,
 	}
-	mock.lockGetUniqueDimensionAndOptions.Lock()
+	lockStorerMockGetUniqueDimensionAndOptions.Lock()
 	mock.calls.GetUniqueDimensionAndOptions = append(mock.calls.GetUniqueDimensionAndOptions, callInfo)
-	mock.lockGetUniqueDimensionAndOptions.Unlock()
+	lockStorerMockGetUniqueDimensionAndOptions.Unlock()
 	return mock.GetUniqueDimensionAndOptionsFunc(ctx, ID, dimension, offset, limit)
 }
 
@@ -1357,9 +1477,9 @@ func (mock *StorerMock) GetUniqueDimensionAndOptionsCalls() []struct {
 		Offset    int
 		Limit     int
 	}
-	mock.lockGetUniqueDimensionAndOptions.RLock()
+	lockStorerMockGetUniqueDimensionAndOptions.RLock()
 	calls = mock.calls.GetUniqueDimensionAndOptions
-	mock.lockGetUniqueDimensionAndOptions.RUnlock()
+	lockStorerMockGetUniqueDimensionAndOptions.RUnlock()
 	return calls
 }
 
@@ -1379,9 +1499,9 @@ func (mock *StorerMock) GetVersion(datasetID string, editionID string, version i
 		Version:   version,
 		State:     state,
 	}
-	mock.lockGetVersion.Lock()
+	lockStorerMockGetVersion.Lock()
 	mock.calls.GetVersion = append(mock.calls.GetVersion, callInfo)
-	mock.lockGetVersion.Unlock()
+	lockStorerMockGetVersion.Unlock()
 	return mock.GetVersionFunc(datasetID, editionID, version, state)
 }
 
@@ -1400,9 +1520,9 @@ func (mock *StorerMock) GetVersionCalls() []struct {
 		Version   int
 		State     string
 	}
-	mock.lockGetVersion.RLock()
+	lockStorerMockGetVersion.RLock()
 	calls = mock.calls.GetVersion
-	mock.lockGetVersion.RUnlock()
+	lockStorerMockGetVersion.RUnlock()
 	return calls
 }
 
@@ -1426,9 +1546,9 @@ func (mock *StorerMock) GetVersions(ctx context.Context, datasetID string, editi
 		Offset:    offset,
 		Limit:     limit,
 	}
-	mock.lockGetVersions.Lock()
+	lockStorerMockGetVersions.Lock()
 	mock.calls.GetVersions = append(mock.calls.GetVersions, callInfo)
-	mock.lockGetVersions.Unlock()
+	lockStorerMockGetVersions.Unlock()
 	return mock.GetVersionsFunc(ctx, datasetID, editionID, state, offset, limit)
 }
 
@@ -1451,9 +1571,9 @@ func (mock *StorerMock) GetVersionsCalls() []struct {
 		Offset    int
 		Limit     int
 	}
-	mock.lockGetVersions.RLock()
+	lockStorerMockGetVersions.RLock()
 	calls = mock.calls.GetVersions
-	mock.lockGetVersions.RUnlock()
+	lockStorerMockGetVersions.RUnlock()
 	return calls
 }
 
@@ -1469,9 +1589,9 @@ func (mock *StorerMock) SetInstanceIsPublished(ctx context.Context, instanceID s
 		Ctx:        ctx,
 		InstanceID: instanceID,
 	}
-	mock.lockSetInstanceIsPublished.Lock()
+	lockStorerMockSetInstanceIsPublished.Lock()
 	mock.calls.SetInstanceIsPublished = append(mock.calls.SetInstanceIsPublished, callInfo)
-	mock.lockSetInstanceIsPublished.Unlock()
+	lockStorerMockSetInstanceIsPublished.Unlock()
 	return mock.SetInstanceIsPublishedFunc(ctx, instanceID)
 }
 
@@ -1486,87 +1606,126 @@ func (mock *StorerMock) SetInstanceIsPublishedCalls() []struct {
 		Ctx        context.Context
 		InstanceID string
 	}
-	mock.lockSetInstanceIsPublished.RLock()
+	lockStorerMockSetInstanceIsPublished.RLock()
 	calls = mock.calls.SetInstanceIsPublished
-	mock.lockSetInstanceIsPublished.RUnlock()
+	lockStorerMockSetInstanceIsPublished.RUnlock()
+	return calls
+}
+
+// UnlockInstance calls UnlockInstanceFunc.
+func (mock *StorerMock) UnlockInstance(lockID string) error {
+	if mock.UnlockInstanceFunc == nil {
+		panic("StorerMock.UnlockInstanceFunc: method is nil but Storer.UnlockInstance was just called")
+	}
+	callInfo := struct {
+		LockID string
+	}{
+		LockID: lockID,
+	}
+	lockStorerMockUnlockInstance.Lock()
+	mock.calls.UnlockInstance = append(mock.calls.UnlockInstance, callInfo)
+	lockStorerMockUnlockInstance.Unlock()
+	return mock.UnlockInstanceFunc(lockID)
+}
+
+// UnlockInstanceCalls gets all the calls that were made to UnlockInstance.
+// Check the length with:
+//     len(mockedStorer.UnlockInstanceCalls())
+func (mock *StorerMock) UnlockInstanceCalls() []struct {
+	LockID string
+} {
+	var calls []struct {
+		LockID string
+	}
+	lockStorerMockUnlockInstance.RLock()
+	calls = mock.calls.UnlockInstance
+	lockStorerMockUnlockInstance.RUnlock()
 	return calls
 }
 
 // UpdateBuildHierarchyTaskState calls UpdateBuildHierarchyTaskStateFunc.
-func (mock *StorerMock) UpdateBuildHierarchyTaskState(id string, dimension string, state string) error {
+func (mock *StorerMock) UpdateBuildHierarchyTaskState(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
 	if mock.UpdateBuildHierarchyTaskStateFunc == nil {
 		panic("StorerMock.UpdateBuildHierarchyTaskStateFunc: method is nil but Storer.UpdateBuildHierarchyTaskState was just called")
 	}
 	callInfo := struct {
-		ID        string
-		Dimension string
-		State     string
+		CurrentInstance *models.Instance
+		Dimension       string
+		State           string
+		ETagSelector    string
 	}{
-		ID:        id,
-		Dimension: dimension,
-		State:     state,
+		CurrentInstance: currentInstance,
+		Dimension:       dimension,
+		State:           state,
+		ETagSelector:    eTagSelector,
 	}
-	mock.lockUpdateBuildHierarchyTaskState.Lock()
+	lockStorerMockUpdateBuildHierarchyTaskState.Lock()
 	mock.calls.UpdateBuildHierarchyTaskState = append(mock.calls.UpdateBuildHierarchyTaskState, callInfo)
-	mock.lockUpdateBuildHierarchyTaskState.Unlock()
-	return mock.UpdateBuildHierarchyTaskStateFunc(id, dimension, state)
+	lockStorerMockUpdateBuildHierarchyTaskState.Unlock()
+	return mock.UpdateBuildHierarchyTaskStateFunc(currentInstance, dimension, state, eTagSelector)
 }
 
 // UpdateBuildHierarchyTaskStateCalls gets all the calls that were made to UpdateBuildHierarchyTaskState.
 // Check the length with:
 //     len(mockedStorer.UpdateBuildHierarchyTaskStateCalls())
 func (mock *StorerMock) UpdateBuildHierarchyTaskStateCalls() []struct {
-	ID        string
-	Dimension string
-	State     string
+	CurrentInstance *models.Instance
+	Dimension       string
+	State           string
+	ETagSelector    string
 } {
 	var calls []struct {
-		ID        string
-		Dimension string
-		State     string
+		CurrentInstance *models.Instance
+		Dimension       string
+		State           string
+		ETagSelector    string
 	}
-	mock.lockUpdateBuildHierarchyTaskState.RLock()
+	lockStorerMockUpdateBuildHierarchyTaskState.RLock()
 	calls = mock.calls.UpdateBuildHierarchyTaskState
-	mock.lockUpdateBuildHierarchyTaskState.RUnlock()
+	lockStorerMockUpdateBuildHierarchyTaskState.RUnlock()
 	return calls
 }
 
 // UpdateBuildSearchTaskState calls UpdateBuildSearchTaskStateFunc.
-func (mock *StorerMock) UpdateBuildSearchTaskState(id string, dimension string, state string) error {
+func (mock *StorerMock) UpdateBuildSearchTaskState(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
 	if mock.UpdateBuildSearchTaskStateFunc == nil {
 		panic("StorerMock.UpdateBuildSearchTaskStateFunc: method is nil but Storer.UpdateBuildSearchTaskState was just called")
 	}
 	callInfo := struct {
-		ID        string
-		Dimension string
-		State     string
+		CurrentInstance *models.Instance
+		Dimension       string
+		State           string
+		ETagSelector    string
 	}{
-		ID:        id,
-		Dimension: dimension,
-		State:     state,
+		CurrentInstance: currentInstance,
+		Dimension:       dimension,
+		State:           state,
+		ETagSelector:    eTagSelector,
 	}
-	mock.lockUpdateBuildSearchTaskState.Lock()
+	lockStorerMockUpdateBuildSearchTaskState.Lock()
 	mock.calls.UpdateBuildSearchTaskState = append(mock.calls.UpdateBuildSearchTaskState, callInfo)
-	mock.lockUpdateBuildSearchTaskState.Unlock()
-	return mock.UpdateBuildSearchTaskStateFunc(id, dimension, state)
+	lockStorerMockUpdateBuildSearchTaskState.Unlock()
+	return mock.UpdateBuildSearchTaskStateFunc(currentInstance, dimension, state, eTagSelector)
 }
 
 // UpdateBuildSearchTaskStateCalls gets all the calls that were made to UpdateBuildSearchTaskState.
 // Check the length with:
 //     len(mockedStorer.UpdateBuildSearchTaskStateCalls())
 func (mock *StorerMock) UpdateBuildSearchTaskStateCalls() []struct {
-	ID        string
-	Dimension string
-	State     string
+	CurrentInstance *models.Instance
+	Dimension       string
+	State           string
+	ETagSelector    string
 } {
 	var calls []struct {
-		ID        string
-		Dimension string
-		State     string
+		CurrentInstance *models.Instance
+		Dimension       string
+		State           string
+		ETagSelector    string
 	}
-	mock.lockUpdateBuildSearchTaskState.RLock()
+	lockStorerMockUpdateBuildSearchTaskState.RLock()
 	calls = mock.calls.UpdateBuildSearchTaskState
-	mock.lockUpdateBuildSearchTaskState.RUnlock()
+	lockStorerMockUpdateBuildSearchTaskState.RUnlock()
 	return calls
 }
 
@@ -1586,9 +1745,9 @@ func (mock *StorerMock) UpdateDataset(ctx context.Context, ID string, dataset *m
 		Dataset:      dataset,
 		CurrentState: currentState,
 	}
-	mock.lockUpdateDataset.Lock()
+	lockStorerMockUpdateDataset.Lock()
 	mock.calls.UpdateDataset = append(mock.calls.UpdateDataset, callInfo)
-	mock.lockUpdateDataset.Unlock()
+	lockStorerMockUpdateDataset.Unlock()
 	return mock.UpdateDatasetFunc(ctx, ID, dataset, currentState)
 }
 
@@ -1607,9 +1766,9 @@ func (mock *StorerMock) UpdateDatasetCalls() []struct {
 		Dataset      *models.Dataset
 		CurrentState string
 	}
-	mock.lockUpdateDataset.RLock()
+	lockStorerMockUpdateDataset.RLock()
 	calls = mock.calls.UpdateDataset
-	mock.lockUpdateDataset.RUnlock()
+	lockStorerMockUpdateDataset.RUnlock()
 	return calls
 }
 
@@ -1627,9 +1786,9 @@ func (mock *StorerMock) UpdateDatasetWithAssociation(ID string, state string, ve
 		State:   state,
 		Version: version,
 	}
-	mock.lockUpdateDatasetWithAssociation.Lock()
+	lockStorerMockUpdateDatasetWithAssociation.Lock()
 	mock.calls.UpdateDatasetWithAssociation = append(mock.calls.UpdateDatasetWithAssociation, callInfo)
-	mock.lockUpdateDatasetWithAssociation.Unlock()
+	lockStorerMockUpdateDatasetWithAssociation.Unlock()
 	return mock.UpdateDatasetWithAssociationFunc(ID, state, version)
 }
 
@@ -1646,9 +1805,9 @@ func (mock *StorerMock) UpdateDatasetWithAssociationCalls() []struct {
 		State   string
 		Version *models.Version
 	}
-	mock.lockUpdateDatasetWithAssociation.RLock()
+	lockStorerMockUpdateDatasetWithAssociation.RLock()
 	calls = mock.calls.UpdateDatasetWithAssociation
-	mock.lockUpdateDatasetWithAssociation.RUnlock()
+	lockStorerMockUpdateDatasetWithAssociation.RUnlock()
 	return calls
 }
 
@@ -1662,9 +1821,9 @@ func (mock *StorerMock) UpdateDimensionNodeIDAndOrder(dimension *models.Dimensio
 	}{
 		Dimension: dimension,
 	}
-	mock.lockUpdateDimensionNodeIDAndOrder.Lock()
+	lockStorerMockUpdateDimensionNodeIDAndOrder.Lock()
 	mock.calls.UpdateDimensionNodeIDAndOrder = append(mock.calls.UpdateDimensionNodeIDAndOrder, callInfo)
-	mock.lockUpdateDimensionNodeIDAndOrder.Unlock()
+	lockStorerMockUpdateDimensionNodeIDAndOrder.Unlock()
 	return mock.UpdateDimensionNodeIDAndOrderFunc(dimension)
 }
 
@@ -1677,118 +1836,212 @@ func (mock *StorerMock) UpdateDimensionNodeIDAndOrderCalls() []struct {
 	var calls []struct {
 		Dimension *models.DimensionOption
 	}
-	mock.lockUpdateDimensionNodeIDAndOrder.RLock()
+	lockStorerMockUpdateDimensionNodeIDAndOrder.RLock()
 	calls = mock.calls.UpdateDimensionNodeIDAndOrder
-	mock.lockUpdateDimensionNodeIDAndOrder.RUnlock()
+	lockStorerMockUpdateDimensionNodeIDAndOrder.RUnlock()
+	return calls
+}
+
+// UpdateETagForNodeIDAndOrder calls UpdateETagForNodeIDAndOrderFunc.
+func (mock *StorerMock) UpdateETagForNodeIDAndOrder(currentInstance *models.Instance, nodeID string, order *int, eTagSelector string) (string, error) {
+	if mock.UpdateETagForNodeIDAndOrderFunc == nil {
+		panic("StorerMock.UpdateETagForNodeIDAndOrderFunc: method is nil but Storer.UpdateETagForNodeIDAndOrder was just called")
+	}
+	callInfo := struct {
+		CurrentInstance *models.Instance
+		NodeID          string
+		Order           *int
+		ETagSelector    string
+	}{
+		CurrentInstance: currentInstance,
+		NodeID:          nodeID,
+		Order:           order,
+		ETagSelector:    eTagSelector,
+	}
+	lockStorerMockUpdateETagForNodeIDAndOrder.Lock()
+	mock.calls.UpdateETagForNodeIDAndOrder = append(mock.calls.UpdateETagForNodeIDAndOrder, callInfo)
+	lockStorerMockUpdateETagForNodeIDAndOrder.Unlock()
+	return mock.UpdateETagForNodeIDAndOrderFunc(currentInstance, nodeID, order, eTagSelector)
+}
+
+// UpdateETagForNodeIDAndOrderCalls gets all the calls that were made to UpdateETagForNodeIDAndOrder.
+// Check the length with:
+//     len(mockedStorer.UpdateETagForNodeIDAndOrderCalls())
+func (mock *StorerMock) UpdateETagForNodeIDAndOrderCalls() []struct {
+	CurrentInstance *models.Instance
+	NodeID          string
+	Order           *int
+	ETagSelector    string
+} {
+	var calls []struct {
+		CurrentInstance *models.Instance
+		NodeID          string
+		Order           *int
+		ETagSelector    string
+	}
+	lockStorerMockUpdateETagForNodeIDAndOrder.RLock()
+	calls = mock.calls.UpdateETagForNodeIDAndOrder
+	lockStorerMockUpdateETagForNodeIDAndOrder.RUnlock()
+	return calls
+}
+
+// UpdateETagForOptions calls UpdateETagForOptionsFunc.
+func (mock *StorerMock) UpdateETagForOptions(currentInstance *models.Instance, option *models.CachedDimensionOption, eTagSelector string) (string, error) {
+	if mock.UpdateETagForOptionsFunc == nil {
+		panic("StorerMock.UpdateETagForOptionsFunc: method is nil but Storer.UpdateETagForOptions was just called")
+	}
+	callInfo := struct {
+		CurrentInstance *models.Instance
+		Option          *models.CachedDimensionOption
+		ETagSelector    string
+	}{
+		CurrentInstance: currentInstance,
+		Option:          option,
+		ETagSelector:    eTagSelector,
+	}
+	lockStorerMockUpdateETagForOptions.Lock()
+	mock.calls.UpdateETagForOptions = append(mock.calls.UpdateETagForOptions, callInfo)
+	lockStorerMockUpdateETagForOptions.Unlock()
+	return mock.UpdateETagForOptionsFunc(currentInstance, option, eTagSelector)
+}
+
+// UpdateETagForOptionsCalls gets all the calls that were made to UpdateETagForOptions.
+// Check the length with:
+//     len(mockedStorer.UpdateETagForOptionsCalls())
+func (mock *StorerMock) UpdateETagForOptionsCalls() []struct {
+	CurrentInstance *models.Instance
+	Option          *models.CachedDimensionOption
+	ETagSelector    string
+} {
+	var calls []struct {
+		CurrentInstance *models.Instance
+		Option          *models.CachedDimensionOption
+		ETagSelector    string
+	}
+	lockStorerMockUpdateETagForOptions.RLock()
+	calls = mock.calls.UpdateETagForOptions
+	lockStorerMockUpdateETagForOptions.RUnlock()
 	return calls
 }
 
 // UpdateImportObservationsTaskState calls UpdateImportObservationsTaskStateFunc.
-func (mock *StorerMock) UpdateImportObservationsTaskState(id string, state string) error {
+func (mock *StorerMock) UpdateImportObservationsTaskState(currentInstance *models.Instance, state string, eTagSelector string) (string, error) {
 	if mock.UpdateImportObservationsTaskStateFunc == nil {
 		panic("StorerMock.UpdateImportObservationsTaskStateFunc: method is nil but Storer.UpdateImportObservationsTaskState was just called")
 	}
 	callInfo := struct {
-		ID    string
-		State string
+		CurrentInstance *models.Instance
+		State           string
+		ETagSelector    string
 	}{
-		ID:    id,
-		State: state,
+		CurrentInstance: currentInstance,
+		State:           state,
+		ETagSelector:    eTagSelector,
 	}
-	mock.lockUpdateImportObservationsTaskState.Lock()
+	lockStorerMockUpdateImportObservationsTaskState.Lock()
 	mock.calls.UpdateImportObservationsTaskState = append(mock.calls.UpdateImportObservationsTaskState, callInfo)
-	mock.lockUpdateImportObservationsTaskState.Unlock()
-	return mock.UpdateImportObservationsTaskStateFunc(id, state)
+	lockStorerMockUpdateImportObservationsTaskState.Unlock()
+	return mock.UpdateImportObservationsTaskStateFunc(currentInstance, state, eTagSelector)
 }
 
 // UpdateImportObservationsTaskStateCalls gets all the calls that were made to UpdateImportObservationsTaskState.
 // Check the length with:
 //     len(mockedStorer.UpdateImportObservationsTaskStateCalls())
 func (mock *StorerMock) UpdateImportObservationsTaskStateCalls() []struct {
-	ID    string
-	State string
+	CurrentInstance *models.Instance
+	State           string
+	ETagSelector    string
 } {
 	var calls []struct {
-		ID    string
-		State string
+		CurrentInstance *models.Instance
+		State           string
+		ETagSelector    string
 	}
-	mock.lockUpdateImportObservationsTaskState.RLock()
+	lockStorerMockUpdateImportObservationsTaskState.RLock()
 	calls = mock.calls.UpdateImportObservationsTaskState
-	mock.lockUpdateImportObservationsTaskState.RUnlock()
+	lockStorerMockUpdateImportObservationsTaskState.RUnlock()
 	return calls
 }
 
 // UpdateInstance calls UpdateInstanceFunc.
-func (mock *StorerMock) UpdateInstance(ctx context.Context, ID string, instance *models.Instance) error {
+func (mock *StorerMock) UpdateInstance(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
 	if mock.UpdateInstanceFunc == nil {
 		panic("StorerMock.UpdateInstanceFunc: method is nil but Storer.UpdateInstance was just called")
 	}
 	callInfo := struct {
-		Ctx      context.Context
-		ID       string
-		Instance *models.Instance
+		Ctx             context.Context
+		CurrentInstance *models.Instance
+		UpdatedInstance *models.Instance
+		ETagSelector    string
 	}{
-		Ctx:      ctx,
-		ID:       ID,
-		Instance: instance,
+		Ctx:             ctx,
+		CurrentInstance: currentInstance,
+		UpdatedInstance: updatedInstance,
+		ETagSelector:    eTagSelector,
 	}
-	mock.lockUpdateInstance.Lock()
+	lockStorerMockUpdateInstance.Lock()
 	mock.calls.UpdateInstance = append(mock.calls.UpdateInstance, callInfo)
-	mock.lockUpdateInstance.Unlock()
-	return mock.UpdateInstanceFunc(ctx, ID, instance)
+	lockStorerMockUpdateInstance.Unlock()
+	return mock.UpdateInstanceFunc(ctx, currentInstance, updatedInstance, eTagSelector)
 }
 
 // UpdateInstanceCalls gets all the calls that were made to UpdateInstance.
 // Check the length with:
 //     len(mockedStorer.UpdateInstanceCalls())
 func (mock *StorerMock) UpdateInstanceCalls() []struct {
-	Ctx      context.Context
-	ID       string
-	Instance *models.Instance
+	Ctx             context.Context
+	CurrentInstance *models.Instance
+	UpdatedInstance *models.Instance
+	ETagSelector    string
 } {
 	var calls []struct {
-		Ctx      context.Context
-		ID       string
-		Instance *models.Instance
+		Ctx             context.Context
+		CurrentInstance *models.Instance
+		UpdatedInstance *models.Instance
+		ETagSelector    string
 	}
-	mock.lockUpdateInstance.RLock()
+	lockStorerMockUpdateInstance.RLock()
 	calls = mock.calls.UpdateInstance
-	mock.lockUpdateInstance.RUnlock()
+	lockStorerMockUpdateInstance.RUnlock()
 	return calls
 }
 
 // UpdateObservationInserted calls UpdateObservationInsertedFunc.
-func (mock *StorerMock) UpdateObservationInserted(ID string, observationInserted int64) error {
+func (mock *StorerMock) UpdateObservationInserted(currentInstance *models.Instance, observationInserted int64, eTagSelector string) (string, error) {
 	if mock.UpdateObservationInsertedFunc == nil {
 		panic("StorerMock.UpdateObservationInsertedFunc: method is nil but Storer.UpdateObservationInserted was just called")
 	}
 	callInfo := struct {
-		ID                  string
+		CurrentInstance     *models.Instance
 		ObservationInserted int64
+		ETagSelector        string
 	}{
-		ID:                  ID,
+		CurrentInstance:     currentInstance,
 		ObservationInserted: observationInserted,
+		ETagSelector:        eTagSelector,
 	}
-	mock.lockUpdateObservationInserted.Lock()
+	lockStorerMockUpdateObservationInserted.Lock()
 	mock.calls.UpdateObservationInserted = append(mock.calls.UpdateObservationInserted, callInfo)
-	mock.lockUpdateObservationInserted.Unlock()
-	return mock.UpdateObservationInsertedFunc(ID, observationInserted)
+	lockStorerMockUpdateObservationInserted.Unlock()
+	return mock.UpdateObservationInsertedFunc(currentInstance, observationInserted, eTagSelector)
 }
 
 // UpdateObservationInsertedCalls gets all the calls that were made to UpdateObservationInserted.
 // Check the length with:
 //     len(mockedStorer.UpdateObservationInsertedCalls())
 func (mock *StorerMock) UpdateObservationInsertedCalls() []struct {
-	ID                  string
+	CurrentInstance     *models.Instance
 	ObservationInserted int64
+	ETagSelector        string
 } {
 	var calls []struct {
-		ID                  string
+		CurrentInstance     *models.Instance
 		ObservationInserted int64
+		ETagSelector        string
 	}
-	mock.lockUpdateObservationInserted.RLock()
+	lockStorerMockUpdateObservationInserted.RLock()
 	calls = mock.calls.UpdateObservationInserted
-	mock.lockUpdateObservationInserted.RUnlock()
+	lockStorerMockUpdateObservationInserted.RUnlock()
 	return calls
 }
 
@@ -1804,9 +2057,9 @@ func (mock *StorerMock) UpdateVersion(ID string, version *models.Version) error 
 		ID:      ID,
 		Version: version,
 	}
-	mock.lockUpdateVersion.Lock()
+	lockStorerMockUpdateVersion.Lock()
 	mock.calls.UpdateVersion = append(mock.calls.UpdateVersion, callInfo)
-	mock.lockUpdateVersion.Unlock()
+	lockStorerMockUpdateVersion.Unlock()
 	return mock.UpdateVersionFunc(ID, version)
 }
 
@@ -1821,9 +2074,9 @@ func (mock *StorerMock) UpdateVersionCalls() []struct {
 		ID      string
 		Version *models.Version
 	}
-	mock.lockUpdateVersion.RLock()
+	lockStorerMockUpdateVersion.RLock()
 	calls = mock.calls.UpdateVersion
-	mock.lockUpdateVersion.RUnlock()
+	lockStorerMockUpdateVersion.RUnlock()
 	return calls
 }
 
@@ -1839,9 +2092,9 @@ func (mock *StorerMock) UpsertContact(ID string, update interface{}) error {
 		ID:     ID,
 		Update: update,
 	}
-	mock.lockUpsertContact.Lock()
+	lockStorerMockUpsertContact.Lock()
 	mock.calls.UpsertContact = append(mock.calls.UpsertContact, callInfo)
-	mock.lockUpsertContact.Unlock()
+	lockStorerMockUpsertContact.Unlock()
 	return mock.UpsertContactFunc(ID, update)
 }
 
@@ -1856,9 +2109,9 @@ func (mock *StorerMock) UpsertContactCalls() []struct {
 		ID     string
 		Update interface{}
 	}
-	mock.lockUpsertContact.RLock()
+	lockStorerMockUpsertContact.RLock()
 	calls = mock.calls.UpsertContact
-	mock.lockUpsertContact.RUnlock()
+	lockStorerMockUpsertContact.RUnlock()
 	return calls
 }
 
@@ -1874,9 +2127,9 @@ func (mock *StorerMock) UpsertDataset(ID string, datasetDoc *models.DatasetUpdat
 		ID:         ID,
 		DatasetDoc: datasetDoc,
 	}
-	mock.lockUpsertDataset.Lock()
+	lockStorerMockUpsertDataset.Lock()
 	mock.calls.UpsertDataset = append(mock.calls.UpsertDataset, callInfo)
-	mock.lockUpsertDataset.Unlock()
+	lockStorerMockUpsertDataset.Unlock()
 	return mock.UpsertDatasetFunc(ID, datasetDoc)
 }
 
@@ -1891,9 +2144,9 @@ func (mock *StorerMock) UpsertDatasetCalls() []struct {
 		ID         string
 		DatasetDoc *models.DatasetUpdate
 	}
-	mock.lockUpsertDataset.RLock()
+	lockStorerMockUpsertDataset.RLock()
 	calls = mock.calls.UpsertDataset
-	mock.lockUpsertDataset.RUnlock()
+	lockStorerMockUpsertDataset.RUnlock()
 	return calls
 }
 
@@ -1911,9 +2164,9 @@ func (mock *StorerMock) UpsertEdition(datasetID string, edition string, editionD
 		Edition:    edition,
 		EditionDoc: editionDoc,
 	}
-	mock.lockUpsertEdition.Lock()
+	lockStorerMockUpsertEdition.Lock()
 	mock.calls.UpsertEdition = append(mock.calls.UpsertEdition, callInfo)
-	mock.lockUpsertEdition.Unlock()
+	lockStorerMockUpsertEdition.Unlock()
 	return mock.UpsertEditionFunc(datasetID, edition, editionDoc)
 }
 
@@ -1930,9 +2183,9 @@ func (mock *StorerMock) UpsertEditionCalls() []struct {
 		Edition    string
 		EditionDoc *models.EditionUpdate
 	}
-	mock.lockUpsertEdition.RLock()
+	lockStorerMockUpsertEdition.RLock()
 	calls = mock.calls.UpsertEdition
-	mock.lockUpsertEdition.RUnlock()
+	lockStorerMockUpsertEdition.RUnlock()
 	return calls
 }
 
@@ -1948,9 +2201,9 @@ func (mock *StorerMock) UpsertVersion(ID string, versionDoc *models.Version) err
 		ID:         ID,
 		VersionDoc: versionDoc,
 	}
-	mock.lockUpsertVersion.Lock()
+	lockStorerMockUpsertVersion.Lock()
 	mock.calls.UpsertVersion = append(mock.calls.UpsertVersion, callInfo)
-	mock.lockUpsertVersion.Unlock()
+	lockStorerMockUpsertVersion.Unlock()
 	return mock.UpsertVersionFunc(ID, versionDoc)
 }
 
@@ -1965,8 +2218,8 @@ func (mock *StorerMock) UpsertVersionCalls() []struct {
 		ID         string
 		VersionDoc *models.Version
 	}
-	mock.lockUpsertVersion.RLock()
+	lockStorerMockUpsertVersion.RLock()
 	calls = mock.calls.UpsertVersion
-	mock.lockUpsertVersion.RUnlock()
+	lockStorerMockUpsertVersion.RUnlock()
 	return calls
 }

--- a/store/datastoretest/graph.go
+++ b/store/datastoretest/graph.go
@@ -10,6 +10,13 @@ import (
 	"sync"
 )
 
+var (
+	lockGraphDBMockAddVersionDetailsToInstance sync.RWMutex
+	lockGraphDBMockChecker                     sync.RWMutex
+	lockGraphDBMockClose                       sync.RWMutex
+	lockGraphDBMockSetInstanceIsPublished      sync.RWMutex
+)
+
 // Ensure, that GraphDBMock does implement store.GraphDB.
 // If this is not the case, regenerate this file with moq.
 var _ store.GraphDB = &GraphDBMock{}
@@ -86,10 +93,6 @@ type GraphDBMock struct {
 			InstanceID string
 		}
 	}
-	lockAddVersionDetailsToInstance sync.RWMutex
-	lockChecker                     sync.RWMutex
-	lockClose                       sync.RWMutex
-	lockSetInstanceIsPublished      sync.RWMutex
 }
 
 // AddVersionDetailsToInstance calls AddVersionDetailsToInstanceFunc.
@@ -110,9 +113,9 @@ func (mock *GraphDBMock) AddVersionDetailsToInstance(ctx context.Context, instan
 		Edition:    edition,
 		Version:    version,
 	}
-	mock.lockAddVersionDetailsToInstance.Lock()
+	lockGraphDBMockAddVersionDetailsToInstance.Lock()
 	mock.calls.AddVersionDetailsToInstance = append(mock.calls.AddVersionDetailsToInstance, callInfo)
-	mock.lockAddVersionDetailsToInstance.Unlock()
+	lockGraphDBMockAddVersionDetailsToInstance.Unlock()
 	return mock.AddVersionDetailsToInstanceFunc(ctx, instanceID, datasetID, edition, version)
 }
 
@@ -133,9 +136,9 @@ func (mock *GraphDBMock) AddVersionDetailsToInstanceCalls() []struct {
 		Edition    string
 		Version    int
 	}
-	mock.lockAddVersionDetailsToInstance.RLock()
+	lockGraphDBMockAddVersionDetailsToInstance.RLock()
 	calls = mock.calls.AddVersionDetailsToInstance
-	mock.lockAddVersionDetailsToInstance.RUnlock()
+	lockGraphDBMockAddVersionDetailsToInstance.RUnlock()
 	return calls
 }
 
@@ -151,9 +154,9 @@ func (mock *GraphDBMock) Checker(in1 context.Context, in2 *healthcheck.CheckStat
 		In1: in1,
 		In2: in2,
 	}
-	mock.lockChecker.Lock()
+	lockGraphDBMockChecker.Lock()
 	mock.calls.Checker = append(mock.calls.Checker, callInfo)
-	mock.lockChecker.Unlock()
+	lockGraphDBMockChecker.Unlock()
 	return mock.CheckerFunc(in1, in2)
 }
 
@@ -168,9 +171,9 @@ func (mock *GraphDBMock) CheckerCalls() []struct {
 		In1 context.Context
 		In2 *healthcheck.CheckState
 	}
-	mock.lockChecker.RLock()
+	lockGraphDBMockChecker.RLock()
 	calls = mock.calls.Checker
-	mock.lockChecker.RUnlock()
+	lockGraphDBMockChecker.RUnlock()
 	return calls
 }
 
@@ -184,9 +187,9 @@ func (mock *GraphDBMock) Close(ctx context.Context) error {
 	}{
 		Ctx: ctx,
 	}
-	mock.lockClose.Lock()
+	lockGraphDBMockClose.Lock()
 	mock.calls.Close = append(mock.calls.Close, callInfo)
-	mock.lockClose.Unlock()
+	lockGraphDBMockClose.Unlock()
 	return mock.CloseFunc(ctx)
 }
 
@@ -199,9 +202,9 @@ func (mock *GraphDBMock) CloseCalls() []struct {
 	var calls []struct {
 		Ctx context.Context
 	}
-	mock.lockClose.RLock()
+	lockGraphDBMockClose.RLock()
 	calls = mock.calls.Close
-	mock.lockClose.RUnlock()
+	lockGraphDBMockClose.RUnlock()
 	return calls
 }
 
@@ -217,9 +220,9 @@ func (mock *GraphDBMock) SetInstanceIsPublished(ctx context.Context, instanceID 
 		Ctx:        ctx,
 		InstanceID: instanceID,
 	}
-	mock.lockSetInstanceIsPublished.Lock()
+	lockGraphDBMockSetInstanceIsPublished.Lock()
 	mock.calls.SetInstanceIsPublished = append(mock.calls.SetInstanceIsPublished, callInfo)
-	mock.lockSetInstanceIsPublished.Unlock()
+	lockGraphDBMockSetInstanceIsPublished.Unlock()
 	return mock.SetInstanceIsPublishedFunc(ctx, instanceID)
 }
 
@@ -234,8 +237,8 @@ func (mock *GraphDBMock) SetInstanceIsPublishedCalls() []struct {
 		Ctx        context.Context
 		InstanceID string
 	}
-	mock.lockSetInstanceIsPublished.RLock()
+	lockGraphDBMockSetInstanceIsPublished.RLock()
 	calls = mock.calls.SetInstanceIsPublished
-	mock.lockSetInstanceIsPublished.RUnlock()
+	lockGraphDBMockSetInstanceIsPublished.RUnlock()
 	return calls
 }

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -12,6 +12,49 @@ import (
 	"sync"
 )
 
+var (
+	lockMongoDBMockAcquireInstanceLock               sync.RWMutex
+	lockMongoDBMockAddDimensionToInstance            sync.RWMutex
+	lockMongoDBMockAddEventToInstance                sync.RWMutex
+	lockMongoDBMockAddInstance                       sync.RWMutex
+	lockMongoDBMockCheckDatasetExists                sync.RWMutex
+	lockMongoDBMockCheckEditionExists                sync.RWMutex
+	lockMongoDBMockChecker                           sync.RWMutex
+	lockMongoDBMockClose                             sync.RWMutex
+	lockMongoDBMockDeleteDataset                     sync.RWMutex
+	lockMongoDBMockDeleteEdition                     sync.RWMutex
+	lockMongoDBMockGetDataset                        sync.RWMutex
+	lockMongoDBMockGetDatasets                       sync.RWMutex
+	lockMongoDBMockGetDimensionOptions               sync.RWMutex
+	lockMongoDBMockGetDimensionOptionsFromIDs        sync.RWMutex
+	lockMongoDBMockGetDimensions                     sync.RWMutex
+	lockMongoDBMockGetDimensionsFromInstance         sync.RWMutex
+	lockMongoDBMockGetEdition                        sync.RWMutex
+	lockMongoDBMockGetEditions                       sync.RWMutex
+	lockMongoDBMockGetInstance                       sync.RWMutex
+	lockMongoDBMockGetInstances                      sync.RWMutex
+	lockMongoDBMockGetNextVersion                    sync.RWMutex
+	lockMongoDBMockGetUniqueDimensionAndOptions      sync.RWMutex
+	lockMongoDBMockGetVersion                        sync.RWMutex
+	lockMongoDBMockGetVersions                       sync.RWMutex
+	lockMongoDBMockUnlockInstance                    sync.RWMutex
+	lockMongoDBMockUpdateBuildHierarchyTaskState     sync.RWMutex
+	lockMongoDBMockUpdateBuildSearchTaskState        sync.RWMutex
+	lockMongoDBMockUpdateDataset                     sync.RWMutex
+	lockMongoDBMockUpdateDatasetWithAssociation      sync.RWMutex
+	lockMongoDBMockUpdateDimensionNodeIDAndOrder     sync.RWMutex
+	lockMongoDBMockUpdateETagForNodeIDAndOrder       sync.RWMutex
+	lockMongoDBMockUpdateETagForOptions              sync.RWMutex
+	lockMongoDBMockUpdateImportObservationsTaskState sync.RWMutex
+	lockMongoDBMockUpdateInstance                    sync.RWMutex
+	lockMongoDBMockUpdateObservationInserted         sync.RWMutex
+	lockMongoDBMockUpdateVersion                     sync.RWMutex
+	lockMongoDBMockUpsertContact                     sync.RWMutex
+	lockMongoDBMockUpsertDataset                     sync.RWMutex
+	lockMongoDBMockUpsertEdition                     sync.RWMutex
+	lockMongoDBMockUpsertVersion                     sync.RWMutex
+)
+
 // Ensure, that MongoDBMock does implement store.MongoDB.
 // If this is not the case, regenerate this file with moq.
 var _ store.MongoDB = &MongoDBMock{}
@@ -22,10 +65,13 @@ var _ store.MongoDB = &MongoDBMock{}
 //
 //         // make and configure a mocked store.MongoDB
 //         mockedMongoDB := &MongoDBMock{
+//             AcquireInstanceLockFunc: func(ctx context.Context, instanceID string) (string, error) {
+// 	               panic("mock out the AcquireInstanceLock method")
+//             },
 //             AddDimensionToInstanceFunc: func(dimension *models.CachedDimensionOption) error {
 // 	               panic("mock out the AddDimensionToInstance method")
 //             },
-//             AddEventToInstanceFunc: func(instanceID string, event *models.Event) error {
+//             AddEventToInstanceFunc: func(currentInstance *models.Instance, event *models.Event, eTagSelector string) (string, error) {
 // 	               panic("mock out the AddEventToInstance method")
 //             },
 //             AddInstanceFunc: func(instance *models.Instance) (*models.Instance, error) {
@@ -73,7 +119,7 @@ var _ store.MongoDB = &MongoDBMock{}
 //             GetEditionsFunc: func(ctx context.Context, ID string, state string, offset int, limit int, authorised bool) ([]*models.EditionUpdate, int, error) {
 // 	               panic("mock out the GetEditions method")
 //             },
-//             GetInstanceFunc: func(ID string) (*models.Instance, error) {
+//             GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
 // 	               panic("mock out the GetInstance method")
 //             },
 //             GetInstancesFunc: func(ctx context.Context, states []string, datasets []string, offset int, limit int) ([]*models.Instance, int, error) {
@@ -91,10 +137,13 @@ var _ store.MongoDB = &MongoDBMock{}
 //             GetVersionsFunc: func(ctx context.Context, datasetID string, editionID string, state string, offset int, limit int) ([]models.Version, int, error) {
 // 	               panic("mock out the GetVersions method")
 //             },
-//             UpdateBuildHierarchyTaskStateFunc: func(id string, dimension string, state string) error {
+//             UnlockInstanceFunc: func(lockID string) error {
+// 	               panic("mock out the UnlockInstance method")
+//             },
+//             UpdateBuildHierarchyTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
 // 	               panic("mock out the UpdateBuildHierarchyTaskState method")
 //             },
-//             UpdateBuildSearchTaskStateFunc: func(id string, dimension string, state string) error {
+//             UpdateBuildSearchTaskStateFunc: func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
 // 	               panic("mock out the UpdateBuildSearchTaskState method")
 //             },
 //             UpdateDatasetFunc: func(ctx context.Context, ID string, dataset *models.Dataset, currentState string) error {
@@ -106,13 +155,19 @@ var _ store.MongoDB = &MongoDBMock{}
 //             UpdateDimensionNodeIDAndOrderFunc: func(dimension *models.DimensionOption) error {
 // 	               panic("mock out the UpdateDimensionNodeIDAndOrder method")
 //             },
-//             UpdateImportObservationsTaskStateFunc: func(id string, state string) error {
+//             UpdateETagForNodeIDAndOrderFunc: func(currentInstance *models.Instance, nodeID string, order *int, eTagSelector string) (string, error) {
+// 	               panic("mock out the UpdateETagForNodeIDAndOrder method")
+//             },
+//             UpdateETagForOptionsFunc: func(currentInstance *models.Instance, option *models.CachedDimensionOption, eTagSelector string) (string, error) {
+// 	               panic("mock out the UpdateETagForOptions method")
+//             },
+//             UpdateImportObservationsTaskStateFunc: func(currentInstance *models.Instance, state string, eTagSelector string) (string, error) {
 // 	               panic("mock out the UpdateImportObservationsTaskState method")
 //             },
-//             UpdateInstanceFunc: func(ctx context.Context, ID string, instance *models.Instance) error {
+//             UpdateInstanceFunc: func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
 // 	               panic("mock out the UpdateInstance method")
 //             },
-//             UpdateObservationInsertedFunc: func(ID string, observationInserted int64) error {
+//             UpdateObservationInsertedFunc: func(currentInstance *models.Instance, observationInserted int64, eTagSelector string) (string, error) {
 // 	               panic("mock out the UpdateObservationInserted method")
 //             },
 //             UpdateVersionFunc: func(ID string, version *models.Version) error {
@@ -137,11 +192,14 @@ var _ store.MongoDB = &MongoDBMock{}
 //
 //     }
 type MongoDBMock struct {
+	// AcquireInstanceLockFunc mocks the AcquireInstanceLock method.
+	AcquireInstanceLockFunc func(ctx context.Context, instanceID string) (string, error)
+
 	// AddDimensionToInstanceFunc mocks the AddDimensionToInstance method.
 	AddDimensionToInstanceFunc func(dimension *models.CachedDimensionOption) error
 
 	// AddEventToInstanceFunc mocks the AddEventToInstance method.
-	AddEventToInstanceFunc func(instanceID string, event *models.Event) error
+	AddEventToInstanceFunc func(currentInstance *models.Instance, event *models.Event, eTagSelector string) (string, error)
 
 	// AddInstanceFunc mocks the AddInstance method.
 	AddInstanceFunc func(instance *models.Instance) (*models.Instance, error)
@@ -189,7 +247,7 @@ type MongoDBMock struct {
 	GetEditionsFunc func(ctx context.Context, ID string, state string, offset int, limit int, authorised bool) ([]*models.EditionUpdate, int, error)
 
 	// GetInstanceFunc mocks the GetInstance method.
-	GetInstanceFunc func(ID string) (*models.Instance, error)
+	GetInstanceFunc func(ID string, eTagSelector string) (*models.Instance, error)
 
 	// GetInstancesFunc mocks the GetInstances method.
 	GetInstancesFunc func(ctx context.Context, states []string, datasets []string, offset int, limit int) ([]*models.Instance, int, error)
@@ -206,11 +264,14 @@ type MongoDBMock struct {
 	// GetVersionsFunc mocks the GetVersions method.
 	GetVersionsFunc func(ctx context.Context, datasetID string, editionID string, state string, offset int, limit int) ([]models.Version, int, error)
 
+	// UnlockInstanceFunc mocks the UnlockInstance method.
+	UnlockInstanceFunc func(lockID string) error
+
 	// UpdateBuildHierarchyTaskStateFunc mocks the UpdateBuildHierarchyTaskState method.
-	UpdateBuildHierarchyTaskStateFunc func(id string, dimension string, state string) error
+	UpdateBuildHierarchyTaskStateFunc func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error)
 
 	// UpdateBuildSearchTaskStateFunc mocks the UpdateBuildSearchTaskState method.
-	UpdateBuildSearchTaskStateFunc func(id string, dimension string, state string) error
+	UpdateBuildSearchTaskStateFunc func(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error)
 
 	// UpdateDatasetFunc mocks the UpdateDataset method.
 	UpdateDatasetFunc func(ctx context.Context, ID string, dataset *models.Dataset, currentState string) error
@@ -221,14 +282,20 @@ type MongoDBMock struct {
 	// UpdateDimensionNodeIDAndOrderFunc mocks the UpdateDimensionNodeIDAndOrder method.
 	UpdateDimensionNodeIDAndOrderFunc func(dimension *models.DimensionOption) error
 
+	// UpdateETagForNodeIDAndOrderFunc mocks the UpdateETagForNodeIDAndOrder method.
+	UpdateETagForNodeIDAndOrderFunc func(currentInstance *models.Instance, nodeID string, order *int, eTagSelector string) (string, error)
+
+	// UpdateETagForOptionsFunc mocks the UpdateETagForOptions method.
+	UpdateETagForOptionsFunc func(currentInstance *models.Instance, option *models.CachedDimensionOption, eTagSelector string) (string, error)
+
 	// UpdateImportObservationsTaskStateFunc mocks the UpdateImportObservationsTaskState method.
-	UpdateImportObservationsTaskStateFunc func(id string, state string) error
+	UpdateImportObservationsTaskStateFunc func(currentInstance *models.Instance, state string, eTagSelector string) (string, error)
 
 	// UpdateInstanceFunc mocks the UpdateInstance method.
-	UpdateInstanceFunc func(ctx context.Context, ID string, instance *models.Instance) error
+	UpdateInstanceFunc func(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error)
 
 	// UpdateObservationInsertedFunc mocks the UpdateObservationInserted method.
-	UpdateObservationInsertedFunc func(ID string, observationInserted int64) error
+	UpdateObservationInsertedFunc func(currentInstance *models.Instance, observationInserted int64, eTagSelector string) (string, error)
 
 	// UpdateVersionFunc mocks the UpdateVersion method.
 	UpdateVersionFunc func(ID string, version *models.Version) error
@@ -247,6 +314,13 @@ type MongoDBMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// AcquireInstanceLock holds details about calls to the AcquireInstanceLock method.
+		AcquireInstanceLock []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// InstanceID is the instanceID argument value.
+			InstanceID string
+		}
 		// AddDimensionToInstance holds details about calls to the AddDimensionToInstance method.
 		AddDimensionToInstance []struct {
 			// Dimension is the dimension argument value.
@@ -254,10 +328,12 @@ type MongoDBMock struct {
 		}
 		// AddEventToInstance holds details about calls to the AddEventToInstance method.
 		AddEventToInstance []struct {
-			// InstanceID is the instanceID argument value.
-			InstanceID string
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
 			// Event is the event argument value.
 			Event *models.Event
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// AddInstance holds details about calls to the AddInstance method.
 		AddInstance []struct {
@@ -386,6 +462,8 @@ type MongoDBMock struct {
 		GetInstance []struct {
 			// ID is the ID argument value.
 			ID string
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// GetInstances holds details about calls to the GetInstances method.
 		GetInstances []struct {
@@ -446,23 +524,32 @@ type MongoDBMock struct {
 			// Limit is the limit argument value.
 			Limit int
 		}
+		// UnlockInstance holds details about calls to the UnlockInstance method.
+		UnlockInstance []struct {
+			// LockID is the lockID argument value.
+			LockID string
+		}
 		// UpdateBuildHierarchyTaskState holds details about calls to the UpdateBuildHierarchyTaskState method.
 		UpdateBuildHierarchyTaskState []struct {
-			// ID is the id argument value.
-			ID string
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
 			// Dimension is the dimension argument value.
 			Dimension string
 			// State is the state argument value.
 			State string
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// UpdateBuildSearchTaskState holds details about calls to the UpdateBuildSearchTaskState method.
 		UpdateBuildSearchTaskState []struct {
-			// ID is the id argument value.
-			ID string
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
 			// Dimension is the dimension argument value.
 			Dimension string
 			// State is the state argument value.
 			State string
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// UpdateDataset holds details about calls to the UpdateDataset method.
 		UpdateDataset []struct {
@@ -489,28 +576,54 @@ type MongoDBMock struct {
 			// Dimension is the dimension argument value.
 			Dimension *models.DimensionOption
 		}
+		// UpdateETagForNodeIDAndOrder holds details about calls to the UpdateETagForNodeIDAndOrder method.
+		UpdateETagForNodeIDAndOrder []struct {
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
+			// NodeID is the nodeID argument value.
+			NodeID string
+			// Order is the order argument value.
+			Order *int
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
+		}
+		// UpdateETagForOptions holds details about calls to the UpdateETagForOptions method.
+		UpdateETagForOptions []struct {
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
+			// Option is the option argument value.
+			Option *models.CachedDimensionOption
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
+		}
 		// UpdateImportObservationsTaskState holds details about calls to the UpdateImportObservationsTaskState method.
 		UpdateImportObservationsTaskState []struct {
-			// ID is the id argument value.
-			ID string
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
 			// State is the state argument value.
 			State string
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// UpdateInstance holds details about calls to the UpdateInstance method.
 		UpdateInstance []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// ID is the ID argument value.
-			ID string
-			// Instance is the instance argument value.
-			Instance *models.Instance
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
+			// UpdatedInstance is the updatedInstance argument value.
+			UpdatedInstance *models.Instance
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// UpdateObservationInserted holds details about calls to the UpdateObservationInserted method.
 		UpdateObservationInserted []struct {
-			// ID is the ID argument value.
-			ID string
+			// CurrentInstance is the currentInstance argument value.
+			CurrentInstance *models.Instance
 			// ObservationInserted is the observationInserted argument value.
 			ObservationInserted int64
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// UpdateVersion holds details about calls to the UpdateVersion method.
 		UpdateVersion []struct {
@@ -550,42 +663,41 @@ type MongoDBMock struct {
 			VersionDoc *models.Version
 		}
 	}
-	lockAddDimensionToInstance            sync.RWMutex
-	lockAddEventToInstance                sync.RWMutex
-	lockAddInstance                       sync.RWMutex
-	lockCheckDatasetExists                sync.RWMutex
-	lockCheckEditionExists                sync.RWMutex
-	lockChecker                           sync.RWMutex
-	lockClose                             sync.RWMutex
-	lockDeleteDataset                     sync.RWMutex
-	lockDeleteEdition                     sync.RWMutex
-	lockGetDataset                        sync.RWMutex
-	lockGetDatasets                       sync.RWMutex
-	lockGetDimensionOptions               sync.RWMutex
-	lockGetDimensionOptionsFromIDs        sync.RWMutex
-	lockGetDimensions                     sync.RWMutex
-	lockGetDimensionsFromInstance         sync.RWMutex
-	lockGetEdition                        sync.RWMutex
-	lockGetEditions                       sync.RWMutex
-	lockGetInstance                       sync.RWMutex
-	lockGetInstances                      sync.RWMutex
-	lockGetNextVersion                    sync.RWMutex
-	lockGetUniqueDimensionAndOptions      sync.RWMutex
-	lockGetVersion                        sync.RWMutex
-	lockGetVersions                       sync.RWMutex
-	lockUpdateBuildHierarchyTaskState     sync.RWMutex
-	lockUpdateBuildSearchTaskState        sync.RWMutex
-	lockUpdateDataset                     sync.RWMutex
-	lockUpdateDatasetWithAssociation      sync.RWMutex
-	lockUpdateDimensionNodeIDAndOrder     sync.RWMutex
-	lockUpdateImportObservationsTaskState sync.RWMutex
-	lockUpdateInstance                    sync.RWMutex
-	lockUpdateObservationInserted         sync.RWMutex
-	lockUpdateVersion                     sync.RWMutex
-	lockUpsertContact                     sync.RWMutex
-	lockUpsertDataset                     sync.RWMutex
-	lockUpsertEdition                     sync.RWMutex
-	lockUpsertVersion                     sync.RWMutex
+}
+
+// AcquireInstanceLock calls AcquireInstanceLockFunc.
+func (mock *MongoDBMock) AcquireInstanceLock(ctx context.Context, instanceID string) (string, error) {
+	if mock.AcquireInstanceLockFunc == nil {
+		panic("MongoDBMock.AcquireInstanceLockFunc: method is nil but MongoDB.AcquireInstanceLock was just called")
+	}
+	callInfo := struct {
+		Ctx        context.Context
+		InstanceID string
+	}{
+		Ctx:        ctx,
+		InstanceID: instanceID,
+	}
+	lockMongoDBMockAcquireInstanceLock.Lock()
+	mock.calls.AcquireInstanceLock = append(mock.calls.AcquireInstanceLock, callInfo)
+	lockMongoDBMockAcquireInstanceLock.Unlock()
+	return mock.AcquireInstanceLockFunc(ctx, instanceID)
+}
+
+// AcquireInstanceLockCalls gets all the calls that were made to AcquireInstanceLock.
+// Check the length with:
+//     len(mockedMongoDB.AcquireInstanceLockCalls())
+func (mock *MongoDBMock) AcquireInstanceLockCalls() []struct {
+	Ctx        context.Context
+	InstanceID string
+} {
+	var calls []struct {
+		Ctx        context.Context
+		InstanceID string
+	}
+	lockMongoDBMockAcquireInstanceLock.RLock()
+	calls = mock.calls.AcquireInstanceLock
+	lockMongoDBMockAcquireInstanceLock.RUnlock()
+	return calls
 }
 
 // AddDimensionToInstance calls AddDimensionToInstanceFunc.
@@ -598,9 +710,9 @@ func (mock *MongoDBMock) AddDimensionToInstance(dimension *models.CachedDimensio
 	}{
 		Dimension: dimension,
 	}
-	mock.lockAddDimensionToInstance.Lock()
+	lockMongoDBMockAddDimensionToInstance.Lock()
 	mock.calls.AddDimensionToInstance = append(mock.calls.AddDimensionToInstance, callInfo)
-	mock.lockAddDimensionToInstance.Unlock()
+	lockMongoDBMockAddDimensionToInstance.Unlock()
 	return mock.AddDimensionToInstanceFunc(dimension)
 }
 
@@ -613,44 +725,48 @@ func (mock *MongoDBMock) AddDimensionToInstanceCalls() []struct {
 	var calls []struct {
 		Dimension *models.CachedDimensionOption
 	}
-	mock.lockAddDimensionToInstance.RLock()
+	lockMongoDBMockAddDimensionToInstance.RLock()
 	calls = mock.calls.AddDimensionToInstance
-	mock.lockAddDimensionToInstance.RUnlock()
+	lockMongoDBMockAddDimensionToInstance.RUnlock()
 	return calls
 }
 
 // AddEventToInstance calls AddEventToInstanceFunc.
-func (mock *MongoDBMock) AddEventToInstance(instanceID string, event *models.Event) error {
+func (mock *MongoDBMock) AddEventToInstance(currentInstance *models.Instance, event *models.Event, eTagSelector string) (string, error) {
 	if mock.AddEventToInstanceFunc == nil {
 		panic("MongoDBMock.AddEventToInstanceFunc: method is nil but MongoDB.AddEventToInstance was just called")
 	}
 	callInfo := struct {
-		InstanceID string
-		Event      *models.Event
+		CurrentInstance *models.Instance
+		Event           *models.Event
+		ETagSelector    string
 	}{
-		InstanceID: instanceID,
-		Event:      event,
+		CurrentInstance: currentInstance,
+		Event:           event,
+		ETagSelector:    eTagSelector,
 	}
-	mock.lockAddEventToInstance.Lock()
+	lockMongoDBMockAddEventToInstance.Lock()
 	mock.calls.AddEventToInstance = append(mock.calls.AddEventToInstance, callInfo)
-	mock.lockAddEventToInstance.Unlock()
-	return mock.AddEventToInstanceFunc(instanceID, event)
+	lockMongoDBMockAddEventToInstance.Unlock()
+	return mock.AddEventToInstanceFunc(currentInstance, event, eTagSelector)
 }
 
 // AddEventToInstanceCalls gets all the calls that were made to AddEventToInstance.
 // Check the length with:
 //     len(mockedMongoDB.AddEventToInstanceCalls())
 func (mock *MongoDBMock) AddEventToInstanceCalls() []struct {
-	InstanceID string
-	Event      *models.Event
+	CurrentInstance *models.Instance
+	Event           *models.Event
+	ETagSelector    string
 } {
 	var calls []struct {
-		InstanceID string
-		Event      *models.Event
+		CurrentInstance *models.Instance
+		Event           *models.Event
+		ETagSelector    string
 	}
-	mock.lockAddEventToInstance.RLock()
+	lockMongoDBMockAddEventToInstance.RLock()
 	calls = mock.calls.AddEventToInstance
-	mock.lockAddEventToInstance.RUnlock()
+	lockMongoDBMockAddEventToInstance.RUnlock()
 	return calls
 }
 
@@ -664,9 +780,9 @@ func (mock *MongoDBMock) AddInstance(instance *models.Instance) (*models.Instanc
 	}{
 		Instance: instance,
 	}
-	mock.lockAddInstance.Lock()
+	lockMongoDBMockAddInstance.Lock()
 	mock.calls.AddInstance = append(mock.calls.AddInstance, callInfo)
-	mock.lockAddInstance.Unlock()
+	lockMongoDBMockAddInstance.Unlock()
 	return mock.AddInstanceFunc(instance)
 }
 
@@ -679,9 +795,9 @@ func (mock *MongoDBMock) AddInstanceCalls() []struct {
 	var calls []struct {
 		Instance *models.Instance
 	}
-	mock.lockAddInstance.RLock()
+	lockMongoDBMockAddInstance.RLock()
 	calls = mock.calls.AddInstance
-	mock.lockAddInstance.RUnlock()
+	lockMongoDBMockAddInstance.RUnlock()
 	return calls
 }
 
@@ -697,9 +813,9 @@ func (mock *MongoDBMock) CheckDatasetExists(ID string, state string) error {
 		ID:    ID,
 		State: state,
 	}
-	mock.lockCheckDatasetExists.Lock()
+	lockMongoDBMockCheckDatasetExists.Lock()
 	mock.calls.CheckDatasetExists = append(mock.calls.CheckDatasetExists, callInfo)
-	mock.lockCheckDatasetExists.Unlock()
+	lockMongoDBMockCheckDatasetExists.Unlock()
 	return mock.CheckDatasetExistsFunc(ID, state)
 }
 
@@ -714,9 +830,9 @@ func (mock *MongoDBMock) CheckDatasetExistsCalls() []struct {
 		ID    string
 		State string
 	}
-	mock.lockCheckDatasetExists.RLock()
+	lockMongoDBMockCheckDatasetExists.RLock()
 	calls = mock.calls.CheckDatasetExists
-	mock.lockCheckDatasetExists.RUnlock()
+	lockMongoDBMockCheckDatasetExists.RUnlock()
 	return calls
 }
 
@@ -734,9 +850,9 @@ func (mock *MongoDBMock) CheckEditionExists(ID string, editionID string, state s
 		EditionID: editionID,
 		State:     state,
 	}
-	mock.lockCheckEditionExists.Lock()
+	lockMongoDBMockCheckEditionExists.Lock()
 	mock.calls.CheckEditionExists = append(mock.calls.CheckEditionExists, callInfo)
-	mock.lockCheckEditionExists.Unlock()
+	lockMongoDBMockCheckEditionExists.Unlock()
 	return mock.CheckEditionExistsFunc(ID, editionID, state)
 }
 
@@ -753,9 +869,9 @@ func (mock *MongoDBMock) CheckEditionExistsCalls() []struct {
 		EditionID string
 		State     string
 	}
-	mock.lockCheckEditionExists.RLock()
+	lockMongoDBMockCheckEditionExists.RLock()
 	calls = mock.calls.CheckEditionExists
-	mock.lockCheckEditionExists.RUnlock()
+	lockMongoDBMockCheckEditionExists.RUnlock()
 	return calls
 }
 
@@ -771,9 +887,9 @@ func (mock *MongoDBMock) Checker(in1 context.Context, in2 *healthcheck.CheckStat
 		In1: in1,
 		In2: in2,
 	}
-	mock.lockChecker.Lock()
+	lockMongoDBMockChecker.Lock()
 	mock.calls.Checker = append(mock.calls.Checker, callInfo)
-	mock.lockChecker.Unlock()
+	lockMongoDBMockChecker.Unlock()
 	return mock.CheckerFunc(in1, in2)
 }
 
@@ -788,9 +904,9 @@ func (mock *MongoDBMock) CheckerCalls() []struct {
 		In1 context.Context
 		In2 *healthcheck.CheckState
 	}
-	mock.lockChecker.RLock()
+	lockMongoDBMockChecker.RLock()
 	calls = mock.calls.Checker
-	mock.lockChecker.RUnlock()
+	lockMongoDBMockChecker.RUnlock()
 	return calls
 }
 
@@ -804,9 +920,9 @@ func (mock *MongoDBMock) Close(in1 context.Context) error {
 	}{
 		In1: in1,
 	}
-	mock.lockClose.Lock()
+	lockMongoDBMockClose.Lock()
 	mock.calls.Close = append(mock.calls.Close, callInfo)
-	mock.lockClose.Unlock()
+	lockMongoDBMockClose.Unlock()
 	return mock.CloseFunc(in1)
 }
 
@@ -819,9 +935,9 @@ func (mock *MongoDBMock) CloseCalls() []struct {
 	var calls []struct {
 		In1 context.Context
 	}
-	mock.lockClose.RLock()
+	lockMongoDBMockClose.RLock()
 	calls = mock.calls.Close
-	mock.lockClose.RUnlock()
+	lockMongoDBMockClose.RUnlock()
 	return calls
 }
 
@@ -835,9 +951,9 @@ func (mock *MongoDBMock) DeleteDataset(ID string) error {
 	}{
 		ID: ID,
 	}
-	mock.lockDeleteDataset.Lock()
+	lockMongoDBMockDeleteDataset.Lock()
 	mock.calls.DeleteDataset = append(mock.calls.DeleteDataset, callInfo)
-	mock.lockDeleteDataset.Unlock()
+	lockMongoDBMockDeleteDataset.Unlock()
 	return mock.DeleteDatasetFunc(ID)
 }
 
@@ -850,9 +966,9 @@ func (mock *MongoDBMock) DeleteDatasetCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	mock.lockDeleteDataset.RLock()
+	lockMongoDBMockDeleteDataset.RLock()
 	calls = mock.calls.DeleteDataset
-	mock.lockDeleteDataset.RUnlock()
+	lockMongoDBMockDeleteDataset.RUnlock()
 	return calls
 }
 
@@ -866,9 +982,9 @@ func (mock *MongoDBMock) DeleteEdition(ID string) error {
 	}{
 		ID: ID,
 	}
-	mock.lockDeleteEdition.Lock()
+	lockMongoDBMockDeleteEdition.Lock()
 	mock.calls.DeleteEdition = append(mock.calls.DeleteEdition, callInfo)
-	mock.lockDeleteEdition.Unlock()
+	lockMongoDBMockDeleteEdition.Unlock()
 	return mock.DeleteEditionFunc(ID)
 }
 
@@ -881,9 +997,9 @@ func (mock *MongoDBMock) DeleteEditionCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	mock.lockDeleteEdition.RLock()
+	lockMongoDBMockDeleteEdition.RLock()
 	calls = mock.calls.DeleteEdition
-	mock.lockDeleteEdition.RUnlock()
+	lockMongoDBMockDeleteEdition.RUnlock()
 	return calls
 }
 
@@ -897,9 +1013,9 @@ func (mock *MongoDBMock) GetDataset(ID string) (*models.DatasetUpdate, error) {
 	}{
 		ID: ID,
 	}
-	mock.lockGetDataset.Lock()
+	lockMongoDBMockGetDataset.Lock()
 	mock.calls.GetDataset = append(mock.calls.GetDataset, callInfo)
-	mock.lockGetDataset.Unlock()
+	lockMongoDBMockGetDataset.Unlock()
 	return mock.GetDatasetFunc(ID)
 }
 
@@ -912,9 +1028,9 @@ func (mock *MongoDBMock) GetDatasetCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	mock.lockGetDataset.RLock()
+	lockMongoDBMockGetDataset.RLock()
 	calls = mock.calls.GetDataset
-	mock.lockGetDataset.RUnlock()
+	lockMongoDBMockGetDataset.RUnlock()
 	return calls
 }
 
@@ -934,9 +1050,9 @@ func (mock *MongoDBMock) GetDatasets(ctx context.Context, offset int, limit int,
 		Limit:      limit,
 		Authorised: authorised,
 	}
-	mock.lockGetDatasets.Lock()
+	lockMongoDBMockGetDatasets.Lock()
 	mock.calls.GetDatasets = append(mock.calls.GetDatasets, callInfo)
-	mock.lockGetDatasets.Unlock()
+	lockMongoDBMockGetDatasets.Unlock()
 	return mock.GetDatasetsFunc(ctx, offset, limit, authorised)
 }
 
@@ -955,9 +1071,9 @@ func (mock *MongoDBMock) GetDatasetsCalls() []struct {
 		Limit      int
 		Authorised bool
 	}
-	mock.lockGetDatasets.RLock()
+	lockMongoDBMockGetDatasets.RLock()
 	calls = mock.calls.GetDatasets
-	mock.lockGetDatasets.RUnlock()
+	lockMongoDBMockGetDatasets.RUnlock()
 	return calls
 }
 
@@ -979,9 +1095,9 @@ func (mock *MongoDBMock) GetDimensionOptions(ctx context.Context, version *model
 		Offset:    offset,
 		Limit:     limit,
 	}
-	mock.lockGetDimensionOptions.Lock()
+	lockMongoDBMockGetDimensionOptions.Lock()
 	mock.calls.GetDimensionOptions = append(mock.calls.GetDimensionOptions, callInfo)
-	mock.lockGetDimensionOptions.Unlock()
+	lockMongoDBMockGetDimensionOptions.Unlock()
 	return mock.GetDimensionOptionsFunc(ctx, version, dimension, offset, limit)
 }
 
@@ -1002,9 +1118,9 @@ func (mock *MongoDBMock) GetDimensionOptionsCalls() []struct {
 		Offset    int
 		Limit     int
 	}
-	mock.lockGetDimensionOptions.RLock()
+	lockMongoDBMockGetDimensionOptions.RLock()
 	calls = mock.calls.GetDimensionOptions
-	mock.lockGetDimensionOptions.RUnlock()
+	lockMongoDBMockGetDimensionOptions.RUnlock()
 	return calls
 }
 
@@ -1022,9 +1138,9 @@ func (mock *MongoDBMock) GetDimensionOptionsFromIDs(version *models.Version, dim
 		Dimension: dimension,
 		Ids:       ids,
 	}
-	mock.lockGetDimensionOptionsFromIDs.Lock()
+	lockMongoDBMockGetDimensionOptionsFromIDs.Lock()
 	mock.calls.GetDimensionOptionsFromIDs = append(mock.calls.GetDimensionOptionsFromIDs, callInfo)
-	mock.lockGetDimensionOptionsFromIDs.Unlock()
+	lockMongoDBMockGetDimensionOptionsFromIDs.Unlock()
 	return mock.GetDimensionOptionsFromIDsFunc(version, dimension, ids)
 }
 
@@ -1041,9 +1157,9 @@ func (mock *MongoDBMock) GetDimensionOptionsFromIDsCalls() []struct {
 		Dimension string
 		Ids       []string
 	}
-	mock.lockGetDimensionOptionsFromIDs.RLock()
+	lockMongoDBMockGetDimensionOptionsFromIDs.RLock()
 	calls = mock.calls.GetDimensionOptionsFromIDs
-	mock.lockGetDimensionOptionsFromIDs.RUnlock()
+	lockMongoDBMockGetDimensionOptionsFromIDs.RUnlock()
 	return calls
 }
 
@@ -1059,9 +1175,9 @@ func (mock *MongoDBMock) GetDimensions(datasetID string, versionID string) ([]bs
 		DatasetID: datasetID,
 		VersionID: versionID,
 	}
-	mock.lockGetDimensions.Lock()
+	lockMongoDBMockGetDimensions.Lock()
 	mock.calls.GetDimensions = append(mock.calls.GetDimensions, callInfo)
-	mock.lockGetDimensions.Unlock()
+	lockMongoDBMockGetDimensions.Unlock()
 	return mock.GetDimensionsFunc(datasetID, versionID)
 }
 
@@ -1076,9 +1192,9 @@ func (mock *MongoDBMock) GetDimensionsCalls() []struct {
 		DatasetID string
 		VersionID string
 	}
-	mock.lockGetDimensions.RLock()
+	lockMongoDBMockGetDimensions.RLock()
 	calls = mock.calls.GetDimensions
-	mock.lockGetDimensions.RUnlock()
+	lockMongoDBMockGetDimensions.RUnlock()
 	return calls
 }
 
@@ -1098,9 +1214,9 @@ func (mock *MongoDBMock) GetDimensionsFromInstance(ctx context.Context, ID strin
 		Offset: offset,
 		Limit:  limit,
 	}
-	mock.lockGetDimensionsFromInstance.Lock()
+	lockMongoDBMockGetDimensionsFromInstance.Lock()
 	mock.calls.GetDimensionsFromInstance = append(mock.calls.GetDimensionsFromInstance, callInfo)
-	mock.lockGetDimensionsFromInstance.Unlock()
+	lockMongoDBMockGetDimensionsFromInstance.Unlock()
 	return mock.GetDimensionsFromInstanceFunc(ctx, ID, offset, limit)
 }
 
@@ -1119,9 +1235,9 @@ func (mock *MongoDBMock) GetDimensionsFromInstanceCalls() []struct {
 		Offset int
 		Limit  int
 	}
-	mock.lockGetDimensionsFromInstance.RLock()
+	lockMongoDBMockGetDimensionsFromInstance.RLock()
 	calls = mock.calls.GetDimensionsFromInstance
-	mock.lockGetDimensionsFromInstance.RUnlock()
+	lockMongoDBMockGetDimensionsFromInstance.RUnlock()
 	return calls
 }
 
@@ -1139,9 +1255,9 @@ func (mock *MongoDBMock) GetEdition(ID string, editionID string, state string) (
 		EditionID: editionID,
 		State:     state,
 	}
-	mock.lockGetEdition.Lock()
+	lockMongoDBMockGetEdition.Lock()
 	mock.calls.GetEdition = append(mock.calls.GetEdition, callInfo)
-	mock.lockGetEdition.Unlock()
+	lockMongoDBMockGetEdition.Unlock()
 	return mock.GetEditionFunc(ID, editionID, state)
 }
 
@@ -1158,9 +1274,9 @@ func (mock *MongoDBMock) GetEditionCalls() []struct {
 		EditionID string
 		State     string
 	}
-	mock.lockGetEdition.RLock()
+	lockMongoDBMockGetEdition.RLock()
 	calls = mock.calls.GetEdition
-	mock.lockGetEdition.RUnlock()
+	lockMongoDBMockGetEdition.RUnlock()
 	return calls
 }
 
@@ -1184,9 +1300,9 @@ func (mock *MongoDBMock) GetEditions(ctx context.Context, ID string, state strin
 		Limit:      limit,
 		Authorised: authorised,
 	}
-	mock.lockGetEditions.Lock()
+	lockMongoDBMockGetEditions.Lock()
 	mock.calls.GetEditions = append(mock.calls.GetEditions, callInfo)
-	mock.lockGetEditions.Unlock()
+	lockMongoDBMockGetEditions.Unlock()
 	return mock.GetEditionsFunc(ctx, ID, state, offset, limit, authorised)
 }
 
@@ -1209,40 +1325,44 @@ func (mock *MongoDBMock) GetEditionsCalls() []struct {
 		Limit      int
 		Authorised bool
 	}
-	mock.lockGetEditions.RLock()
+	lockMongoDBMockGetEditions.RLock()
 	calls = mock.calls.GetEditions
-	mock.lockGetEditions.RUnlock()
+	lockMongoDBMockGetEditions.RUnlock()
 	return calls
 }
 
 // GetInstance calls GetInstanceFunc.
-func (mock *MongoDBMock) GetInstance(ID string) (*models.Instance, error) {
+func (mock *MongoDBMock) GetInstance(ID string, eTagSelector string) (*models.Instance, error) {
 	if mock.GetInstanceFunc == nil {
 		panic("MongoDBMock.GetInstanceFunc: method is nil but MongoDB.GetInstance was just called")
 	}
 	callInfo := struct {
-		ID string
+		ID           string
+		ETagSelector string
 	}{
-		ID: ID,
+		ID:           ID,
+		ETagSelector: eTagSelector,
 	}
-	mock.lockGetInstance.Lock()
+	lockMongoDBMockGetInstance.Lock()
 	mock.calls.GetInstance = append(mock.calls.GetInstance, callInfo)
-	mock.lockGetInstance.Unlock()
-	return mock.GetInstanceFunc(ID)
+	lockMongoDBMockGetInstance.Unlock()
+	return mock.GetInstanceFunc(ID, eTagSelector)
 }
 
 // GetInstanceCalls gets all the calls that were made to GetInstance.
 // Check the length with:
 //     len(mockedMongoDB.GetInstanceCalls())
 func (mock *MongoDBMock) GetInstanceCalls() []struct {
-	ID string
+	ID           string
+	ETagSelector string
 } {
 	var calls []struct {
-		ID string
+		ID           string
+		ETagSelector string
 	}
-	mock.lockGetInstance.RLock()
+	lockMongoDBMockGetInstance.RLock()
 	calls = mock.calls.GetInstance
-	mock.lockGetInstance.RUnlock()
+	lockMongoDBMockGetInstance.RUnlock()
 	return calls
 }
 
@@ -1264,9 +1384,9 @@ func (mock *MongoDBMock) GetInstances(ctx context.Context, states []string, data
 		Offset:   offset,
 		Limit:    limit,
 	}
-	mock.lockGetInstances.Lock()
+	lockMongoDBMockGetInstances.Lock()
 	mock.calls.GetInstances = append(mock.calls.GetInstances, callInfo)
-	mock.lockGetInstances.Unlock()
+	lockMongoDBMockGetInstances.Unlock()
 	return mock.GetInstancesFunc(ctx, states, datasets, offset, limit)
 }
 
@@ -1287,9 +1407,9 @@ func (mock *MongoDBMock) GetInstancesCalls() []struct {
 		Offset   int
 		Limit    int
 	}
-	mock.lockGetInstances.RLock()
+	lockMongoDBMockGetInstances.RLock()
 	calls = mock.calls.GetInstances
-	mock.lockGetInstances.RUnlock()
+	lockMongoDBMockGetInstances.RUnlock()
 	return calls
 }
 
@@ -1305,9 +1425,9 @@ func (mock *MongoDBMock) GetNextVersion(datasetID string, editionID string) (int
 		DatasetID: datasetID,
 		EditionID: editionID,
 	}
-	mock.lockGetNextVersion.Lock()
+	lockMongoDBMockGetNextVersion.Lock()
 	mock.calls.GetNextVersion = append(mock.calls.GetNextVersion, callInfo)
-	mock.lockGetNextVersion.Unlock()
+	lockMongoDBMockGetNextVersion.Unlock()
 	return mock.GetNextVersionFunc(datasetID, editionID)
 }
 
@@ -1322,9 +1442,9 @@ func (mock *MongoDBMock) GetNextVersionCalls() []struct {
 		DatasetID string
 		EditionID string
 	}
-	mock.lockGetNextVersion.RLock()
+	lockMongoDBMockGetNextVersion.RLock()
 	calls = mock.calls.GetNextVersion
-	mock.lockGetNextVersion.RUnlock()
+	lockMongoDBMockGetNextVersion.RUnlock()
 	return calls
 }
 
@@ -1346,9 +1466,9 @@ func (mock *MongoDBMock) GetUniqueDimensionAndOptions(ctx context.Context, ID st
 		Offset:    offset,
 		Limit:     limit,
 	}
-	mock.lockGetUniqueDimensionAndOptions.Lock()
+	lockMongoDBMockGetUniqueDimensionAndOptions.Lock()
 	mock.calls.GetUniqueDimensionAndOptions = append(mock.calls.GetUniqueDimensionAndOptions, callInfo)
-	mock.lockGetUniqueDimensionAndOptions.Unlock()
+	lockMongoDBMockGetUniqueDimensionAndOptions.Unlock()
 	return mock.GetUniqueDimensionAndOptionsFunc(ctx, ID, dimension, offset, limit)
 }
 
@@ -1369,9 +1489,9 @@ func (mock *MongoDBMock) GetUniqueDimensionAndOptionsCalls() []struct {
 		Offset    int
 		Limit     int
 	}
-	mock.lockGetUniqueDimensionAndOptions.RLock()
+	lockMongoDBMockGetUniqueDimensionAndOptions.RLock()
 	calls = mock.calls.GetUniqueDimensionAndOptions
-	mock.lockGetUniqueDimensionAndOptions.RUnlock()
+	lockMongoDBMockGetUniqueDimensionAndOptions.RUnlock()
 	return calls
 }
 
@@ -1391,9 +1511,9 @@ func (mock *MongoDBMock) GetVersion(datasetID string, editionID string, version 
 		Version:   version,
 		State:     state,
 	}
-	mock.lockGetVersion.Lock()
+	lockMongoDBMockGetVersion.Lock()
 	mock.calls.GetVersion = append(mock.calls.GetVersion, callInfo)
-	mock.lockGetVersion.Unlock()
+	lockMongoDBMockGetVersion.Unlock()
 	return mock.GetVersionFunc(datasetID, editionID, version, state)
 }
 
@@ -1412,9 +1532,9 @@ func (mock *MongoDBMock) GetVersionCalls() []struct {
 		Version   int
 		State     string
 	}
-	mock.lockGetVersion.RLock()
+	lockMongoDBMockGetVersion.RLock()
 	calls = mock.calls.GetVersion
-	mock.lockGetVersion.RUnlock()
+	lockMongoDBMockGetVersion.RUnlock()
 	return calls
 }
 
@@ -1438,9 +1558,9 @@ func (mock *MongoDBMock) GetVersions(ctx context.Context, datasetID string, edit
 		Offset:    offset,
 		Limit:     limit,
 	}
-	mock.lockGetVersions.Lock()
+	lockMongoDBMockGetVersions.Lock()
 	mock.calls.GetVersions = append(mock.calls.GetVersions, callInfo)
-	mock.lockGetVersions.Unlock()
+	lockMongoDBMockGetVersions.Unlock()
 	return mock.GetVersionsFunc(ctx, datasetID, editionID, state, offset, limit)
 }
 
@@ -1463,87 +1583,126 @@ func (mock *MongoDBMock) GetVersionsCalls() []struct {
 		Offset    int
 		Limit     int
 	}
-	mock.lockGetVersions.RLock()
+	lockMongoDBMockGetVersions.RLock()
 	calls = mock.calls.GetVersions
-	mock.lockGetVersions.RUnlock()
+	lockMongoDBMockGetVersions.RUnlock()
+	return calls
+}
+
+// UnlockInstance calls UnlockInstanceFunc.
+func (mock *MongoDBMock) UnlockInstance(lockID string) error {
+	if mock.UnlockInstanceFunc == nil {
+		panic("MongoDBMock.UnlockInstanceFunc: method is nil but MongoDB.UnlockInstance was just called")
+	}
+	callInfo := struct {
+		LockID string
+	}{
+		LockID: lockID,
+	}
+	lockMongoDBMockUnlockInstance.Lock()
+	mock.calls.UnlockInstance = append(mock.calls.UnlockInstance, callInfo)
+	lockMongoDBMockUnlockInstance.Unlock()
+	return mock.UnlockInstanceFunc(lockID)
+}
+
+// UnlockInstanceCalls gets all the calls that were made to UnlockInstance.
+// Check the length with:
+//     len(mockedMongoDB.UnlockInstanceCalls())
+func (mock *MongoDBMock) UnlockInstanceCalls() []struct {
+	LockID string
+} {
+	var calls []struct {
+		LockID string
+	}
+	lockMongoDBMockUnlockInstance.RLock()
+	calls = mock.calls.UnlockInstance
+	lockMongoDBMockUnlockInstance.RUnlock()
 	return calls
 }
 
 // UpdateBuildHierarchyTaskState calls UpdateBuildHierarchyTaskStateFunc.
-func (mock *MongoDBMock) UpdateBuildHierarchyTaskState(id string, dimension string, state string) error {
+func (mock *MongoDBMock) UpdateBuildHierarchyTaskState(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
 	if mock.UpdateBuildHierarchyTaskStateFunc == nil {
 		panic("MongoDBMock.UpdateBuildHierarchyTaskStateFunc: method is nil but MongoDB.UpdateBuildHierarchyTaskState was just called")
 	}
 	callInfo := struct {
-		ID        string
-		Dimension string
-		State     string
+		CurrentInstance *models.Instance
+		Dimension       string
+		State           string
+		ETagSelector    string
 	}{
-		ID:        id,
-		Dimension: dimension,
-		State:     state,
+		CurrentInstance: currentInstance,
+		Dimension:       dimension,
+		State:           state,
+		ETagSelector:    eTagSelector,
 	}
-	mock.lockUpdateBuildHierarchyTaskState.Lock()
+	lockMongoDBMockUpdateBuildHierarchyTaskState.Lock()
 	mock.calls.UpdateBuildHierarchyTaskState = append(mock.calls.UpdateBuildHierarchyTaskState, callInfo)
-	mock.lockUpdateBuildHierarchyTaskState.Unlock()
-	return mock.UpdateBuildHierarchyTaskStateFunc(id, dimension, state)
+	lockMongoDBMockUpdateBuildHierarchyTaskState.Unlock()
+	return mock.UpdateBuildHierarchyTaskStateFunc(currentInstance, dimension, state, eTagSelector)
 }
 
 // UpdateBuildHierarchyTaskStateCalls gets all the calls that were made to UpdateBuildHierarchyTaskState.
 // Check the length with:
 //     len(mockedMongoDB.UpdateBuildHierarchyTaskStateCalls())
 func (mock *MongoDBMock) UpdateBuildHierarchyTaskStateCalls() []struct {
-	ID        string
-	Dimension string
-	State     string
+	CurrentInstance *models.Instance
+	Dimension       string
+	State           string
+	ETagSelector    string
 } {
 	var calls []struct {
-		ID        string
-		Dimension string
-		State     string
+		CurrentInstance *models.Instance
+		Dimension       string
+		State           string
+		ETagSelector    string
 	}
-	mock.lockUpdateBuildHierarchyTaskState.RLock()
+	lockMongoDBMockUpdateBuildHierarchyTaskState.RLock()
 	calls = mock.calls.UpdateBuildHierarchyTaskState
-	mock.lockUpdateBuildHierarchyTaskState.RUnlock()
+	lockMongoDBMockUpdateBuildHierarchyTaskState.RUnlock()
 	return calls
 }
 
 // UpdateBuildSearchTaskState calls UpdateBuildSearchTaskStateFunc.
-func (mock *MongoDBMock) UpdateBuildSearchTaskState(id string, dimension string, state string) error {
+func (mock *MongoDBMock) UpdateBuildSearchTaskState(currentInstance *models.Instance, dimension string, state string, eTagSelector string) (string, error) {
 	if mock.UpdateBuildSearchTaskStateFunc == nil {
 		panic("MongoDBMock.UpdateBuildSearchTaskStateFunc: method is nil but MongoDB.UpdateBuildSearchTaskState was just called")
 	}
 	callInfo := struct {
-		ID        string
-		Dimension string
-		State     string
+		CurrentInstance *models.Instance
+		Dimension       string
+		State           string
+		ETagSelector    string
 	}{
-		ID:        id,
-		Dimension: dimension,
-		State:     state,
+		CurrentInstance: currentInstance,
+		Dimension:       dimension,
+		State:           state,
+		ETagSelector:    eTagSelector,
 	}
-	mock.lockUpdateBuildSearchTaskState.Lock()
+	lockMongoDBMockUpdateBuildSearchTaskState.Lock()
 	mock.calls.UpdateBuildSearchTaskState = append(mock.calls.UpdateBuildSearchTaskState, callInfo)
-	mock.lockUpdateBuildSearchTaskState.Unlock()
-	return mock.UpdateBuildSearchTaskStateFunc(id, dimension, state)
+	lockMongoDBMockUpdateBuildSearchTaskState.Unlock()
+	return mock.UpdateBuildSearchTaskStateFunc(currentInstance, dimension, state, eTagSelector)
 }
 
 // UpdateBuildSearchTaskStateCalls gets all the calls that were made to UpdateBuildSearchTaskState.
 // Check the length with:
 //     len(mockedMongoDB.UpdateBuildSearchTaskStateCalls())
 func (mock *MongoDBMock) UpdateBuildSearchTaskStateCalls() []struct {
-	ID        string
-	Dimension string
-	State     string
+	CurrentInstance *models.Instance
+	Dimension       string
+	State           string
+	ETagSelector    string
 } {
 	var calls []struct {
-		ID        string
-		Dimension string
-		State     string
+		CurrentInstance *models.Instance
+		Dimension       string
+		State           string
+		ETagSelector    string
 	}
-	mock.lockUpdateBuildSearchTaskState.RLock()
+	lockMongoDBMockUpdateBuildSearchTaskState.RLock()
 	calls = mock.calls.UpdateBuildSearchTaskState
-	mock.lockUpdateBuildSearchTaskState.RUnlock()
+	lockMongoDBMockUpdateBuildSearchTaskState.RUnlock()
 	return calls
 }
 
@@ -1563,9 +1722,9 @@ func (mock *MongoDBMock) UpdateDataset(ctx context.Context, ID string, dataset *
 		Dataset:      dataset,
 		CurrentState: currentState,
 	}
-	mock.lockUpdateDataset.Lock()
+	lockMongoDBMockUpdateDataset.Lock()
 	mock.calls.UpdateDataset = append(mock.calls.UpdateDataset, callInfo)
-	mock.lockUpdateDataset.Unlock()
+	lockMongoDBMockUpdateDataset.Unlock()
 	return mock.UpdateDatasetFunc(ctx, ID, dataset, currentState)
 }
 
@@ -1584,9 +1743,9 @@ func (mock *MongoDBMock) UpdateDatasetCalls() []struct {
 		Dataset      *models.Dataset
 		CurrentState string
 	}
-	mock.lockUpdateDataset.RLock()
+	lockMongoDBMockUpdateDataset.RLock()
 	calls = mock.calls.UpdateDataset
-	mock.lockUpdateDataset.RUnlock()
+	lockMongoDBMockUpdateDataset.RUnlock()
 	return calls
 }
 
@@ -1604,9 +1763,9 @@ func (mock *MongoDBMock) UpdateDatasetWithAssociation(ID string, state string, v
 		State:   state,
 		Version: version,
 	}
-	mock.lockUpdateDatasetWithAssociation.Lock()
+	lockMongoDBMockUpdateDatasetWithAssociation.Lock()
 	mock.calls.UpdateDatasetWithAssociation = append(mock.calls.UpdateDatasetWithAssociation, callInfo)
-	mock.lockUpdateDatasetWithAssociation.Unlock()
+	lockMongoDBMockUpdateDatasetWithAssociation.Unlock()
 	return mock.UpdateDatasetWithAssociationFunc(ID, state, version)
 }
 
@@ -1623,9 +1782,9 @@ func (mock *MongoDBMock) UpdateDatasetWithAssociationCalls() []struct {
 		State   string
 		Version *models.Version
 	}
-	mock.lockUpdateDatasetWithAssociation.RLock()
+	lockMongoDBMockUpdateDatasetWithAssociation.RLock()
 	calls = mock.calls.UpdateDatasetWithAssociation
-	mock.lockUpdateDatasetWithAssociation.RUnlock()
+	lockMongoDBMockUpdateDatasetWithAssociation.RUnlock()
 	return calls
 }
 
@@ -1639,9 +1798,9 @@ func (mock *MongoDBMock) UpdateDimensionNodeIDAndOrder(dimension *models.Dimensi
 	}{
 		Dimension: dimension,
 	}
-	mock.lockUpdateDimensionNodeIDAndOrder.Lock()
+	lockMongoDBMockUpdateDimensionNodeIDAndOrder.Lock()
 	mock.calls.UpdateDimensionNodeIDAndOrder = append(mock.calls.UpdateDimensionNodeIDAndOrder, callInfo)
-	mock.lockUpdateDimensionNodeIDAndOrder.Unlock()
+	lockMongoDBMockUpdateDimensionNodeIDAndOrder.Unlock()
 	return mock.UpdateDimensionNodeIDAndOrderFunc(dimension)
 }
 
@@ -1654,118 +1813,212 @@ func (mock *MongoDBMock) UpdateDimensionNodeIDAndOrderCalls() []struct {
 	var calls []struct {
 		Dimension *models.DimensionOption
 	}
-	mock.lockUpdateDimensionNodeIDAndOrder.RLock()
+	lockMongoDBMockUpdateDimensionNodeIDAndOrder.RLock()
 	calls = mock.calls.UpdateDimensionNodeIDAndOrder
-	mock.lockUpdateDimensionNodeIDAndOrder.RUnlock()
+	lockMongoDBMockUpdateDimensionNodeIDAndOrder.RUnlock()
+	return calls
+}
+
+// UpdateETagForNodeIDAndOrder calls UpdateETagForNodeIDAndOrderFunc.
+func (mock *MongoDBMock) UpdateETagForNodeIDAndOrder(currentInstance *models.Instance, nodeID string, order *int, eTagSelector string) (string, error) {
+	if mock.UpdateETagForNodeIDAndOrderFunc == nil {
+		panic("MongoDBMock.UpdateETagForNodeIDAndOrderFunc: method is nil but MongoDB.UpdateETagForNodeIDAndOrder was just called")
+	}
+	callInfo := struct {
+		CurrentInstance *models.Instance
+		NodeID          string
+		Order           *int
+		ETagSelector    string
+	}{
+		CurrentInstance: currentInstance,
+		NodeID:          nodeID,
+		Order:           order,
+		ETagSelector:    eTagSelector,
+	}
+	lockMongoDBMockUpdateETagForNodeIDAndOrder.Lock()
+	mock.calls.UpdateETagForNodeIDAndOrder = append(mock.calls.UpdateETagForNodeIDAndOrder, callInfo)
+	lockMongoDBMockUpdateETagForNodeIDAndOrder.Unlock()
+	return mock.UpdateETagForNodeIDAndOrderFunc(currentInstance, nodeID, order, eTagSelector)
+}
+
+// UpdateETagForNodeIDAndOrderCalls gets all the calls that were made to UpdateETagForNodeIDAndOrder.
+// Check the length with:
+//     len(mockedMongoDB.UpdateETagForNodeIDAndOrderCalls())
+func (mock *MongoDBMock) UpdateETagForNodeIDAndOrderCalls() []struct {
+	CurrentInstance *models.Instance
+	NodeID          string
+	Order           *int
+	ETagSelector    string
+} {
+	var calls []struct {
+		CurrentInstance *models.Instance
+		NodeID          string
+		Order           *int
+		ETagSelector    string
+	}
+	lockMongoDBMockUpdateETagForNodeIDAndOrder.RLock()
+	calls = mock.calls.UpdateETagForNodeIDAndOrder
+	lockMongoDBMockUpdateETagForNodeIDAndOrder.RUnlock()
+	return calls
+}
+
+// UpdateETagForOptions calls UpdateETagForOptionsFunc.
+func (mock *MongoDBMock) UpdateETagForOptions(currentInstance *models.Instance, option *models.CachedDimensionOption, eTagSelector string) (string, error) {
+	if mock.UpdateETagForOptionsFunc == nil {
+		panic("MongoDBMock.UpdateETagForOptionsFunc: method is nil but MongoDB.UpdateETagForOptions was just called")
+	}
+	callInfo := struct {
+		CurrentInstance *models.Instance
+		Option          *models.CachedDimensionOption
+		ETagSelector    string
+	}{
+		CurrentInstance: currentInstance,
+		Option:          option,
+		ETagSelector:    eTagSelector,
+	}
+	lockMongoDBMockUpdateETagForOptions.Lock()
+	mock.calls.UpdateETagForOptions = append(mock.calls.UpdateETagForOptions, callInfo)
+	lockMongoDBMockUpdateETagForOptions.Unlock()
+	return mock.UpdateETagForOptionsFunc(currentInstance, option, eTagSelector)
+}
+
+// UpdateETagForOptionsCalls gets all the calls that were made to UpdateETagForOptions.
+// Check the length with:
+//     len(mockedMongoDB.UpdateETagForOptionsCalls())
+func (mock *MongoDBMock) UpdateETagForOptionsCalls() []struct {
+	CurrentInstance *models.Instance
+	Option          *models.CachedDimensionOption
+	ETagSelector    string
+} {
+	var calls []struct {
+		CurrentInstance *models.Instance
+		Option          *models.CachedDimensionOption
+		ETagSelector    string
+	}
+	lockMongoDBMockUpdateETagForOptions.RLock()
+	calls = mock.calls.UpdateETagForOptions
+	lockMongoDBMockUpdateETagForOptions.RUnlock()
 	return calls
 }
 
 // UpdateImportObservationsTaskState calls UpdateImportObservationsTaskStateFunc.
-func (mock *MongoDBMock) UpdateImportObservationsTaskState(id string, state string) error {
+func (mock *MongoDBMock) UpdateImportObservationsTaskState(currentInstance *models.Instance, state string, eTagSelector string) (string, error) {
 	if mock.UpdateImportObservationsTaskStateFunc == nil {
 		panic("MongoDBMock.UpdateImportObservationsTaskStateFunc: method is nil but MongoDB.UpdateImportObservationsTaskState was just called")
 	}
 	callInfo := struct {
-		ID    string
-		State string
+		CurrentInstance *models.Instance
+		State           string
+		ETagSelector    string
 	}{
-		ID:    id,
-		State: state,
+		CurrentInstance: currentInstance,
+		State:           state,
+		ETagSelector:    eTagSelector,
 	}
-	mock.lockUpdateImportObservationsTaskState.Lock()
+	lockMongoDBMockUpdateImportObservationsTaskState.Lock()
 	mock.calls.UpdateImportObservationsTaskState = append(mock.calls.UpdateImportObservationsTaskState, callInfo)
-	mock.lockUpdateImportObservationsTaskState.Unlock()
-	return mock.UpdateImportObservationsTaskStateFunc(id, state)
+	lockMongoDBMockUpdateImportObservationsTaskState.Unlock()
+	return mock.UpdateImportObservationsTaskStateFunc(currentInstance, state, eTagSelector)
 }
 
 // UpdateImportObservationsTaskStateCalls gets all the calls that were made to UpdateImportObservationsTaskState.
 // Check the length with:
 //     len(mockedMongoDB.UpdateImportObservationsTaskStateCalls())
 func (mock *MongoDBMock) UpdateImportObservationsTaskStateCalls() []struct {
-	ID    string
-	State string
+	CurrentInstance *models.Instance
+	State           string
+	ETagSelector    string
 } {
 	var calls []struct {
-		ID    string
-		State string
+		CurrentInstance *models.Instance
+		State           string
+		ETagSelector    string
 	}
-	mock.lockUpdateImportObservationsTaskState.RLock()
+	lockMongoDBMockUpdateImportObservationsTaskState.RLock()
 	calls = mock.calls.UpdateImportObservationsTaskState
-	mock.lockUpdateImportObservationsTaskState.RUnlock()
+	lockMongoDBMockUpdateImportObservationsTaskState.RUnlock()
 	return calls
 }
 
 // UpdateInstance calls UpdateInstanceFunc.
-func (mock *MongoDBMock) UpdateInstance(ctx context.Context, ID string, instance *models.Instance) error {
+func (mock *MongoDBMock) UpdateInstance(ctx context.Context, currentInstance *models.Instance, updatedInstance *models.Instance, eTagSelector string) (string, error) {
 	if mock.UpdateInstanceFunc == nil {
 		panic("MongoDBMock.UpdateInstanceFunc: method is nil but MongoDB.UpdateInstance was just called")
 	}
 	callInfo := struct {
-		Ctx      context.Context
-		ID       string
-		Instance *models.Instance
+		Ctx             context.Context
+		CurrentInstance *models.Instance
+		UpdatedInstance *models.Instance
+		ETagSelector    string
 	}{
-		Ctx:      ctx,
-		ID:       ID,
-		Instance: instance,
+		Ctx:             ctx,
+		CurrentInstance: currentInstance,
+		UpdatedInstance: updatedInstance,
+		ETagSelector:    eTagSelector,
 	}
-	mock.lockUpdateInstance.Lock()
+	lockMongoDBMockUpdateInstance.Lock()
 	mock.calls.UpdateInstance = append(mock.calls.UpdateInstance, callInfo)
-	mock.lockUpdateInstance.Unlock()
-	return mock.UpdateInstanceFunc(ctx, ID, instance)
+	lockMongoDBMockUpdateInstance.Unlock()
+	return mock.UpdateInstanceFunc(ctx, currentInstance, updatedInstance, eTagSelector)
 }
 
 // UpdateInstanceCalls gets all the calls that were made to UpdateInstance.
 // Check the length with:
 //     len(mockedMongoDB.UpdateInstanceCalls())
 func (mock *MongoDBMock) UpdateInstanceCalls() []struct {
-	Ctx      context.Context
-	ID       string
-	Instance *models.Instance
+	Ctx             context.Context
+	CurrentInstance *models.Instance
+	UpdatedInstance *models.Instance
+	ETagSelector    string
 } {
 	var calls []struct {
-		Ctx      context.Context
-		ID       string
-		Instance *models.Instance
+		Ctx             context.Context
+		CurrentInstance *models.Instance
+		UpdatedInstance *models.Instance
+		ETagSelector    string
 	}
-	mock.lockUpdateInstance.RLock()
+	lockMongoDBMockUpdateInstance.RLock()
 	calls = mock.calls.UpdateInstance
-	mock.lockUpdateInstance.RUnlock()
+	lockMongoDBMockUpdateInstance.RUnlock()
 	return calls
 }
 
 // UpdateObservationInserted calls UpdateObservationInsertedFunc.
-func (mock *MongoDBMock) UpdateObservationInserted(ID string, observationInserted int64) error {
+func (mock *MongoDBMock) UpdateObservationInserted(currentInstance *models.Instance, observationInserted int64, eTagSelector string) (string, error) {
 	if mock.UpdateObservationInsertedFunc == nil {
 		panic("MongoDBMock.UpdateObservationInsertedFunc: method is nil but MongoDB.UpdateObservationInserted was just called")
 	}
 	callInfo := struct {
-		ID                  string
+		CurrentInstance     *models.Instance
 		ObservationInserted int64
+		ETagSelector        string
 	}{
-		ID:                  ID,
+		CurrentInstance:     currentInstance,
 		ObservationInserted: observationInserted,
+		ETagSelector:        eTagSelector,
 	}
-	mock.lockUpdateObservationInserted.Lock()
+	lockMongoDBMockUpdateObservationInserted.Lock()
 	mock.calls.UpdateObservationInserted = append(mock.calls.UpdateObservationInserted, callInfo)
-	mock.lockUpdateObservationInserted.Unlock()
-	return mock.UpdateObservationInsertedFunc(ID, observationInserted)
+	lockMongoDBMockUpdateObservationInserted.Unlock()
+	return mock.UpdateObservationInsertedFunc(currentInstance, observationInserted, eTagSelector)
 }
 
 // UpdateObservationInsertedCalls gets all the calls that were made to UpdateObservationInserted.
 // Check the length with:
 //     len(mockedMongoDB.UpdateObservationInsertedCalls())
 func (mock *MongoDBMock) UpdateObservationInsertedCalls() []struct {
-	ID                  string
+	CurrentInstance     *models.Instance
 	ObservationInserted int64
+	ETagSelector        string
 } {
 	var calls []struct {
-		ID                  string
+		CurrentInstance     *models.Instance
 		ObservationInserted int64
+		ETagSelector        string
 	}
-	mock.lockUpdateObservationInserted.RLock()
+	lockMongoDBMockUpdateObservationInserted.RLock()
 	calls = mock.calls.UpdateObservationInserted
-	mock.lockUpdateObservationInserted.RUnlock()
+	lockMongoDBMockUpdateObservationInserted.RUnlock()
 	return calls
 }
 
@@ -1781,9 +2034,9 @@ func (mock *MongoDBMock) UpdateVersion(ID string, version *models.Version) error
 		ID:      ID,
 		Version: version,
 	}
-	mock.lockUpdateVersion.Lock()
+	lockMongoDBMockUpdateVersion.Lock()
 	mock.calls.UpdateVersion = append(mock.calls.UpdateVersion, callInfo)
-	mock.lockUpdateVersion.Unlock()
+	lockMongoDBMockUpdateVersion.Unlock()
 	return mock.UpdateVersionFunc(ID, version)
 }
 
@@ -1798,9 +2051,9 @@ func (mock *MongoDBMock) UpdateVersionCalls() []struct {
 		ID      string
 		Version *models.Version
 	}
-	mock.lockUpdateVersion.RLock()
+	lockMongoDBMockUpdateVersion.RLock()
 	calls = mock.calls.UpdateVersion
-	mock.lockUpdateVersion.RUnlock()
+	lockMongoDBMockUpdateVersion.RUnlock()
 	return calls
 }
 
@@ -1816,9 +2069,9 @@ func (mock *MongoDBMock) UpsertContact(ID string, update interface{}) error {
 		ID:     ID,
 		Update: update,
 	}
-	mock.lockUpsertContact.Lock()
+	lockMongoDBMockUpsertContact.Lock()
 	mock.calls.UpsertContact = append(mock.calls.UpsertContact, callInfo)
-	mock.lockUpsertContact.Unlock()
+	lockMongoDBMockUpsertContact.Unlock()
 	return mock.UpsertContactFunc(ID, update)
 }
 
@@ -1833,9 +2086,9 @@ func (mock *MongoDBMock) UpsertContactCalls() []struct {
 		ID     string
 		Update interface{}
 	}
-	mock.lockUpsertContact.RLock()
+	lockMongoDBMockUpsertContact.RLock()
 	calls = mock.calls.UpsertContact
-	mock.lockUpsertContact.RUnlock()
+	lockMongoDBMockUpsertContact.RUnlock()
 	return calls
 }
 
@@ -1851,9 +2104,9 @@ func (mock *MongoDBMock) UpsertDataset(ID string, datasetDoc *models.DatasetUpda
 		ID:         ID,
 		DatasetDoc: datasetDoc,
 	}
-	mock.lockUpsertDataset.Lock()
+	lockMongoDBMockUpsertDataset.Lock()
 	mock.calls.UpsertDataset = append(mock.calls.UpsertDataset, callInfo)
-	mock.lockUpsertDataset.Unlock()
+	lockMongoDBMockUpsertDataset.Unlock()
 	return mock.UpsertDatasetFunc(ID, datasetDoc)
 }
 
@@ -1868,9 +2121,9 @@ func (mock *MongoDBMock) UpsertDatasetCalls() []struct {
 		ID         string
 		DatasetDoc *models.DatasetUpdate
 	}
-	mock.lockUpsertDataset.RLock()
+	lockMongoDBMockUpsertDataset.RLock()
 	calls = mock.calls.UpsertDataset
-	mock.lockUpsertDataset.RUnlock()
+	lockMongoDBMockUpsertDataset.RUnlock()
 	return calls
 }
 
@@ -1888,9 +2141,9 @@ func (mock *MongoDBMock) UpsertEdition(datasetID string, edition string, edition
 		Edition:    edition,
 		EditionDoc: editionDoc,
 	}
-	mock.lockUpsertEdition.Lock()
+	lockMongoDBMockUpsertEdition.Lock()
 	mock.calls.UpsertEdition = append(mock.calls.UpsertEdition, callInfo)
-	mock.lockUpsertEdition.Unlock()
+	lockMongoDBMockUpsertEdition.Unlock()
 	return mock.UpsertEditionFunc(datasetID, edition, editionDoc)
 }
 
@@ -1907,9 +2160,9 @@ func (mock *MongoDBMock) UpsertEditionCalls() []struct {
 		Edition    string
 		EditionDoc *models.EditionUpdate
 	}
-	mock.lockUpsertEdition.RLock()
+	lockMongoDBMockUpsertEdition.RLock()
 	calls = mock.calls.UpsertEdition
-	mock.lockUpsertEdition.RUnlock()
+	lockMongoDBMockUpsertEdition.RUnlock()
 	return calls
 }
 
@@ -1925,9 +2178,9 @@ func (mock *MongoDBMock) UpsertVersion(ID string, versionDoc *models.Version) er
 		ID:         ID,
 		VersionDoc: versionDoc,
 	}
-	mock.lockUpsertVersion.Lock()
+	lockMongoDBMockUpsertVersion.Lock()
 	mock.calls.UpsertVersion = append(mock.calls.UpsertVersion, callInfo)
-	mock.lockUpsertVersion.Unlock()
+	lockMongoDBMockUpsertVersion.Unlock()
 	return mock.UpsertVersionFunc(ID, versionDoc)
 }
 
@@ -1942,8 +2195,8 @@ func (mock *MongoDBMock) UpsertVersionCalls() []struct {
 		ID         string
 		VersionDoc *models.Version
 	}
-	mock.lockUpsertVersion.RLock()
+	lockMongoDBMockUpsertVersion.RLock()
 	calls = mock.calls.UpsertVersion
-	mock.lockUpsertVersion.RUnlock()
+	lockMongoDBMockUpsertVersion.RUnlock()
 	return calls
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -185,6 +185,12 @@ parameters:
     in: query
     required: false
     type: string
+  if_match:
+    name: If-Match
+    required: false
+    description: "Filter resource version, as returned by a previous ETag, to be validated; or '*' to skip the version check"
+    in: header
+    type: string
 securityDefinitions:
   FlorenceAPIKey:
     name: florence-token
@@ -601,6 +607,10 @@ paths:
           description: "Successfully created instance"
           schema:
             $ref: '#/definitions/NewInstance'
+          headers:
+            ETag:
+              type: string
+              description: "Defines a unique instance resource version"
         400:
           $ref: '#/responses/InvalidRequestError'
         401:
@@ -617,6 +627,7 @@ paths:
       description: "Get the current state of an instance, this includes all events which have happened."
       parameters:
       - $ref: '#/parameters/instance_id'
+      - $ref: '#/parameters/if_match'
       produces:
       - "application/json"
       security:
@@ -626,10 +637,16 @@ paths:
           description: "Return a single instance state"
           schema:
             $ref: '#/definitions/Instance'
+          headers:
+            ETag:
+              type: string
+              description: "Defines a unique instance resource version"
         401:
           $ref: '#/responses/UnauthorisedError'
         404:
           $ref: '#/responses/InstanceNotFound'
+        409:
+          $ref: '#/responses/ConflictError'
         500:
           $ref: '#/responses/InternalError'
     put:
@@ -640,6 +657,7 @@ paths:
       parameters:
       - $ref: '#/parameters/instance_id'
       - $ref: '#/parameters/instance'
+      - $ref: '#/parameters/if_match'
       produces:
       - "application/json"
       security:
@@ -647,6 +665,10 @@ paths:
       responses:
         200:
           description: "The instance has been updated"
+          headers:
+            ETag:
+              type: string
+              description: "Defines a unique instance resource version"
         400:
           $ref: '#/responses/InvalidRequestError'
         401:
@@ -667,6 +689,7 @@ paths:
       description: "Get all dimensions from an instance"
       parameters:
       - $ref: '#/parameters/instance_id'
+      - $ref: '#/parameters/if_match'
       produces:
       - "application/json"
       security:
@@ -678,6 +701,10 @@ paths:
             type: array
             items:
               $ref: '#/definitions/DimensionOption'
+          headers:
+            ETag:
+              type: string
+              description: "Defines a unique instance resource version"
         400:
           $ref: '#/responses/InvalidRequestError'
         401:
@@ -686,6 +713,8 @@ paths:
           $ref: '#/responses/ForbiddenError'
         404:
           $ref: '#/responses/InstanceNotFound'
+        409:
+          $ref: '#/responses/ConflictError'
         500:
           $ref: '#/responses/InternalError'
     post:
@@ -696,15 +725,22 @@ paths:
       parameters:
       - $ref: '#/parameters/instance_id'
       - $ref: '#/parameters/update_dimension_option_request'
+      - $ref: '#/parameters/if_match'
       security:
       - InternalAPIKey: []
       responses:
         201:
           description: "Dimension was created"
+          headers:
+            ETag:
+              type: string
+              description: "Defines a unique instance resource version"
         400:
           $ref: '#/responses/InvalidRequestError'
         404:
           $ref: '#/responses/InstanceNotFound'
+        409:
+          $ref: '#/responses/ConflictError'
         500:
           $ref: '#/responses/InternalError'
   /instances/{instance_id}/dimensions/{dimension}:
@@ -717,11 +753,16 @@ paths:
       - $ref: '#/parameters/instance_id'
       - $ref: '#/parameters/dimension'
       - $ref: '#/parameters/update_dimension'
+      - $ref: '#/parameters/if_match'
       security:
       - InternalAPIKey: []
       responses:
         200:
           description: "The instance has been updated"
+          headers:
+            ETag:
+              type: string
+              description: "Defines a unique instance resource version"
         400:
           $ref: '#/responses/InvalidRequestError'
         401:
@@ -743,6 +784,7 @@ paths:
       parameters:
       - $ref: '#/parameters/instance_id'
       - $ref: '#/parameters/dimension'
+      - $ref: '#/parameters/if_match'
       produces:
       - "application/json"
       security:
@@ -761,6 +803,10 @@ paths:
                 type: array
                 items:
                   type: string
+          headers:
+            ETag:
+              type: string
+              description: "Defines a unique instance resource version"
         400:
           $ref: '#/responses/InvalidRequestError'
         401:
@@ -769,6 +815,8 @@ paths:
           $ref: '#/responses/ForbiddenError'
         404:
           description: "dimension does not match any dimensions within the instance"
+        409:
+          $ref: '#/responses/ConflictError'
         500:
           $ref: '#/responses/InternalError'
   /instances/{instance_id}/events:
@@ -783,17 +831,24 @@ paths:
       parameters:
       - $ref: '#/parameters/instance_id'
       - $ref: '#/parameters/event'
+      - $ref: '#/parameters/if_match'
       security:
       - InternalAPIKey: []
       responses:
         201:
           description: "The event was added to the instance"
+          headers:
+            ETag:
+              type: string
+              description: "Defines a unique instance resource version"
         400:
           $ref: '#/responses/InvalidRequestError'
         401:
           $ref: '#/responses/UnauthorisedError'
         404:
           description: "InstanceId does not match any instances"
+        409:
+          $ref: '#/responses/ConflictError'
         500:
           $ref: '#/responses/InternalError'
   /instances/{instance_id}/inserted_observations/{inserted_observations}:
@@ -805,17 +860,24 @@ paths:
       parameters:
       - $ref: '#/parameters/instance_id'
       - $ref: '#/parameters/inserted_observations'
+      - $ref: '#/parameters/if_match'
       security:
       - InternalAPIKey: []
       responses:
         200:
           description: "Added value to inserted observation"
+          headers:
+            ETag:
+              type: string
+              description: "Defines a unique instance resource version"
         400:
           $ref: '#/responses/InvalidRequestError'
         401:
           $ref: '#/responses/UnauthorisedError'
         404:
           description: "InstanceId does not match any instances"
+        409:
+          $ref: '#/responses/ConflictError'
         500:
           $ref: '#/responses/InternalError'
   /instances/{instance_id}/import_tasks:
@@ -827,17 +889,24 @@ paths:
       parameters:
       - $ref: '#/parameters/instance_id'
       - $ref: '#/parameters/import_tasks'
+      - $ref: '#/parameters/if_match'
       security:
       - InternalAPIKey: []
       responses:
         200:
           description: "Updated the state of the import task"
+          headers:
+            ETag:
+              type: string
+              description: "Defines a unique instance resource version"
         400:
           $ref: '#/responses/InvalidRequestError'
         401:
           $ref: '#/responses/UnauthorisedError'
         404:
           description: "InstanceId does not match any instances"
+        409:
+          $ref: '#/responses/ConflictError'
         500:
           $ref: '#/responses/InternalError'
   /instances/{instance_id}/dimensions/{dimension}/options/{option}:
@@ -852,6 +921,7 @@ paths:
       - $ref: '#/parameters/dimension'
       - $ref: '#/parameters/option'
       - $ref: '#/parameters/patch_options'
+      - $ref: '#/parameters/if_match'
       produces:
       - "application/json-patch+json"
       security:
@@ -861,6 +931,10 @@ paths:
           description: "The dimension option was modified and the successfully applied patch operations are returned"
           schema:
             $ref: '#/definitions/PatchOptions'
+          headers:
+            ETag:
+              type: string
+              description: "Defines a unique instance resource version"
         400:
           $ref: '#/responses/InvalidRequestError'
         401:
@@ -869,6 +943,8 @@ paths:
           $ref: '#/responses/ForbiddenError'
         404:
           description: "InstanceId does not match any instances"
+        409:
+          $ref: '#/responses/ConflictError'
         500:
           $ref: '#/responses/InternalError'
   /instances/{instance_id}/dimensions/{dimension}/options/{option}/node_id/{node_id}:
@@ -884,6 +960,7 @@ paths:
       - $ref: '#/parameters/dimension'
       - $ref: '#/parameters/node_id'
       - $ref: '#/parameters/option'
+      - $ref: '#/parameters/if_match'
       produces:
       - "application/json"
       security:
@@ -891,6 +968,10 @@ paths:
       responses:
         200:
           description: "Updated the dimension with the nodeId"
+          headers:
+            ETag:
+              type: string
+              description: "Defines a unique instance resource version"
         400:
           $ref: '#/responses/InvalidRequestError'
         401:
@@ -899,6 +980,8 @@ paths:
           $ref: '#/responses/ForbiddenError'
         404:
           description: "InstanceId does not match any instances"
+        409:
+          $ref: '#/responses/ConflictError'
         500:
           $ref: '#/responses/InternalError'
 responses:


### PR DESCRIPTION
### What

The Cantabular import services will update the instances by calling dataset API, instead of using the import tracker. Hence, in order to prevent any concurrency issue, in this PR there is an implementation of the ETag / IfMatch mechanism for the instances endpoints in dataset API:

- List of endpoints that accept an `If-Match` header and return `ETag` header:
  - `POST /instances` (doesn't need If-Match, but returns ETag)
  - `GET /instances/{instance_id}`
  - `PUT /instances/{instance_id}`
  - `PUT /instances/{instance_id}/dimensions/{dimension}`
  - `POST /instances/{instance_id}/events`
  - `PUT /instances/{instance_id}/inserted_observations/{inserted_observations}`
  - `PUT /instances/{instance_id}/import_tasks`
  - `GET /instances/{instance_id}/dimensions`
  - `POST /instances/{instance_id}/dimensions`
  - `GET /instances/{instance_id}/dimensions/{dimension}/options`
  - `PATCH /instances/{instance_id}/dimensions/{dimension}/options/{option}`
  - `PUT /instances/{instance_id}/dimensions/{dimension}/options/{option}/node_id/{node_id}`

The changes are backwards compatible, meaning that if no `If-Match` header is provided, then the eTag value of the instance will not be checked (i.e. same behaviour as `If-Match` = `*`)

For operations that cannot be performed atomically (e.g. update instance collection and also update dimension.options collection) a MongoDB lock is used (by instance ID).

Trello card: https://trello.com/c/bzOXDGya/5161-implement-etag-if-match-for-dataset-api-instance-endpoints

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- Make sure component tests pass
- Check that the swagger spec matches the requirements

### Who can review

anyone


____


Postman collection (in case you want to test the changes locally):
```
{
	"info": {
		"_postman_id": "5231d578-e6c6-49c6-b856-acb6152f20dc",
		"name": "dp-dataset-api (instances)",
		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
	},
	"item": [
		{
			"name": "Get Health",
			"request": {
				"method": "GET",
				"header": [
					{
						"key": "X-Florence-Token",
						"value": "44d9c10b3dce08d6a4e09d06ead011ce6ec0c70508001553b61beb48cf7d30b7",
						"type": "text"
					}
				],
				"url": {
					"raw": "http://localhost:22000/health",
					"protocol": "http",
					"host": [
						"localhost"
					],
					"port": "22000",
					"path": [
						"health"
					]
				}
			},
			"response": []
		},
		{
			"name": "Get instances",
			"request": {
				"method": "GET",
				"header": [
					{
						"key": "X-Florence-Token",
						"value": "39b5ba94417813b4e5b23506ddce99bd7c13023bdd948483cd3dbe57aa72e2e1",
						"type": "text"
					}
				],
				"url": {
					"raw": "http://localhost:22000/instances",
					"protocol": "http",
					"host": [
						"localhost"
					],
					"port": "22000",
					"path": [
						"instances"
					]
				}
			},
			"response": []
		},
		{
			"name": "Get instance",
			"request": {
				"method": "GET",
				"header": [
					{
						"key": "X-Florence-Token",
						"value": "39b5ba94417813b4e5b23506ddce99bd7c13023bdd948483cd3dbe57aa72e2e1",
						"type": "text"
					},
					{
						"key": "If-Match",
						"value": "5c5a5d0bf283fc51844cb9b4c9b11b217d054296",
						"type": "text"
					}
				],
				"url": {
					"raw": "http://localhost:22000/instances/24fa40bd-4806-43a5-b1ba-f34ddb0ae245",
					"protocol": "http",
					"host": [
						"localhost"
					],
					"port": "22000",
					"path": [
						"instances",
						"24fa40bd-4806-43a5-b1ba-f34ddb0ae245"
					]
				}
			},
			"response": []
		},
		{
			"name": "Post instance",
			"request": {
				"method": "POST",
				"header": [
					{
						"key": "X-Florence-Token",
						"value": "39b5ba94417813b4e5b23506ddce99bd7c13023bdd948483cd3dbe57aa72e2e1",
						"type": "text"
					}
				],
				"body": {
					"mode": "raw",
					"raw": "{\n    \"id\": \"1\",\n    \"import_tasks\": {\n        \"import_observations\": {\n            \"total_inserted_observations\": 0,\n            \"state\": \"created\"\n        }\n    },\n    \"links\": {\n        \"dataset\": {\n            \"href\": \"http://localhost:22000/datasets/cantabular-dataset\",\n            \"id\": \"cantabular-dataset\"\n        },\n        \"job\": {\n            \"href\": \"http://localhost:21800/jobs/e7f99293-44f2-47ce-b6cb-db2f6618ef40\",\n            \"id\": \"e7f99293-44f2-47ce-b6cb-db2f6618ef40\"\n        },\n        \"self\": {\n            \"href\": \"http://localhost:22000/instances/9281c9e2-0f3c-458a-b995-38dd1ca85c29\"\n        }\n    },\n    \"state\": \"submitted\"\n}",
					"options": {
						"raw": {
							"language": "json"
						}
					}
				},
				"url": {
					"raw": "http://localhost:22000/instances",
					"protocol": "http",
					"host": [
						"localhost"
					],
					"port": "22000",
					"path": [
						"instances"
					]
				}
			},
			"response": []
		},
		{
			"name": "PUT instance",
			"request": {
				"method": "PUT",
				"header": [
					{
						"key": "X-Florence-Token",
						"value": "39b5ba94417813b4e5b23506ddce99bd7c13023bdd948483cd3dbe57aa72e2e1",
						"type": "text"
					},
					{
						"key": "If-Match",
						"value": "*",
						"type": "text"
					}
				],
				"body": {
					"mode": "raw",
					"raw": "{\n    \"state\": \"completed\"\n}\n",
					"options": {
						"raw": {
							"language": "json"
						}
					}
				},
				"url": {
					"raw": "http://localhost:22000/instances/24fa40bd-4806-43a5-b1ba-f34ddb0ae245",
					"protocol": "http",
					"host": [
						"localhost"
					],
					"port": "22000",
					"path": [
						"instances",
						"24fa40bd-4806-43a5-b1ba-f34ddb0ae245"
					]
				}
			},
			"response": []
		},
		{
			"name": "PUT instance dimension",
			"request": {
				"method": "PUT",
				"header": [
					{
						"key": "X-Florence-Token",
						"value": "39b5ba94417813b4e5b23506ddce99bd7c13023bdd948483cd3dbe57aa72e2e1",
						"type": "text"
					},
					{
						"key": "If-Match",
						"value": "*",
						"type": "text"
					}
				],
				"body": {
					"mode": "raw",
					"raw": "{\n    \"label\": \"myTime\",\n    \"option\": \"myOption\"\n}\n",
					"options": {
						"raw": {
							"language": "json"
						}
					}
				},
				"url": {
					"raw": "http://localhost:22000/instances/13e456fb-2ab6-4918-952a-64406bee6f66/dimensions/time",
					"protocol": "http",
					"host": [
						"localhost"
					],
					"port": "22000",
					"path": [
						"instances",
						"13e456fb-2ab6-4918-952a-64406bee6f66",
						"dimensions",
						"time"
					]
				}
			},
			"response": []
		},
		{
			"name": "Post instance event",
			"request": {
				"method": "POST",
				"header": [
					{
						"key": "X-Florence-Token",
						"value": "39b5ba94417813b4e5b23506ddce99bd7c13023bdd948483cd3dbe57aa72e2e1",
						"type": "text"
					},
					{
						"key": "If-Match",
						"value": "*",
						"type": "text"
					}
				],
				"body": {
					"mode": "raw",
					"raw": "{\n    \"message\": \"myEvent\",\n    \"message_offset\": \"56\",\n    \"time\": \"2020-12-09T16:09:53+00:00\",\n    \"type\": \"error\"\n}",
					"options": {
						"raw": {
							"language": "json"
						}
					}
				},
				"url": {
					"raw": "http://localhost:22000/instances/e9ddf7a4-c72f-44e6-a23a-a02666b92139/events",
					"protocol": "http",
					"host": [
						"localhost"
					],
					"port": "22000",
					"path": [
						"instances",
						"e9ddf7a4-c72f-44e6-a23a-a02666b92139",
						"events"
					]
				}
			},
			"response": []
		},
		{
			"name": "PUT instance inserted observations",
			"request": {
				"method": "PUT",
				"header": [
					{
						"key": "X-Florence-Token",
						"value": "39b5ba94417813b4e5b23506ddce99bd7c13023bdd948483cd3dbe57aa72e2e1",
						"type": "text"
					},
					{
						"key": "If-Match",
						"value": "*",
						"type": "text"
					}
				],
				"url": {
					"raw": "http://localhost:22000/instances/13e456fb-2ab6-4918-952a-64406bee6f66/inserted_observations/123",
					"protocol": "http",
					"host": [
						"localhost"
					],
					"port": "22000",
					"path": [
						"instances",
						"13e456fb-2ab6-4918-952a-64406bee6f66",
						"inserted_observations",
						"123"
					]
				}
			},
			"response": []
		},
		{
			"name": "PUT instance import tasks",
			"request": {
				"method": "PUT",
				"header": [
					{
						"key": "X-Florence-Token",
						"value": "39b5ba94417813b4e5b23506ddce99bd7c13023bdd948483cd3dbe57aa72e2e1",
						"type": "text"
					},
					{
						"key": "If-Match",
						"value": "*",
						"type": "text"
					}
				],
				"body": {
					"mode": "raw",
					"raw": "{\n    \"import_observations\": {\n        \"total_inserted_observations\": 333,\n        \"state\": \"completed\"\n    }\n}",
					"options": {
						"raw": {
							"language": "json"
						}
					}
				},
				"url": {
					"raw": "http://localhost:22000/instances/13e456fb-2ab6-4918-952a-64406bee6f66/import_tasks",
					"protocol": "http",
					"host": [
						"localhost"
					],
					"port": "22000",
					"path": [
						"instances",
						"13e456fb-2ab6-4918-952a-64406bee6f66",
						"import_tasks"
					]
				}
			},
			"response": []
		},
		{
			"name": "Get instance dimensions",
			"request": {
				"method": "GET",
				"header": [
					{
						"key": "X-Florence-Token",
						"value": "39b5ba94417813b4e5b23506ddce99bd7c13023bdd948483cd3dbe57aa72e2e1",
						"type": "text"
					},
					{
						"key": "If-Match",
						"value": "7cd6db85ea24bffd9dae1cff6df431bd2e70de32",
						"type": "text"
					}
				],
				"url": {
					"raw": "http://localhost:22000/instances/e9ddf7a4-c72f-44e6-a23a-a02666b92139/dimensions",
					"protocol": "http",
					"host": [
						"localhost"
					],
					"port": "22000",
					"path": [
						"instances",
						"e9ddf7a4-c72f-44e6-a23a-a02666b92139",
						"dimensions"
					]
				}
			},
			"response": []
		},
		{
			"name": "Post Instance dimensions (options)",
			"request": {
				"method": "POST",
				"header": [
					{
						"key": "X-Florence-Token",
						"value": "39b5ba94417813b4e5b23506ddce99bd7c13023bdd948483cd3dbe57aa72e2e1",
						"type": "text"
					},
					{
						"key": "If-Match",
						"value": "*",
						"type": "text"
					}
				],
				"body": {
					"mode": "raw",
					"raw": "{\n  \"code\": \"testCode\",\n  \"codelist\": \"testCodeList\",\n  \"dimension\": \"testDimension\",\n  \"instance_id\": \"c7b29cd-a551-4c7b-9133-8a313589a47a\",\n  \"label\": \"testLabel\",\n  \"option\": \"testOption\",\n  \"order\": 2\n}",
					"options": {
						"raw": {
							"language": "json"
						}
					}
				},
				"url": {
					"raw": "http://localhost:22000/instances/e9ddf7a4-c72f-44e6-a23a-a02666b92139/dimensions",
					"protocol": "http",
					"host": [
						"localhost"
					],
					"port": "22000",
					"path": [
						"instances",
						"e9ddf7a4-c72f-44e6-a23a-a02666b92139",
						"dimensions"
					]
				}
			},
			"response": []
		},
		{
			"name": "Get instance dimension options",
			"request": {
				"method": "GET",
				"header": [
					{
						"key": "X-Florence-Token",
						"value": "39b5ba94417813b4e5b23506ddce99bd7c13023bdd948483cd3dbe57aa72e2e1",
						"type": "text"
					},
					{
						"key": "If-Match",
						"value": "*",
						"type": "text"
					}
				],
				"url": {
					"raw": "http://localhost:22000/instances/e9ddf7a4-c72f-44e6-a23a-a02666b92139/dimensions/time/options",
					"protocol": "http",
					"host": [
						"localhost"
					],
					"port": "22000",
					"path": [
						"instances",
						"e9ddf7a4-c72f-44e6-a23a-a02666b92139",
						"dimensions",
						"time",
						"options"
					]
				}
			},
			"response": []
		},
		{
			"name": "Patch instance dimension option",
			"request": {
				"method": "PATCH",
				"header": [
					{
						"key": "X-Florence-Token",
						"type": "text",
						"value": "39b5ba94417813b4e5b23506ddce99bd7c13023bdd948483cd3dbe57aa72e2e1"
					},
					{
						"key": "If-Match",
						"value": "*",
						"type": "text"
					}
				],
				"body": {
					"mode": "raw",
					"raw": "[\n    {\n        \"op\": \"add\",\n        \"path\": \"/order\",\n        \"value\": 123\n    },\n    {\n        \"op\": \"add\",\n        \"path\": \"/node_id\",\n        \"value\": \"testNode\"\n    }\n]",
					"options": {
						"raw": {
							"language": "json"
						}
					}
				},
				"url": {
					"raw": "http://localhost:22000/instances/e9ddf7a4-c72f-44e6-a23a-a02666b92139/dimensions/time/options/2015-q2",
					"protocol": "http",
					"host": [
						"localhost"
					],
					"port": "22000",
					"path": [
						"instances",
						"e9ddf7a4-c72f-44e6-a23a-a02666b92139",
						"dimensions",
						"time",
						"options",
						"2015-q2"
					]
				}
			},
			"response": []
		},
		{
			"name": "Put instance dimension options nodeId (deprecated)",
			"request": {
				"method": "PUT",
				"header": [
					{
						"key": "X-Florence-Token",
						"type": "text",
						"value": "39b5ba94417813b4e5b23506ddce99bd7c13023bdd948483cd3dbe57aa72e2e1"
					},
					{
						"key": "If-Match",
						"value": "*",
						"type": "text"
					}
				],
				"url": {
					"raw": "http://localhost:22000/instances/e9ddf7a4-c72f-44e6-a23a-a02666b92139/dimensions/time/options/2015-q2/node_id/666",
					"protocol": "http",
					"host": [
						"localhost"
					],
					"port": "22000",
					"path": [
						"instances",
						"e9ddf7a4-c72f-44e6-a23a-a02666b92139",
						"dimensions",
						"time",
						"options",
						"2015-q2",
						"node_id",
						"666"
					]
				}
			},
			"response": []
		}
	]
}
```
