### PR TITLE
add struct to pass dataset version link

### DIFF
--- a/models/metadata.go
+++ b/models/metadata.go
@@ -40,6 +40,8 @@ type Metadata struct {
 	Classifications   string               `json:"classifications,omitempty"`
 	Source            string               `json:"source,omitempty"`
 	CSVHeader         []string             `json:"headers,omitempty"`
+	Version           int                  `json:"version,omitempty"`
+	DatasetLinks      *DatasetLinks        `json:"dataset_links,omitempty"`
 }
 
 // MetadataLinks represents a link object to list of metadata relevant to a version
@@ -143,6 +145,8 @@ func CreateCantabularMetaDataDoc(d *Dataset, v *Version, urlBuilder *url.Builder
 		Contacts:      d.Contacts,
 		URI:           d.URI,
 		QMI:           d.QMI,
+		Version:       v.Version,
+		DatasetLinks:  d.Links,
 	}
 
 	m.Distribution = getDistribution(m.Downloads)

--- a/models/test_data.go
+++ b/models/test_data.go
@@ -281,5 +281,6 @@ func expectedCantabularMetadataDoc() Metadata {
 		ReleaseDate:   "2017-10-12",
 		Title:         "CensusEthnicity",
 		UnitOfMeasure: "Pounds Sterling",
+		Version:       1,
 	}
 }


### PR DESCRIPTION
### What

Add struct to enable cantabular xlsx exporter to get dataset version links (due to clash with metadata struct also having json name of 'links')

Related to this PR - https://github.com/ONSdigital/dp-api-clients-go/pull/163

### How to review

Confirm changes are correct and make sense

### Who can review

Anyone
