### PR TITLE
Store is_based_on in mongoDB, so that it can be accessed by Cantabula…

### DIFF
--- a/models/dataset.go
+++ b/models/dataset.go
@@ -243,8 +243,8 @@ type VersionLinks struct {
 
 // IsBasedOn refers to the Cantabular blob source
 type IsBasedOn struct {
-	Type string `bson:"@type" json:"@type"`
-	ID   string `bson:"@id"   json:"@id"`
+	Type string `bson:"type" json:"@type"`
+	ID   string `bson:"id"   json:"@id"`
 }
 
 // CreateDataset manages the creation of a dataset from a reader

--- a/mongo/instance_store.go
+++ b/mongo/instance_store.go
@@ -271,6 +271,15 @@ func createInstanceUpdateQuery(ctx context.Context, instanceID string, instance 
 		updates["version"] = instance.Version
 	}
 
+	if instance.IsBasedOn != nil {
+		if instance.IsBasedOn.ID != "" {
+			updates["is_based_on.id"] = instance.IsBasedOn.ID
+		}
+		if instance.IsBasedOn.Type != "" {
+			updates["is_based_on.type"] = instance.IsBasedOn.Type
+		}
+	}
+
 	logData["updates"] = updates
 	log.Info(ctx, "built update query for instance resource", logData)
 


### PR DESCRIPTION
### What

- Store `IsBasedOn` to MongoDB
- This is needed by Cantabular CSV exporter in order to make a request to Cantabular

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (info only) tested locally with postman and robo3T

### Who can review

anyone