### PR TITLE
Fixed kafka message schema

### DIFF
--- a/download/cantabular_generator.go
+++ b/download/cantabular_generator.go
@@ -7,11 +7,12 @@ import (
 )
 
 type CantabularGeneratorDownloads struct {
-	InstanceID     string `avro:"instance_id"`
-	DatasetID      string `avro:"dataset_id"`
-	Edition        string `avro:"edition"`
-	Version        string `avro:"version"`
-	FilterOutputID string `avro:"filter_output_id"`
+	InstanceID     string   `avro:"instance_id"`
+	DatasetID      string   `avro:"dataset_id"`
+	Edition        string   `avro:"edition"`
+	Version        string   `avro:"version"`
+	FilterOutputID string   `avro:"filter_output_id"`
+	Dimensions     []string `avro:"dimensions"`
 }
 
 // Generator kicks off a full dataset version download task

--- a/features/versions.feature
+++ b/features/versions.feature
@@ -358,8 +358,8 @@ Feature: Dataset API
             }
             """
     And these cantabular generator downloads events are produced:
-      | InstanceID                | DatasetID                 | Edition | Version | FilterOutputID |
-      | test-cantabular-version-1 | test-cantabular-dataset-1 | 2021    | 1       |                |
+      | InstanceID                | DatasetID                 | Edition | Version |FilterOutputID| Dimensions |
+      | test-cantabular-version-1 | test-cantabular-dataset-1 | 2021    | 1       |              | []         |
     Then the HTTP status code should be "200"
 
 
@@ -394,6 +394,6 @@ Feature: Dataset API
             }
             """
     And these cantabular generator downloads events are produced:
-      | InstanceID                | DatasetID                 | Edition | Version | FilterOutputID |
-      | test-cantabular-version-2 | test-cantabular-dataset-2 | 2021    | 1       |                |
+      | InstanceID                | DatasetID                 | Edition | Version |FilterOutputID| Dimensions |
+      | test-cantabular-version-2 | test-cantabular-dataset-2 | 2021    | 1       |              | []         |
     Then the HTTP status code should be "200"

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -18,11 +18,12 @@ var generateCantabularDownloads = `{
   "type": "record",
   "name": "cantabular-export-start",
   "fields": [
-    {"name": "instance_id", 		"type": "string", "default": ""},
-    {"name": "dataset_id", 			"type": "string", "default": ""},
-    {"name": "edition", 			"type": "string", "default": ""},
-    {"name": "version", 			"type": "string", "default": ""},
-	{"name": "filter_output_id", 	"type": "string", "default": ""}
+    {"name": "instance_id",     "type": "string", "default": ""},
+    {"name": "dataset_id",      "type": "string", "default": ""},
+    {"name": "edition",         "type": "string", "default": ""},
+    {"name": "version",         "type": "string", "default": ""},
+    {"name": "filter_output_id","type": "string", "default": ""},
+    {"name": "dimensions",      "type": { "type": "array", "items": "string"}, "default": [] }
   ]
 }`
 


### PR DESCRIPTION
### What

Fixed schema for cantabular-export-start kafka event. The events generated from dataset-api failed at consumer end as the schema were different. 

### How to review
Get this branch and on local florence when on landing page should show the option to download

### Who can review

Anyone