### PR TITLE
Added extra necessary locks for instance writer handlers

### DIFF
--- a/instance/dimensions.go
+++ b/instance/dimensions.go
@@ -27,6 +27,13 @@ func (s *Store) UpdateDimension(w http.ResponseWriter, r *http.Request) {
 
 	log.Event(ctx, "update instance dimension: update instance dimension", log.INFO, logData)
 
+	// Acquire instance lock to make sure that this call does not interfere with any other 'write' call against the same instance
+	lockID, err := s.AcquireInstanceLock(ctx, instanceID)
+	if err != nil {
+		handleInstanceErr(ctx, err, w, logData)
+	}
+	defer s.UnlockInstance(lockID)
+
 	instance, err := s.GetInstance(instanceID, eTag)
 	if err != nil {
 		log.Event(ctx, "update instance dimension: Failed to GET instance", log.ERROR, log.Error(err), logData)

--- a/instance/event.go
+++ b/instance/event.go
@@ -51,6 +51,13 @@ func (s *Store) AddEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Acquire instance lock to make sure that this call does not interfere with any other 'write' call against the same instance
+	lockID, err := s.AcquireInstanceLock(ctx, instanceID)
+	if err != nil {
+		handleInstanceErr(ctx, err, w, data)
+	}
+	defer s.UnlockInstance(lockID)
+
 	instance, err := s.GetInstance(instanceID, eTag)
 	if err != nil {
 		log.Event(ctx, "add instance event: failed to get instance from datastore", log.ERROR, log.Error(err), data)

--- a/instance/import.go
+++ b/instance/import.go
@@ -33,6 +33,13 @@ func (s *Store) UpdateObservations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Acquire instance lock to make sure that this call does not interfere with any other 'write' call against the same instance
+	lockID, err := s.AcquireInstanceLock(ctx, instanceID)
+	if err != nil {
+		handleInstanceErr(ctx, err, w, logData)
+	}
+	defer s.UnlockInstance(lockID)
+
 	instance, err := s.GetInstance(instanceID, eTag)
 	if err != nil {
 		log.Event(ctx, "failed to get instance from database", log.ERROR, log.Error(err), logData)
@@ -74,6 +81,13 @@ func (s *Store) UpdateImportTask(w http.ResponseWriter, r *http.Request) {
 		handleError(&taskError{err, http.StatusBadRequest})
 		return
 	}
+
+	// Acquire instance lock to make sure that this call does not interfere with any other 'write' call against the same instance
+	lockID, err := s.AcquireInstanceLock(ctx, instanceID)
+	if err != nil {
+		handleInstanceErr(ctx, err, w, logData)
+	}
+	defer s.UnlockInstance(lockID)
 
 	instance, err := s.GetInstance(instanceID, eTag)
 	if err != nil {

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -89,6 +89,8 @@ func (s *Store) GetList(w http.ResponseWriter, r *http.Request, limit int, offse
 }
 
 // Get a single instance by id
+// Note that this method doesn't need to acquire the instance lock because it's a getter,
+// which will fail if the ETag doesn't match, and cannot interfere with writers.
 func (s *Store) Get(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	vars := mux.Vars(r)
@@ -129,6 +131,8 @@ func (s *Store) Get(w http.ResponseWriter, r *http.Request) {
 }
 
 // Add an instance
+// Note that this method doesn't need to acquire the instance lock because it creates a new instance,
+// so it is not possible that any other call is concurrently trying to access the same instance
 func (s *Store) Add(w http.ResponseWriter, r *http.Request) {
 
 	defer dphttp.DrainBody(r)


### PR DESCRIPTION
### What

- Added extra locks acquire/release's in all remaining instance writer endpoints because, although they were doing atomic updates, they still need to wait if some non-atomic write operation is taking place.
- Added comments where locks are not needed (i.e. instance getter and new instance creation)

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- Make sure new comments are clear

### Who can review

anyone (probably Rhys)