### PR TITLE
add optional DISABLE_GRAPH_DB_DEPENDENCY environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Scripts for updating and debugging Kafka can be found [here](https://github.com/
 | HEALTHCHECK_INTERVAL         | 30s                                    | The time between calling healthcheck endpoints for check subsystems
 | HEALTHCHECK_CRITICAL_TIMEOUT | 90s                                    | The time taken for the health changes from warning state to critical due to subsystem check failures
 | ENABLE_PRIVATE_ENDPOINTS     | false                                  | Enable private endpoints for the API
+| DISABLE_GRAPH_DB_DEPENDENCY  | false                                  | Disables connection and health check for graph db
 | DOWNLOAD_SERVICE_SECRET_KEY  | QB0108EZ-825D-412C-9B1D-41EF7747F462   | A key specific for the download service to access public/private links
 | ZEBEDEE_URL                  | http://localhost:8082                  | The host name for Zebedee
 | ENABLE_PERMISSIONS_AUTH      | false                                  | Enable/disable user/service permissions checking for private endpoints

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ type Configuration struct {
 	EnableDetachDataset        bool          `envconfig:"ENABLE_DETACH_DATASET"`
 	EnablePermissionsAuth      bool          `envconfig:"ENABLE_PERMISSIONS_AUTH"`
 	EnableObservationEndpoint  bool          `envconfig:"ENABLE_OBSERVATION_ENDPOINT"`
+	DisableGraphDBDependency   bool          `envconfig:"DISABLE_GRAPH_DB_DEPENDENCY"`
 	KafkaVersion               string        `envconfig:"KAFKA_VERSION"`
 	DefaultMaxLimit            int           `envconfig:"DEFAULT_MAXIMUM_LIMIT"`
 	DefaultLimit               int           `envconfig:"DEFAULT_LIMIT"`
@@ -64,6 +65,7 @@ func Get() (*Configuration, error) {
 		EnableDetachDataset:        false,
 		EnablePermissionsAuth:      false,
 		EnableObservationEndpoint:  true,
+		DisableGraphDBDependency:   false,
 		KafkaVersion:               "1.0.2",
 		DefaultMaxLimit:            1000,
 		DefaultLimit:               20,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,6 +33,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.MongoConfig.BindAddr, ShouldEqual, "localhost:27017")
 				So(cfg.MongoConfig.Collection, ShouldEqual, "datasets")
 				So(cfg.MongoConfig.Database, ShouldEqual, "datasets")
+				So(cfg.DisableGraphDBDependency, ShouldEqual, false)
 				So(cfg.DefaultLimit, ShouldEqual, 20)
 				So(cfg.DefaultOffset, ShouldEqual, 0)
 				So(cfg.EnablePermissionsAuth, ShouldBeFalse)

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -241,7 +241,7 @@ type VersionLinks struct {
 }
 
 // IsBasedOn refers to the Cantabular blob source
-type IsBasedOn struct{
+type IsBasedOn struct {
 	Type string `bson:"@type" json:"@type"`
 	ID   string `bson:"@id"   json:"@id"`
 }

--- a/service/service.go
+++ b/service/service.go
@@ -95,7 +95,7 @@ func (svc *Service) Run(ctx context.Context, buildTime, gitCommit, version strin
 	}
 
 	// Get graphDB connection for observation store
-	if !svc.config.EnablePrivateEndpoints {
+	if !svc.config.EnablePrivateEndpoints || svc.config.DisableGraphDBDependency {
 		log.Event(ctx, "skipping graph DB client creation, because it is not required by the enabled endpoints", log.INFO, log.Data{
 			"EnablePrivateEndpoints": svc.config.EnablePrivateEndpoints,
 		})
@@ -309,7 +309,7 @@ func (svc *Service) registerCheckers(ctx context.Context) (err error) {
 	hasErrors := false
 
 	if svc.config.EnablePrivateEndpoints {
-		log.Event(ctx, "adding kafka, zebedee and graph db health check as the private endpoints are enabled", log.INFO)
+		log.Event(ctx, "private endpoints enabled: adding kafka and zebedee health checks", log.INFO)
 		if err = svc.healthCheck.AddCheck("Zebedee", svc.identityClient.Checker); err != nil {
 			hasErrors = true
 			log.Event(ctx, "error adding check for zebedeee", log.ERROR, log.Error(err))
@@ -320,9 +320,12 @@ func (svc *Service) registerCheckers(ctx context.Context) (err error) {
 			log.Event(ctx, "error adding check for kafka downloads producer", log.ERROR, log.Error(err))
 		}
 
-		if err = svc.healthCheck.AddCheck("Graph DB", svc.graphDB.Checker); err != nil {
-			hasErrors = true
-			log.Event(ctx, "error adding check for graph db", log.ERROR, log.Error(err))
+		if !svc.config.DisableGraphDBDependency{
+			log.Event(ctx, "private endpoints enabled: adding graph db health check", log.INFO)
+			if err = svc.healthCheck.AddCheck("Graph DB", svc.graphDB.Checker); err != nil {
+				hasErrors = true
+				log.Event(ctx, "error adding check for graph db", log.ERROR, log.Error(err))
+			}
 		}
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -320,7 +320,7 @@ func (svc *Service) registerCheckers(ctx context.Context) (err error) {
 			log.Event(ctx, "error adding check for kafka downloads producer", log.ERROR, log.Error(err))
 		}
 
-		if !svc.config.DisableGraphDBDependency{
+		if !svc.config.DisableGraphDBDependency {
 			log.Event(ctx, "private endpoints enabled: adding graph db health check", log.INFO)
 			if err = svc.healthCheck.AddCheck("Graph DB", svc.graphDB.Checker); err != nil {
 				hasErrors = true


### PR DESCRIPTION
### What

Added an optional DISABLE_GRAPH_DB_DEPENDENCY environment variable which skips making the connection and adding the health check for Graph DB. Useful when you want to run the service in a journey that doesn't depend on Graph DB but still needs Kafka and Zebedee

### How to review

- When completely omitted service runs unchanged - connection and health check should still be added and checked

- When explicitly added and set to TRUE, service should run without an open connection to any graph DB and health check should pass.

### Who can review

Anyone
