### PR TITLE
locked before looping patch operations

### DIFF
--- a/dimension/dimension_test.go
+++ b/dimension/dimension_test.go
@@ -417,12 +417,7 @@ func TestPatchOptionReturnsBadRequest(t *testing.T) {
 	Convey("Given a Dataset API instance with a mocked datastore GetInstance", t, func() {
 		w := httptest.NewRecorder()
 
-		mockedDataStore := &storetest.StorerMock{
-			GetInstanceFunc: func(ID string, eTagSelector string) (*models.Instance, error) {
-				return &models.Instance{State: models.CreatedState}, nil
-			},
-		}
-
+		mockedDataStore, isLocked := storeMockWithLock(false)
 		datasetAPI := getAPIWithMocks(testContext, mockedDataStore, &mocks.DownloadsGeneratorMock{})
 
 		bodies := map[string]io.Reader{
@@ -441,6 +436,7 @@ func TestPatchOptionReturnsBadRequest(t *testing.T) {
 				datasetAPI.Router.ServeHTTP(w, r)
 				So(w.Code, ShouldEqual, http.StatusBadRequest)
 				So(mockedDataStore.GetInstanceCalls(), ShouldHaveLength, 1)
+				So(*isLocked, ShouldBeFalse)
 			})
 		}
 	})


### PR DESCRIPTION
### What

Moved the `acquire lock` before looping patch operations in order to prevent race condition between external calls and internal dataset api looping.

bug fix for issue described (here)[https://docs.google.com/document/d/10zjmmTIef1Bd5mESTEvBKv_cl8uvRI7yMl9MzNCIPzA/edit#]

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

anyone