### PR TITLE
lock instance document on putVersion

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -670,28 +670,20 @@ func populateNewVersionDoc(currentVersion models.Version, version models.Version
 	if version.Downloads == nil {
 		version.Downloads = currentVersion.Downloads
 	} else {
-		if version.Downloads.XLS == nil {
-			if currentVersion.Downloads != nil && currentVersion.Downloads.XLS != nil {
-				version.Downloads.XLS = currentVersion.Downloads.XLS
-			}
+		if version.Downloads.XLS == nil && currentVersion.Downloads != nil {
+			version.Downloads.XLS = currentVersion.Downloads.XLS
 		}
 
-		if version.Downloads.CSV == nil {
-			if currentVersion.Downloads != nil && currentVersion.Downloads.CSV != nil {
-				version.Downloads.CSV = currentVersion.Downloads.CSV
-			}
+		if version.Downloads.CSV == nil && currentVersion.Downloads != nil {
+			version.Downloads.CSV = currentVersion.Downloads.CSV
 		}
 
-		if version.Downloads.CSVW == nil {
-			if currentVersion.Downloads != nil && currentVersion.Downloads.CSVW != nil {
-				version.Downloads.CSVW = currentVersion.Downloads.CSVW
-			}
+		if version.Downloads.CSVW == nil && currentVersion.Downloads != nil {
+			version.Downloads.CSVW = currentVersion.Downloads.CSVW
 		}
 
-		if version.Downloads.TXT == nil {
-			if currentVersion.Downloads != nil && currentVersion.Downloads.TXT != nil {
-				version.Downloads.TXT = currentVersion.Downloads.TXT
-			}
+		if version.Downloads.TXT == nil && currentVersion.Downloads != nil {
+			version.Downloads.TXT = currentVersion.Downloads.TXT
 		}
 	}
 

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -1889,70 +1889,70 @@ func TestPutVersionReturnsError(t *testing.T) {
 		})
 	})
 
-	// Convey("When the request body is invalid return status bad request", t, func() {
-	// 	generatorMock := &mocks.DownloadsGeneratorMock{
-	// 		GenerateFunc: func(context.Context, string, string, string, string) error {
-	// 			return nil
-	// 		},
-	// 	}
+	Convey("When the request body is invalid return status bad request", t, func() {
+		generatorMock := &mocks.DownloadsGeneratorMock{
+			GenerateFunc: func(context.Context, string, string, string, string) error {
+				return nil
+			},
+		}
 
-	// 	b := `{"instance_id":"a1b2c3","edition":"2017","license":"ONS","release_date":"2017-04-04","state":"associated"}`
-	// 	r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
+		b := `{"instance_id":"a1b2c3","edition":"2017","license":"ONS","release_date":"2017-04-04","state":"associated"}`
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 
-	// 	w := httptest.NewRecorder()
-	// 	isLocked := false
-	// 	mockedDataStore := &storetest.StorerMock{
-	// 		GetVersionFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
-	// 			return &models.Version{
-	// 				ID:    "789",
-	// 				State: "associated",
-	// 			}, nil
-	// 		},
-	// 		GetDatasetFunc: func(ctx context.Context, datasetID string) (*models.DatasetUpdate, error) {
-	// 			return &models.DatasetUpdate{}, nil
-	// 		},
-	// 		CheckEditionExistsFunc: func(context.Context, string, string, string) error {
-	// 			return nil
-	// 		},
-	// 		UpdateVersionFunc: func(ctx context.Context, currentVersion *models.Version, version *models.Version, eTagSelector string) (string, error) {
-	// 			So(isLocked, ShouldBeTrue)
-	// 			return "", nil
-	// 		},
-	// 		AcquireInstanceLockFunc: func(ctx context.Context, instanceID string) (string, error) {
-	// 			isLocked = true
-	// 			return testLockID, nil
-	// 		},
-	// 		UnlockInstanceFunc: func(ctx context.Context, lockID string) {
-	// 			isLocked = false
-	// 		},
-	// 	}
+		w := httptest.NewRecorder()
+		isLocked := false
+		mockedDataStore := &storetest.StorerMock{
+			GetVersionFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
+				return &models.Version{
+					ID:    "789",
+					State: "associated",
+				}, nil
+			},
+			GetDatasetFunc: func(ctx context.Context, datasetID string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{}, nil
+			},
+			CheckEditionExistsFunc: func(context.Context, string, string, string) error {
+				return nil
+			},
+			UpdateVersionFunc: func(ctx context.Context, currentVersion *models.Version, version *models.Version, eTagSelector string) (string, error) {
+				So(isLocked, ShouldBeTrue)
+				return "", nil
+			},
+			AcquireInstanceLockFunc: func(ctx context.Context, instanceID string) (string, error) {
+				isLocked = true
+				return testLockID, nil
+			},
+			UnlockInstanceFunc: func(ctx context.Context, lockID string) {
+				isLocked = false
+			},
+		}
 
-	// 	datasetPermissions := getAuthorisationHandlerMock()
-	// 	permissions := getAuthorisationHandlerMock()
-	// 	api := GetAPIWithCMDMocks(mockedDataStore, generatorMock, datasetPermissions, permissions)
-	// 	api.Router.ServeHTTP(w, r)
+		datasetPermissions := getAuthorisationHandlerMock()
+		permissions := getAuthorisationHandlerMock()
+		api := GetAPIWithCMDMocks(mockedDataStore, generatorMock, datasetPermissions, permissions)
+		api.Router.ServeHTTP(w, r)
 
-	// 	So(w.Code, ShouldEqual, http.StatusBadRequest)
-	// 	So(w.Body.String(), ShouldEqual, "missing collection_id for association between version and a collection\n")
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Body.String(), ShouldEqual, "missing collection_id for association between version and a collection\n")
 
-	// 	So(datasetPermissions.Required.Calls, ShouldEqual, 1)
-	// 	So(permissions.Required.Calls, ShouldEqual, 0)
-	// 	So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
-	// 	So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
-	// 	So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
-	// 	So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 0)
-	// 	So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
+		So(datasetPermissions.Required.Calls, ShouldEqual, 1)
+		So(permissions.Required.Calls, ShouldEqual, 0)
+		So(len(mockedDataStore.GetVersionCalls()), ShouldEqual, 2)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 0)
+		So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 
-	// 	Convey("Then the lock has been acquired and released ", func() {
-	// 		validateLock(mockedDataStore, "789")
-	// 		So(isLocked, ShouldBeFalse)
-	// 	})
+		Convey("Then the lock has been acquired and released ", func() {
+			validateLock(mockedDataStore, "789")
+			So(isLocked, ShouldBeFalse)
+		})
 
-	// 	Convey("then the request body has been drained", func() {
-	// 		_, err := r.Body.Read(make([]byte, 1))
-	// 		So(err, ShouldEqual, io.EOF)
-	// 	})
-	// })
+		Convey("then the request body has been drained", func() {
+			_, err := r.Body.Read(make([]byte, 1))
+			So(err, ShouldEqual, io.EOF)
+		})
+	})
 
 	Convey("When setting the instance node to published fails", t, func() {
 		generatorMock := &mocks.DownloadsGeneratorMock{

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -193,11 +193,11 @@ type Version struct {
 // but it has been selected for performance as we are only interested in uniqueness.
 // ETag field value is ignored when generating a hash.
 // An optional byte array can be provided to append to the hash.
-// This can be used, for example, to calculate a hash of this filter and an update applied to it.
+// This can be used, for example, to calculate a hash of this version and an update applied to it.
 func (v *Version) Hash(extraBytes []byte) (string, error) {
 	h := sha1.New()
 
-	// copy by value to ignore ETag without affecting f
+	// copy by value to ignore ETag without affecting v
 	v2 := *v
 	v2.ETag = ""
 

--- a/models/instance.go
+++ b/models/instance.go
@@ -39,11 +39,11 @@ type Instance struct {
 // but it has been selected for performance as we are only interested in uniqueness.
 // ETag field value is ignored when generating a hash.
 // An optional byte array can be provided to append to the hash.
-// This can be used, for example, to calculate a hash of this filter and an update applied to it.
+// This can be used, for example, to calculate a hash of this instance and an update applied to it.
 func (i *Instance) Hash(extraBytes []byte) (string, error) {
 	h := sha1.New()
 
-	// copy by value to ignore ETag without affecting f
+	// copy by value to ignore ETag without affecting i
 	i2 := *i
 	i2.ETag = ""
 

--- a/mongo/dataset_test.go
+++ b/mongo/dataset_test.go
@@ -284,6 +284,7 @@ func TestVersionUpdateQuery(t *testing.T) {
 			"links.spatial.href": "http://ons.gov.uk/geographylist",
 			"state":              models.PublishedState,
 			"temporal":           &[]models.TemporalFrequency{temporal},
+			"e_tag":              "newETag",
 		}
 
 		version := &models.Version{
@@ -298,7 +299,7 @@ func TestVersionUpdateQuery(t *testing.T) {
 			Temporal: &[]models.TemporalFrequency{temporal},
 		}
 
-		selector := createVersionUpdateQuery(version)
+		selector := createVersionUpdateQuery(version, "newETag")
 		So(selector, ShouldNotBeNil)
 		So(selector, ShouldResemble, expectedUpdate)
 	})

--- a/mongo/etag.go
+++ b/mongo/etag.go
@@ -19,6 +19,14 @@ func newETagForUpdate(currentInstance *models.Instance, update *models.Instance)
 	return currentInstance.Hash(b)
 }
 
+func newETagForVersionUpdate(currentVersion *models.Version, update *models.Version) (eTag string, err error) {
+	b, err := bson.Marshal(update)
+	if err != nil {
+		return "", err
+	}
+	return currentVersion.Hash(b)
+}
+
 func newETagForAddEvent(currentInstance *models.Instance, event *models.Event) (eTag string, err error) {
 	b, err := bson.Marshal(event)
 	if err != nil {

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -47,7 +47,7 @@ type dataMongoDB interface {
 	UpdateBuildHierarchyTaskState(ctx context.Context, currentInstance *models.Instance, dimension, state, eTagSelector string) (newETag string, err error)
 	UpdateBuildSearchTaskState(ctx context.Context, currentInstance *models.Instance, dimension, state, eTagSelector string) (newETag string, err error)
 	UpdateETagForOptions(ctx context.Context, currentInstance *models.Instance, upserts []*models.CachedDimensionOption, updates []*models.DimensionOption, eTagSelector string) (newETag string, err error)
-	UpdateVersion(ctx context.Context, ID string, version *models.Version) error
+	UpdateVersion(ctx context.Context, currentVersion *models.Version, version *models.Version, eTagSelector string) (newETag string, err error)
 	UpsertContact(ctx context.Context, ID string, update interface{}) error
 	UpsertDataset(ctx context.Context, ID string, datasetDoc *models.DatasetUpdate) error
 	UpsertEdition(ctx context.Context, datasetID, edition string, editionDoc *models.EditionUpdate) error

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -123,7 +123,7 @@ var _ store.Storer = &StorerMock{}
 // 			UpdateObservationInsertedFunc: func(ctx context.Context, currentInstance *models.Instance, observationInserted int64, eTagSelector string) (string, error) {
 // 				panic("mock out the UpdateObservationInserted method")
 // 			},
-// 			UpdateVersionFunc: func(ctx context.Context, ID string, version *models.Version) error {
+// 			UpdateVersionFunc: func(ctx context.Context, currentVersion *models.Version, version *models.Version, eTagSelector string) (string, error) {
 // 				panic("mock out the UpdateVersion method")
 // 			},
 // 			UpsertContactFunc: func(ctx context.Context, ID string, update interface{}) error {
@@ -251,7 +251,7 @@ type StorerMock struct {
 	UpdateObservationInsertedFunc func(ctx context.Context, currentInstance *models.Instance, observationInserted int64, eTagSelector string) (string, error)
 
 	// UpdateVersionFunc mocks the UpdateVersion method.
-	UpdateVersionFunc func(ctx context.Context, ID string, version *models.Version) error
+	UpdateVersionFunc func(ctx context.Context, currentVersion *models.Version, version *models.Version, eTagSelector string) (string, error)
 
 	// UpsertContactFunc mocks the UpsertContact method.
 	UpsertContactFunc func(ctx context.Context, ID string, update interface{}) error
@@ -622,10 +622,12 @@ type StorerMock struct {
 		UpdateVersion []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// ID is the ID argument value.
-			ID string
+			// CurrentVersion is the currentVersion argument value.
+			CurrentVersion *models.Version
 			// Version is the version argument value.
 			Version *models.Version
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// UpsertContact holds details about calls to the UpsertContact method.
 		UpsertContact []struct {
@@ -2126,37 +2128,41 @@ func (mock *StorerMock) UpdateObservationInsertedCalls() []struct {
 }
 
 // UpdateVersion calls UpdateVersionFunc.
-func (mock *StorerMock) UpdateVersion(ctx context.Context, ID string, version *models.Version) error {
+func (mock *StorerMock) UpdateVersion(ctx context.Context, currentVersion *models.Version, version *models.Version, eTagSelector string) (string, error) {
 	if mock.UpdateVersionFunc == nil {
 		panic("StorerMock.UpdateVersionFunc: method is nil but Storer.UpdateVersion was just called")
 	}
 	callInfo := struct {
-		Ctx     context.Context
-		ID      string
-		Version *models.Version
+		Ctx            context.Context
+		CurrentVersion *models.Version
+		Version        *models.Version
+		ETagSelector   string
 	}{
-		Ctx:     ctx,
-		ID:      ID,
-		Version: version,
+		Ctx:            ctx,
+		CurrentVersion: currentVersion,
+		Version:        version,
+		ETagSelector:   eTagSelector,
 	}
 	mock.lockUpdateVersion.Lock()
 	mock.calls.UpdateVersion = append(mock.calls.UpdateVersion, callInfo)
 	mock.lockUpdateVersion.Unlock()
-	return mock.UpdateVersionFunc(ctx, ID, version)
+	return mock.UpdateVersionFunc(ctx, currentVersion, version, eTagSelector)
 }
 
 // UpdateVersionCalls gets all the calls that were made to UpdateVersion.
 // Check the length with:
 //     len(mockedStorer.UpdateVersionCalls())
 func (mock *StorerMock) UpdateVersionCalls() []struct {
-	Ctx     context.Context
-	ID      string
-	Version *models.Version
+	Ctx            context.Context
+	CurrentVersion *models.Version
+	Version        *models.Version
+	ETagSelector   string
 } {
 	var calls []struct {
-		Ctx     context.Context
-		ID      string
-		Version *models.Version
+		Ctx            context.Context
+		CurrentVersion *models.Version
+		Version        *models.Version
+		ETagSelector   string
 	}
 	mock.lockUpdateVersion.RLock()
 	calls = mock.calls.UpdateVersion

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -124,7 +124,7 @@ var _ store.MongoDB = &MongoDBMock{}
 // 			UpdateObservationInsertedFunc: func(ctx context.Context, currentInstance *models.Instance, observationInserted int64, eTagSelector string) (string, error) {
 // 				panic("mock out the UpdateObservationInserted method")
 // 			},
-// 			UpdateVersionFunc: func(ctx context.Context, ID string, version *models.Version) error {
+// 			UpdateVersionFunc: func(ctx context.Context, currentVersion *models.Version, version *models.Version, eTagSelector string) (string, error) {
 // 				panic("mock out the UpdateVersion method")
 // 			},
 // 			UpsertContactFunc: func(ctx context.Context, ID string, update interface{}) error {
@@ -252,7 +252,7 @@ type MongoDBMock struct {
 	UpdateObservationInsertedFunc func(ctx context.Context, currentInstance *models.Instance, observationInserted int64, eTagSelector string) (string, error)
 
 	// UpdateVersionFunc mocks the UpdateVersion method.
-	UpdateVersionFunc func(ctx context.Context, ID string, version *models.Version) error
+	UpdateVersionFunc func(ctx context.Context, currentVersion *models.Version, version *models.Version, eTagSelector string) (string, error)
 
 	// UpsertContactFunc mocks the UpsertContact method.
 	UpsertContactFunc func(ctx context.Context, ID string, update interface{}) error
@@ -615,10 +615,12 @@ type MongoDBMock struct {
 		UpdateVersion []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// ID is the ID argument value.
-			ID string
+			// CurrentVersion is the currentVersion argument value.
+			CurrentVersion *models.Version
 			// Version is the version argument value.
 			Version *models.Version
+			// ETagSelector is the eTagSelector argument value.
+			ETagSelector string
 		}
 		// UpsertContact holds details about calls to the UpsertContact method.
 		UpsertContact []struct {
@@ -2103,37 +2105,41 @@ func (mock *MongoDBMock) UpdateObservationInsertedCalls() []struct {
 }
 
 // UpdateVersion calls UpdateVersionFunc.
-func (mock *MongoDBMock) UpdateVersion(ctx context.Context, ID string, version *models.Version) error {
+func (mock *MongoDBMock) UpdateVersion(ctx context.Context, currentVersion *models.Version, version *models.Version, eTagSelector string) (string, error) {
 	if mock.UpdateVersionFunc == nil {
 		panic("MongoDBMock.UpdateVersionFunc: method is nil but MongoDB.UpdateVersion was just called")
 	}
 	callInfo := struct {
-		Ctx     context.Context
-		ID      string
-		Version *models.Version
+		Ctx            context.Context
+		CurrentVersion *models.Version
+		Version        *models.Version
+		ETagSelector   string
 	}{
-		Ctx:     ctx,
-		ID:      ID,
-		Version: version,
+		Ctx:            ctx,
+		CurrentVersion: currentVersion,
+		Version:        version,
+		ETagSelector:   eTagSelector,
 	}
 	mock.lockUpdateVersion.Lock()
 	mock.calls.UpdateVersion = append(mock.calls.UpdateVersion, callInfo)
 	mock.lockUpdateVersion.Unlock()
-	return mock.UpdateVersionFunc(ctx, ID, version)
+	return mock.UpdateVersionFunc(ctx, currentVersion, version, eTagSelector)
 }
 
 // UpdateVersionCalls gets all the calls that were made to UpdateVersion.
 // Check the length with:
 //     len(mockedMongoDB.UpdateVersionCalls())
 func (mock *MongoDBMock) UpdateVersionCalls() []struct {
-	Ctx     context.Context
-	ID      string
-	Version *models.Version
+	Ctx            context.Context
+	CurrentVersion *models.Version
+	Version        *models.Version
+	ETagSelector   string
 } {
 	var calls []struct {
-		Ctx     context.Context
-		ID      string
-		Version *models.Version
+		Ctx            context.Context
+		CurrentVersion *models.Version
+		Version        *models.Version
+		ETagSelector   string
 	}
 	mock.lockUpdateVersion.RLock()
 	calls = mock.calls.UpdateVersion


### PR DESCRIPTION
### What

- Added instance lock for putVersion
- Added extra `Get` after acquiring the lock - before that point, we did not know the instanceID.
- Modified unit tests accordingly

Update:
- Removed extra `Get` and used ETag in update query selector instead.
- If the update fails with NotFound error, then we do another Get + Update

trello card :https://trello.com/c/P6hJI2Zt/5429-add-lock-to-dataset-api-put-version-handler

### How to review

- Make sure code changes make sense
- Make sure unit and component tests pass

### Who can review

anyone