### PR TITLE
bubfix: fix mongoDB code for UpdateBuildSearchTaskState

### DIFF
--- a/mongo/instance_store.go
+++ b/mongo/instance_store.go
@@ -395,7 +395,7 @@ func (m *Mongo) UpdateBuildHierarchyTaskState(currentInstance *models.Instance, 
 		"$currentDate": bson.M{"last_updated": true},
 	}
 
-	if err := s.DB(m.Database).C(instanceCollection).Update(selector, update); err != nil {
+	if err := s.DB(m.Database).C(instanceCollection).Update(sel, update); err != nil {
 		return "", err
 	}
 
@@ -424,7 +424,7 @@ func (m *Mongo) UpdateBuildSearchTaskState(currentInstance *models.Instance, dim
 		"$currentDate": bson.M{"last_updated": true},
 	}
 
-	if err := s.DB(m.Database).C(instanceCollection).Update(selector, update); err != nil {
+	if err := s.DB(m.Database).C(instanceCollection).Update(sel, update); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
### What

Fix a bug in `PutInstanceImportTasks`, which prevented cmd imports with hierarchy from working. The `mongoDB` query was using the wrong variable as selector.

### How to review

- Make sure code changes make sense
- Tried to do the call against dataset api with postman.

### Who can review

anyone