### PR TITLE
adding fix for issue with Must().Update whereby the MatchedCount wasn…

### DIFF
--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -258,6 +258,7 @@ func (m *Mongo) UpdateDataset(ctx context.Context, id string, dataset *models.Da
 	if result.MatchedCount == 0 {
 		return errs.ErrDatasetNotFound
 	}
+
 	return nil
 }
 
@@ -395,11 +396,12 @@ func (m *Mongo) UpdateDatasetWithAssociation(ctx context.Context, id, state stri
 		},
 	}
 
-	if _, err = m.Connection.GetConfiguredCollection().Must().UpdateById(ctx, id, update); err != nil {
-		if mongodriver.IsErrNoDocumentFound(err) {
-			return errs.ErrDatasetNotFound
-		}
+	result, err := m.Connection.GetConfiguredCollection().UpdateById(ctx, id, update)
+	if err != nil {
 		return err
+	}
+	if result.MatchedCount == 0 {
+		return errs.ErrDatasetNotFound
 	}
 
 	return nil
@@ -416,6 +418,7 @@ func (m *Mongo) UpdateVersion(ctx context.Context, id string, version *models.Ve
 	if result.MatchedCount == 0 {
 		return errs.ErrDatasetNotFound
 	}
+
 	return nil
 }
 
@@ -503,8 +506,12 @@ func (m *Mongo) RemoveDatasetVersionAndEditionLinks(ctx context.Context, id stri
 		},
 	}
 
-	if _, err := m.Connection.GetConfiguredCollection().Must().UpdateById(ctx, id, update); err != nil {
+	result, err := m.Connection.GetConfiguredCollection().UpdateById(ctx, id, update)
+	if err != nil {
 		return fmt.Errorf("failed in query to MongoDB: %w", err)
+	}
+	if result.MatchedCount == 0 {
+		return errs.ErrDatasetNotFound
 	}
 
 	return nil

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -2,7 +2,6 @@ package mongo
 
 import (
 	"context"
-
 	"github.com/ONSdigital/dp-dataset-api/config"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 


### PR DESCRIPTION

### What

There is a bug in mongodb Must().Update() whereby an incorrect ErrorNoDocument may be returned caused by not checking the MatchedCount in the returned UpdateResult.
This PR fixes this issues in dataset-api by dropping the use of Must() completely.

### How to review

Can visually see the replacement of Must and a correct check on the MatchedCount in an UpdateResult
Ensure tests are passing

### Who can review

Anyone
