### PR TITLE
Stop logging the 'whole' instance

### DIFF
--- a/mongo/instance_store.go
+++ b/mongo/instance_store.go
@@ -142,7 +142,7 @@ func (m *Mongo) UpdateInstance(ctx context.Context, currentInstance, updatedInst
 func createInstanceUpdateQuery(ctx context.Context, instanceID string, instance *models.Instance) bson.M {
 	updates := make(bson.M)
 
-	logData := log.Data{"instance_id": instanceID, "instance": instance}
+	logData := log.Data{"instance_id": instanceID}
 
 	log.Event(ctx, "building update query for instance resource", log.INFO, logData)
 


### PR DESCRIPTION
### What

This has been agreed with Nathan.
It removes the problem of massive logs for large CMD requests and very large ones for census.

### How to review

Visual inspection.

### Who can review

!Me
