### PR TITLE
Added missing error details to error log event

### DIFF
--- a/dimension/helpers.go
+++ b/dimension/helpers.go
@@ -62,7 +62,7 @@ func handleDimensionErr(ctx context.Context, w http.ResponseWriter, err error, d
 			status = http.StatusConflict
 		default:
 			status = http.StatusInternalServerError
-			err = errors.WithMessage(err, errs.ErrInternalServer.Error())
+			err = errors.WithMessage(err, "internal error")
 		}
 	}
 

--- a/dimension/helpers.go
+++ b/dimension/helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/models"
 	dprequest "github.com/ONSdigital/dp-net/request"
 	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -61,7 +62,7 @@ func handleDimensionErr(ctx context.Context, w http.ResponseWriter, err error, d
 			status = http.StatusConflict
 		default:
 			status = http.StatusInternalServerError
-			err = errs.ErrInternalServer
+			err = errors.WithMessage(err, errs.ErrInternalServer.Error())
 		}
 	}
 


### PR DESCRIPTION
### What
Handle error method is overwriting the original error details.

When an internal server error is handled the original cause `err` var is overwritten and the details about what went wrong are lost making the error impossible to diagnose.

Updated to wrap original error to preserve the details
