### PR TITLE
Hotfix: mongoDB query selector ignores any provided ETag. We need to …

### DIFF
--- a/mongo/instance_store.go
+++ b/mongo/instance_store.go
@@ -493,8 +493,10 @@ func selector(instanceID string, timestamp bson.MongoTimestamp, eTagSelector str
 	if timestamp > 0 {
 		selector[dpmongo.UniqueTimestampKey] = timestamp
 	}
-	if eTagSelector != AnyETag {
-		selector["e_tag"] = eTagSelector
-	}
+	// TODO uncomment the following 3 lines once we know how to properly fix the race condition observed
+	// between the dimension importer and dataset api (Postmortem doc: https://docs.google.com/document/d/10zjmmTIef1Bd5mESTEvBKv_cl8uvRI7yMl9MzNCIPzA/edit#)
+	// if eTagSelector != AnyETag {
+	// 	selector["e_tag"] = eTagSelector
+	// }
 	return selector
 }

--- a/mongo/instance_test.go
+++ b/mongo/instance_test.go
@@ -11,21 +11,22 @@ func TestSelector(t *testing.T) {
 
 	Convey("Given some testing values to provide as selector paramters", t, func() {
 		var testInstanceID string = "instanceID"
-		var testETag string = "testETag"
-		var testMongoTimestamp bson.MongoTimestamp = 1234567890
+		// var testETag string = "testETag"
+		// var testMongoTimestamp bson.MongoTimestamp = 1234567890
 
 		Convey("Then, providing a zero timestamp and any eTag generates a selector that only queries by id", func() {
 			s := selector(testInstanceID, 0, AnyETag)
 			So(s, ShouldResemble, bson.M{"id": testInstanceID})
 		})
 
-		Convey("Then, providing values for timestamp, and eTag generates a selector that queries by filterID, timestamp and eTag", func() {
-			s := selector(testInstanceID, testMongoTimestamp, testETag)
-			So(s, ShouldResemble, bson.M{
-				"id":               testInstanceID,
-				"unique_timestamp": testMongoTimestamp,
-				"e_tag":            testETag,
-			})
-		})
+		// TODO uncomment once we know how to fix the race condition between dataset api and dimension importer
+		// Convey("Then, providing values for timestamp, and eTag generates a selector that queries by filterID, timestamp and eTag", func() {
+		// 	s := selector(testInstanceID, testMongoTimestamp, testETag)
+		// 	So(s, ShouldResemble, bson.M{
+		// 		"id":               testInstanceID,
+		// 		"unique_timestamp": testMongoTimestamp,
+		// 		"e_tag":            testETag,
+		// 	})
+		// })
 	})
 }


### PR DESCRIPTION
### What

Make mongoDB ignore any provided ETag, until we fix the race condition defined in the following postmortem doc:
https://docs.google.com/document/d/10zjmmTIef1Bd5mESTEvBKv_cl8uvRI7yMl9MzNCIPzA/edit#

### How to review

- Make sure only the expected change is made
- Make sure unit and component tests pass

### Who can review

Anyone