### PR TITLE
Adding is-based-on query parameter to /datasets to allow the search o…

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -198,10 +198,10 @@ parameters:
     description: "Filter resource version, as returned by a previous ETag, to be validated; or '*' to skip the version check"
     in: header
     type: string
-  is-based-on:
-    name: is-based-on
+  is_based_on:
+    name: is_based_on
     required: false
-    description: "A population type to search on to return datasets that are associated with that population type."
+    description: "A population type to search on to return datasets that are associated with that population type e.g. Usual-Residents."
     in: query
     type: string
 securityDefinitions:
@@ -228,7 +228,7 @@ paths:
       summary: "Get a list of datasets"
       description: "Returns a list of all datasets provided by the ONS that can be filtered using the filter API"
       parameters: 
-      - $ref: '#/parameters/is-based-on'
+      - $ref: '#/parameters/is_based_on'
       - $ref: '#/parameters/limit'
       - $ref: '#/parameters/offset'
       produces:
@@ -238,6 +238,8 @@ paths:
           description: "A json list containing datasets which have been published"
           schema:
             $ref: '#/definitions/Datasets'
+        404:
+          description: "No dataset was found with the popultation-typw provided"
         500:
           $ref: '#/responses/InternalError'
   /datasets/{id}:
@@ -1147,6 +1149,8 @@ definitions:
       description:
         description: "A description for a dataset"
         type: string
+      is_based_on:
+        $ref: '#/definitions/IsBasedOn'
       keywords:
         description: "A list of keywords for a dataset"
         type: array
@@ -1248,6 +1252,18 @@ definitions:
     type: string
     enum: [filterable, nomis]
     default: "filterable"    
+  IsBasedOn:
+    description: "Information about the population-type that the dataset is based on (census 2021 only)" 
+    type: object
+    properties:
+      id:
+        description: "The population-type that the dataset is based on"
+        type: string
+        example: "Usual-Residents"
+      type:
+        description: "The type of the dataset"
+        type: string
+        example: "cantabular_table"
   Dimension:
     description: "A single dimension within a dataset"
     type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -238,8 +238,10 @@ paths:
           description: "A json list containing datasets which have been published"
           schema:
             $ref: '#/definitions/Datasets'
+        400:
+          description: "Parameter is_based_on was sent but no value was provided"
         404:
-          description: "No dataset was found with the popultation-typw provided"
+          description: "No dataset was found with the popultation-type provided"
         500:
           $ref: '#/responses/InternalError'
   /datasets/{id}:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -198,6 +198,12 @@ parameters:
     description: "Filter resource version, as returned by a previous ETag, to be validated; or '*' to skip the version check"
     in: header
     type: string
+  is-based-on:
+    name: is-based-on
+    required: false
+    description: "A population type to search on to return datasets that are associated with that population type."
+    in: query
+    type: string
 securityDefinitions:
   FlorenceAPIKey:
     name: florence-token
@@ -222,6 +228,7 @@ paths:
       summary: "Get a list of datasets"
       description: "Returns a list of all datasets provided by the ONS that can be filtered using the filter API"
       parameters: 
+      - $ref: '#/parameters/is-based-on'
       - $ref: '#/parameters/limit'
       - $ref: '#/parameters/offset'
       produces:


### PR DESCRIPTION
### What

Adding the is-based-on query parameter to /datasets endpoint to allow the searching of a population-type name on census datasets.

This will allow a query to be made on the is_based_on property in mongoDB.

### How to review

Ensure the changes make sense.

### Who can review

Anyone.