### PR TITLE
Add new fields to models

### DIFF
--- a/models/dataset.go
+++ b/models/dataset.go
@@ -24,10 +24,12 @@ type DatasetType int
 const (
 	Filterable DatasetType = iota
 	Nomis
+	CantabularTable
+	CantabularBlob
 	Invalid
 )
 
-var datasetTypes = []string{"filterable", "nomis", "invalid"}
+var datasetTypes = []string{"filterable", "nomis", "cantabular_table", "cantabular_blob", "invalid"}
 
 func (dt DatasetType) String() string {
 	return datasetTypes[dt]
@@ -40,6 +42,10 @@ func GetDatasetType(datasetType string) (DatasetType, error) {
 		return Filterable, nil
 	case "nomis":
 		return Nomis, nil
+	case "cantabular_table":
+		return CantabularTable, nil
+	case "cantabular_blob":
+		return CantabularBlob, nil
 	default:
 		return Invalid, errs.ErrDatasetTypeInvalid
 	}
@@ -85,6 +91,7 @@ type Dataset struct {
 	URI               string           `bson:"uri,omitempty"                    json:"uri,omitempty"`
 	Type              string           `bson:"type,omitempty"                   json:"type,omitempty"`
 	NomisReferenceURL string           `bson:"nomis_reference_url,omitempty"    json:"nomis_reference_url,omitempty"`
+	IsBasedOn         *IsBasedOn       `bson:"is_based_on,omitempty"            json:"is_based_on,omitempty"`
 }
 
 // DatasetLinks represents a list of specific links related to the dataset resource
@@ -142,11 +149,13 @@ type EditionUpdateLinks struct {
 
 // Edition represents information related to a single edition for a dataset
 type Edition struct {
-	Edition     string              `bson:"edition,omitempty"     json:"edition,omitempty"`
-	ID          string              `bson:"id,omitempty"          json:"id,omitempty"`
+	Edition     string              `bson:"edition,omitempty"      json:"edition,omitempty"`
+	ID          string              `bson:"id,omitempty"           json:"id,omitempty"`
 	LastUpdated time.Time           `bson:"last_updated,omitempty" json:"-"`
-	Links       *EditionUpdateLinks `bson:"links,omitempty"       json:"links,omitempty"`
+	Links       *EditionUpdateLinks `bson:"links,omitempty"        json:"links,omitempty"`
 	State       string              `bson:"state,omitempty"        json:"state,omitempty"`
+	IsBasedOn   *IsBasedOn          `bson:"is_based_on,omitempty"  json:"is_based_on,omitempty"`
+	Type        string              `bson:"type,omitempty"         json:"type,omitempty"`
 }
 
 // Publisher represents an object containing information of the publisher
@@ -231,9 +240,14 @@ type VersionLinks struct {
 	Version    *LinkObject `bson:"version,omitempty"     json:"-"`
 }
 
+// IsBasedOn refers to the Cantabular blob source
+type IsBasedOn struct{
+	Type string `bson:"@type" json:"@type"`
+	ID   string `bson:"@id"   json:"@id"`
+}
+
 // CreateDataset manages the creation of a dataset from a reader
 func CreateDataset(reader io.Reader) (*Dataset, error) {
-
 	b, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nil, errs.ErrUnableToReadMessage

--- a/models/dataset_test.go
+++ b/models/dataset_test.go
@@ -59,7 +59,9 @@ func TestString(t *testing.T) {
 			So(result, ShouldEqual, "filterable")
 			So(datasetTypes[0], ShouldEqual, "filterable")
 			So(datasetTypes[1], ShouldEqual, "nomis")
-			So(datasetTypes[2], ShouldEqual, "invalid")
+			So(datasetTypes[2], ShouldEqual, "cantabular_table")
+			So(datasetTypes[3], ShouldEqual, "cantabular_blob")
+			So(datasetTypes[4], ShouldEqual, "invalid")
 
 		})
 	})

--- a/models/dimension.go
+++ b/models/dimension.go
@@ -5,13 +5,15 @@ import "time"
 // Dimension represents an overview for a single dimension. This includes a link to the code list API
 // which provides metadata about the dimension and all possible values.
 type Dimension struct {
-	Description string        `bson:"description,omitempty"   json:"description,omitempty"`
-	Label       string        `bson:"label,omitempty"         json:"label,omitempty"`
-	LastUpdated time.Time     `bson:"last_updated,omitempty"  json:"-"`
-	Links       DimensionLink `bson:"links,omitempty"         json:"links,omitempty"`
-	HRef        string        `json:"href,omitempty"`
-	ID          string        `json:"id,omitempty"`
-	Name        string        `bson:"name,omitempty"          json:"name,omitempty"`
+	Description     string        `bson:"description,omitempty"       json:"description,omitempty"`
+	Label           string        `bson:"label,omitempty"             json:"label,omitempty"`
+	LastUpdated     time.Time     `bson:"last_updated,omitempty"      json:"-"`
+	Links           DimensionLink `bson:"links,omitempty"             json:"links,omitempty"`
+	HRef            string        `json:"href,omitempty"`
+	ID              string        `json:"id,omitempty"`
+	Name            string        `bson:"name,omitempty"              json:"name,omitempty"`
+	Variable        string        `bson:"variable,omitempty"          json:"variable,omitempty"`
+	NumberOfOptions *int          `bson:"number_of_options,omitempty" json:"number_of_options,omitempty"`
 }
 
 // DimensionLink contains all links needed for a dimension

--- a/models/instance.go
+++ b/models/instance.go
@@ -28,6 +28,8 @@ type Instance struct {
 	TotalObservations *int                 `bson:"total_observations,omitempty"          json:"total_observations,omitempty"`
 	UniqueTimestamp   bson.MongoTimestamp  `bson:"unique_timestamp"                      json:"-"`
 	Version           int                  `bson:"version,omitempty"                     json:"version,omitempty"`
+	Type              string               `bson:"type,omitempty"                        json:"type,omitempty"`
+	IsBasedOn         *IsBasedOn           `bson:"is_based_on,omitempty"                 json:"is_based_on,omitempty"`
 }
 
 // InstanceImportTasks represents all of the tasks required to complete an import job.


### PR DESCRIPTION
### What

Updated models for dataset, edition, instance and dimension to include extra fields used for Cantabular import

### How to review

Check correct fields have been added (ticket: https://trello.com/c/vbJnksdX/5154-add-fields-to-mongodb-collections-to-allow-for-versioning-of-cantabular-data-types-5). 

The implementation of the dataset 'type' was changed from the ticket requirements to fit work that had already been done - Expanding the existing 'Type' rather than create new, and to allow for 2 new Cantabular types rather than one Cantabular type and a whole new field 'Cantabular Type' 

Make sure no changes are breaking.

### Who can review

Anyone
