### PR TITLE
Fix csv-exporter unmarshaling errors due to incorrect schema

### DIFF
--- a/download/cantabular_generator.go
+++ b/download/cantabular_generator.go
@@ -2,14 +2,16 @@ package download
 
 import (
 	"context"
+
 	"github.com/ONSdigital/log.go/v2/log"
 )
 
 type CantabularGeneratorDownloads struct {
-	InstanceID string `avro:"instance_id"`
-	DatasetID  string `avro:"dataset_id"`
-	Edition    string `avro:"edition"`
-	Version    string `avro:"version"`
+	InstanceID     string `avro:"instance_id"`
+	DatasetID      string `avro:"dataset_id"`
+	Edition        string `avro:"edition"`
+	Version        string `avro:"version"`
+	FilterOutputID string `avro:"filter_output_id"`
 }
 
 // Generator kicks off a full dataset version download task
@@ -33,20 +35,22 @@ func (gen *CantabularGenerator) Generate(ctx context.Context, datasetID string, 
 		return versionEmptyErr
 	}
 
-	// FilterID is set to an empty string as the avro schema expects there to be
-	// a filter ID otherwise struct wont be marshalled into an acceptable message
+	// FilterOutputID is set to an empty string as the avro schema expects there to be
+	// a filter output ID otherwise struct won't be marshalled into an acceptable message
 	downloads := CantabularGeneratorDownloads{
-		DatasetID:  datasetID,
-		InstanceID: instanceID,
-		Edition:    edition,
-		Version:    version,
+		DatasetID:      datasetID,
+		InstanceID:     instanceID,
+		Edition:        edition,
+		Version:        version,
+		FilterOutputID: "",
 	}
 
 	log.Info(ctx, "send cantabular generate downloads event", log.Data{
-		"datasetID":  datasetID,
-		"instanceID": instanceID,
-		"edition":    edition,
-		"version":    version,
+		"DatasetID":      datasetID,
+		"InstanceID":     instanceID,
+		"Edition":        edition,
+		"Version":        version,
+		"FilterOutputID": "",
 	})
 
 	avroBytes, err := gen.Marshaller.Marshal(downloads)

--- a/download/cmd_generator.go
+++ b/download/cmd_generator.go
@@ -2,6 +2,7 @@ package download
 
 import (
 	"context"
+
 	"github.com/ONSdigital/log.go/v2/log"
 )
 
@@ -12,11 +13,11 @@ type CMDGenerator struct {
 }
 
 type GenerateDownloads struct {
-	FilterID   string `avro:"filter_output_id"`
-	InstanceID string `avro:"instance_id"`
-	DatasetID  string `avro:"dataset_id"`
-	Edition    string `avro:"edition"`
-	Version    string `avro:"version"`
+	FilterOutputID string `avro:"filter_output_id"`
+	InstanceID     string `avro:"instance_id"`
+	DatasetID      string `avro:"dataset_id"`
+	Edition        string `avro:"edition"`
+	Version        string `avro:"version"`
 }
 
 // Generate the full file download files for the specified dataset/edition/version
@@ -34,21 +35,22 @@ func (gen *CMDGenerator) Generate(ctx context.Context, datasetID string, instanc
 		return versionEmptyErr
 	}
 
-	// FilterID is set to an empty string as the avro schema expects there to be
-	// a filter ID otherwise struct wont be marshalled into an acceptable message
+	// FilterOutputID is set to an empty string as the avro schema expects there to be
+	// a filter output ID otherwise struct wont be marshalled into an acceptable message
 	downloads := GenerateDownloads{
-		FilterID:   "",
-		DatasetID:  datasetID,
-		InstanceID: instanceID,
-		Edition:    edition,
-		Version:    version,
+		FilterOutputID: "",
+		DatasetID:      datasetID,
+		InstanceID:     instanceID,
+		Edition:        edition,
+		Version:        version,
 	}
 
 	log.Info(ctx, "send CMD generate downloads event", log.Data{
-		"datasetID":  datasetID,
-		"instanceID": instanceID,
-		"edition":    edition,
-		"version":    version,
+		"datasetID":      datasetID,
+		"instanceID":     instanceID,
+		"edition":        edition,
+		"version":        version,
+		"FilterOutputId": "",
 	})
 
 	avroBytes, err := gen.Marshaller.Marshal(downloads)

--- a/download/cmd_generator_test.go
+++ b/download/cmd_generator_test.go
@@ -152,11 +152,11 @@ func TestGenerator_Generate(t *testing.T) {
 		version := "4"
 
 		downloads := GenerateDownloads{
-			FilterID:   "",
-			DatasetID:  datasetID,
-			InstanceID: instanceID,
-			Edition:    edition,
-			Version:    version,
+			FilterOutputID: "",
+			DatasetID:      datasetID,
+			InstanceID:     instanceID,
+			Edition:        edition,
+			Version:        version,
 		}
 
 		output := make(chan []byte, 1)

--- a/features/versions.feature
+++ b/features/versions.feature
@@ -337,8 +337,8 @@ Feature: Dataset API
             }
             """
     And these generate downloads events are produced:
-      | FilterID | InstanceID  | DatasetID            | Edition | Version |
-      |          | test-item-3 | population-estimates | hellov2 | 3       |
+      | InstanceID  | DatasetID            | Edition | Version | FilterOutputID |
+      | test-item-3 | population-estimates | hellov2 | 3       |                |
     Then the HTTP status code should be "200"
 
 
@@ -358,8 +358,8 @@ Feature: Dataset API
             }
             """
     And these cantabular generator downloads events are produced:
-      | InstanceID                | DatasetID                 | Edition | Version |
-      | test-cantabular-version-1 | test-cantabular-dataset-1 | 2021    | 1       |
+      | InstanceID                | DatasetID                 | Edition | Version | FilterOutputID |
+      | test-cantabular-version-1 | test-cantabular-dataset-1 | 2021    | 1       |                |
     Then the HTTP status code should be "200"
 
 
@@ -394,6 +394,6 @@ Feature: Dataset API
             }
             """
     And these cantabular generator downloads events are produced:
-      | InstanceID                | DatasetID                 | Edition | Version |
-      | test-cantabular-version-2 | test-cantabular-dataset-2 | 2021    | 1       |
+      | InstanceID                | DatasetID                 | Edition | Version | FilterOutputID |
+      | test-cantabular-version-2 | test-cantabular-dataset-2 | 2021    | 1       |                |
     Then the HTTP status code should be "200"

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -18,6 +18,7 @@ var generateCantabularDownloads = `{
   "type": "record",
   "name": "cantabular-export-start",
   "fields": [
+	{"name": "filter_output_id", "type": "string", "default": ""},
     {"name": "instance_id", "type": "string", "default": ""},
     {"name": "dataset_id", "type": "string", "default": ""},
     {"name": "edition", "type": "string", "default": ""},


### PR DESCRIPTION
### What

The ExportStart schema is expected to have a `FilterOutputID` and not a
`FilterID`.

Resolves: [5660](https://trello.com/c/MoJSwBOg/5660-downloads-no-longer-generating-for-cantabulartable-type)

### Who can review

Anyone
