### PR TITLE
Reorder the 'cantabular-export-start' fields

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -18,11 +18,11 @@ var generateCantabularDownloads = `{
   "type": "record",
   "name": "cantabular-export-start",
   "fields": [
-	{"name": "filter_output_id", "type": "string", "default": ""},
-    {"name": "instance_id", "type": "string", "default": ""},
-    {"name": "dataset_id", "type": "string", "default": ""},
-    {"name": "edition", "type": "string", "default": ""},
-    {"name": "version", "type": "string", "default": ""}
+    {"name": "instance_id", 		"type": "string", "default": ""},
+    {"name": "dataset_id", 			"type": "string", "default": ""},
+    {"name": "edition", 			"type": "string", "default": ""},
+    {"name": "version", 			"type": "string", "default": ""},
+	{"name": "filter_output_id", 	"type": "string", "default": ""}
   ]
 }`
 


### PR DESCRIPTION
### What

This will align with the [csv-exporter schema](https://github.com/ONSdigital/dp-cantabular-csv-exporter/blob/develop/schema/schema.go#L15)

The avro/kafka message is being incorrectly unmarshalled by the
csv-exporter.

This will attempt to address that concern.

Resolve: 5660

### Who can review

Anyone
