### PR TITLE
Fix returning of struct

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -16,6 +16,7 @@ import (
 	dprequest "github.com/ONSdigital/dp-net/v2/request"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
+	"github.com/jinzhu/copier"
 	"github.com/pkg/errors"
 )
 
@@ -374,6 +375,8 @@ func (api *DatasetAPI) detachVersion(w http.ResponseWriter, r *http.Request) {
 func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, versionDetails VersionDetails) (*models.DatasetUpdate, *models.Version, *models.Version, error) {
 	data := versionDetails.baseLogData()
 
+	reqID := ctx.Value(dprequest.RequestIdKey) // used to differentiate logs of concurrent calls to this function from different services
+
 	versionNumber, err := models.ParseAndValidateVersionNumber(ctx, versionDetails.version)
 	if err != nil {
 		log.Error(ctx, "putVersion endpoint: invalid version request", err, data)
@@ -387,7 +390,7 @@ func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, ve
 		log.Error(ctx, "putVersion endpoint: failed to model version resource based on request", err, data)
 		return nil, nil, nil, errs.ErrUnableToParseJSON
 	}
-	log.Info(ctx, "DEBUG createVersion from body", log.Data{"time": time.Since(t0)})
+	log.Info(ctx, "DEBUG createVersion from body", log.Data{"time": time.Since(t0), "reqID": reqID})
 
 	t0 = time.Now()
 	currentDataset, err := api.dataStore.Backend.GetDataset(ctx, versionDetails.datasetID)
@@ -395,14 +398,14 @@ func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, ve
 		log.Error(ctx, "putVersion endpoint: datastore.getDataset returned an error", err, data)
 		return nil, nil, nil, err
 	}
-	log.Info(ctx, "DEBUG GetDataset from mongo", log.Data{"time": time.Since(t0)})
+	log.Info(ctx, "DEBUG GetDataset from mongo", log.Data{"time": time.Since(t0), "reqID": reqID})
 
 	t0 = time.Now()
 	if err = api.dataStore.Backend.CheckEditionExists(ctx, versionDetails.datasetID, versionDetails.edition, ""); err != nil {
 		log.Error(ctx, "putVersion endpoint: failed to find edition of dataset", err, data)
 		return nil, nil, nil, err
 	}
-	log.Info(ctx, "DEBUG CheckEditionExists from mongo", log.Data{"time": time.Since(t0)})
+	log.Info(ctx, "DEBUG CheckEditionExists from mongo", log.Data{"time": time.Since(t0), "reqID": reqID})
 
 	t0 = time.Now()
 	currentVersion, err := api.dataStore.Backend.GetVersion(ctx, versionDetails.datasetID, versionDetails.edition, versionNumber, "")
@@ -411,7 +414,7 @@ func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, ve
 		log.Error(ctx, "putVersion endpoint: datastore.GetVersion returned an error", err, data)
 		return nil, nil, nil, err
 	}
-	log.Info(ctx, "DEBUG GetVersion from mongo", log.Data{"time": time.Since(t0)})
+	log.Info(ctx, "DEBUG GetVersion from mongo", log.Data{"time": time.Since(t0), "reqID": reqID})
 
 	var combinedVersionUpdate *models.Version
 
@@ -420,11 +423,11 @@ func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, ve
 	// Note that the combined version update does not mutate versionUpdate because multiple retries might generate a different value depending on the currentVersion at that point.
 	var doUpdate = func() error {
 		t0 = time.Now()
-		combinedVersionUpdate, err = populateNewVersionDoc(*currentVersion, *versionUpdate)
+		combinedVersionUpdate, err = populateNewVersionDoc(currentVersion, versionUpdate)
 		if err != nil {
 			return err
 		}
-		log.Info(ctx, "DEBUG populateNewVersionDoc (merge mongoDB doc and update)", log.Data{"time": time.Since(t0)})
+		log.Info(ctx, "DEBUG populateNewVersionDoc (merge mongoDB doc and update)", log.Data{"time": time.Since(t0), "reqID": reqID})
 		data["updated_version"] = combinedVersionUpdate
 		log.Info(ctx, "putVersion endpoint: combined current version document with update request", data)
 
@@ -433,7 +436,7 @@ func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, ve
 			log.Error(ctx, "putVersion endpoint: failed validation check for version update", err)
 			return err
 		}
-		log.Info(ctx, "DEBUG ValidateVersion", log.Data{"time": time.Since(t0)})
+		log.Info(ctx, "DEBUG ValidateVersion", log.Data{"time": time.Since(t0), "reqID": reqID})
 
 		t0 = time.Now()
 
@@ -446,7 +449,7 @@ func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, ve
 			log.Error(ctx, "putVersion endpoint: failed to update version document", err, data)
 			return err
 		}
-		log.Info(ctx, "DEBUG UpdateVersion to MongoDB", log.Data{"time": time.Since(t0), "etag": eTag})
+		log.Info(ctx, "DEBUG UpdateVersion to MongoDB", log.Data{"time": time.Since(t0), "reqID": reqID, "etag": eTag})
 
 		return nil
 	}
@@ -457,11 +460,11 @@ func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, ve
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	log.Info(ctx, "DEBUG AcquireInstanceLock", log.Data{"time": time.Since(t0)})
+	log.Info(ctx, "DEBUG AcquireInstanceLock", log.Data{"time": time.Since(t0), "reqID": reqID})
 	defer func() {
 		t0 = time.Now()
 		api.dataStore.Backend.UnlockInstance(ctx, lockID)
-		log.Info(ctx, "DEBUG UnlockInstance", log.Data{"time": time.Since(t0)})
+		log.Info(ctx, "DEBUG UnlockInstance", log.Data{"time": time.Since(t0), "reqID": reqID})
 	}()
 
 	// Try to perform the update. If there was a race condition and another caller performed the update
@@ -479,7 +482,7 @@ func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, ve
 				log.Error(ctx, "putVersion endpoint: datastore.GetVersion returned an error", err, data)
 				return nil, nil, nil, err
 			}
-			log.Info(ctx, "DEBUG (retry) GetVersion from mongo", log.Data{"time": time.Since(t0)})
+			log.Info(ctx, "DEBUG (retry) GetVersion from mongo", log.Data{"time": time.Since(t0), "reqID": reqID})
 
 			if err = doUpdate(); err != nil {
 				return nil, nil, nil, err
@@ -490,6 +493,7 @@ func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, ve
 	}
 
 	data["type"] = currentVersion.Type
+	data["reqID"] = reqID
 	log.Info(ctx, "update version completed successfully", data)
 	return currentDataset, currentVersion, combinedVersionUpdate, nil
 }
@@ -618,7 +622,10 @@ func (api *DatasetAPI) associateVersion(ctx context.Context, currentVersion, ver
 	return associateVersionErr
 }
 
-func populateNewVersionDoc(currentVersion models.Version, version models.Version) (*models.Version, error) {
+func populateNewVersionDoc(currentVersion *models.Version, originalVersion *models.Version) (*models.Version, error) {
+	var version models.Version
+	copier.Copy(&version, originalVersion) // create local copy that escapes to the HEAP at the end of this function
+
 	var alerts []models.Alert
 
 	if version.Alerts != nil {

--- a/api/versions.go
+++ b/api/versions.go
@@ -446,7 +446,6 @@ func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, ve
 		}
 
 		if _, err := api.dataStore.Backend.UpdateVersion(ctx, currentVersion, combinedVersionUpdate, eTag); err != nil {
-			log.Error(ctx, "putVersion endpoint: failed to update version document", err, data)
 			return err
 		}
 		log.Info(ctx, "DEBUG UpdateVersion to MongoDB", log.Data{"time": time.Since(t0), "reqID": reqID, "etag": eTag})
@@ -485,6 +484,7 @@ func (api *DatasetAPI) updateVersion(ctx context.Context, body io.ReadCloser, ve
 			log.Info(ctx, "DEBUG (retry) GetVersion from mongo", log.Data{"time": time.Since(t0), "reqID": reqID})
 
 			if err = doUpdate(); err != nil {
+				log.Error(ctx, "putVersion endpoint: failed to update version document on 2nd attempt", err, data)
 				return nil, nil, nil, err
 			}
 		} else {

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -2141,7 +2141,7 @@ func TestCreateNewVersionDoc(t *testing.T) {
 		versionUpdate := models.Version{
 			CollectionID: "4321",
 		}
-		combinedVersionUpdate, err := populateNewVersionDoc(currentVersion, versionUpdate)
+		combinedVersionUpdate, err := populateNewVersionDoc(&currentVersion, &versionUpdate)
 		So(err, ShouldBeNil)
 
 		Convey("Then the combined version update contains the collection_id", func() {
@@ -2165,7 +2165,7 @@ func TestCreateNewVersionDoc(t *testing.T) {
 		versionUpdate := models.Version{
 			CollectionID: "4321",
 		}
-		combinedVersionUpdate, err := populateNewVersionDoc(currentVersion, versionUpdate)
+		combinedVersionUpdate, err := populateNewVersionDoc(&currentVersion, &versionUpdate)
 		So(err, ShouldBeNil)
 
 		Convey("Then the combined version update contains the updated collection_id", func() {
@@ -2189,7 +2189,7 @@ func TestCreateNewVersionDoc(t *testing.T) {
 			CollectionID: "1234",
 		}
 		versionUpdate := models.Version{}
-		combinedVersionUpdate, err := populateNewVersionDoc(currentVersion, versionUpdate)
+		combinedVersionUpdate, err := populateNewVersionDoc(&currentVersion, &versionUpdate)
 		So(err, ShouldBeNil)
 
 		Convey("Then the combined version update contains the updated collection_id", func() {
@@ -2209,7 +2209,7 @@ func TestCreateNewVersionDoc(t *testing.T) {
 	Convey("Given empty current version and update", t, func() {
 		currentVersion := models.Version{}
 		versionUpdate := models.Version{}
-		combinedVersionUpdate, err := populateNewVersionDoc(currentVersion, versionUpdate)
+		combinedVersionUpdate, err := populateNewVersionDoc(&currentVersion, &versionUpdate)
 		So(err, ShouldBeNil)
 
 		Convey("Then the combined version is empty", func() {
@@ -2231,7 +2231,7 @@ func TestCreateNewVersionDoc(t *testing.T) {
 				},
 			},
 		}
-		combinedVersionUpdate, err := populateNewVersionDoc(currentVersion, versionUpdate)
+		combinedVersionUpdate, err := populateNewVersionDoc(&currentVersion, &versionUpdate)
 		So(err, ShouldBeNil)
 
 		Convey("Then the combined version contains the provided spatial link", func() {
@@ -2271,7 +2271,7 @@ func TestCreateNewVersionDoc(t *testing.T) {
 				},
 			},
 		}
-		combinedVersionUpdate, err := populateNewVersionDoc(currentVersion, versionUpdate)
+		combinedVersionUpdate, err := populateNewVersionDoc(&currentVersion, &versionUpdate)
 		So(err, ShouldBeNil)
 
 		Convey("Then the combined version contains the updated spatial link", func() {
@@ -2311,7 +2311,7 @@ func TestCreateNewVersionDoc(t *testing.T) {
 			},
 		}
 		versionUpdate := models.Version{}
-		combinedVersionUpdate, err := populateNewVersionDoc(currentVersion, versionUpdate)
+		combinedVersionUpdate, err := populateNewVersionDoc(&currentVersion, &versionUpdate)
 		So(err, ShouldBeNil)
 
 		Convey("Then the combined version contains the old spatial link", func() {
@@ -2345,7 +2345,7 @@ func TestCreateNewVersionDoc(t *testing.T) {
 			},
 		}
 		versionUpdate := models.Version{}
-		combinedVersionUpdate, err := populateNewVersionDoc(currentVersion, versionUpdate)
+		combinedVersionUpdate, err := populateNewVersionDoc(&currentVersion, &versionUpdate)
 		So(err, ShouldBeNil)
 
 		Convey("Then the combined version contains the old dataset link", func() {

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/cucumber/godog v0.12.3
 	github.com/google/go-cmp v0.5.6
 	github.com/gorilla/mux v1.8.0
+	github.com/jinzhu/copier v0.3.5
 	github.com/justinas/alice v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -378,6 +378,8 @@ github.com/jcmturner/gokrb5/v8 v8.4.2 h1:6ZIM6b/JJN0X8UM43ZOM6Z4SJzla+a/u7scXFJz
 github.com/jcmturner/gokrb5/v8 v8.4.2/go.mod h1:sb+Xq/fTY5yktf/VxLsE3wlfPqQjp0aWNYyvBVK62bc=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
+github.com/jinzhu/copier v0.3.5 h1:GlvfUwHk62RokgqVNvYsku0TATCF7bAHVwEXoBh3iJg=
+github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=


### PR DESCRIPTION
### What
During local integration testing with race detect operating (which changed the system dynamic) on occasions it was observed that the mongo updates were not showing state of files changing from private to public.
The problem was down to returning the address of a struct passed on the stack.
With the change, integration tests now run OK.

### How to review

Run cantabular local compose stack "./test-and-logs-by-id.sh" and observe : 
(string) (len=109) "http://minio:9000/public-bucket/datasets/cantabular-example-1-93a848d9-1405-4e26-a7bd-5d59d11b9773-2021-1.csv"
(string) (len=110) "http://minio:9000/public-bucket/datasets/cantabular-example-1-93a848d9-1405-4e26-a7bd-5d59d11b9773-2021-1.csvw"
(string) (len=109) "http://minio:9000/public-bucket/datasets/cantabular-example-1-93a848d9-1405-4e26-a7bd-5d59d11b9773-2021-1.txt"
(string) (len=110) "http://minio:9000/public-bucket/datasets/cantabular-example-1-93a848d9-1405-4e26-a7bd-5d59d11b9773-2021-1.xlsx"

ALL steps completed OK ...

### Who can review

David Subiros or Andre Urbani
