### PR TITLE
make IsAreaType pointer for proper omitempty behaviour

### DIFF
--- a/models/dimension.go
+++ b/models/dimension.go
@@ -14,7 +14,7 @@ type Dimension struct {
 	Name            string        `bson:"name,omitempty"              json:"name,omitempty"`
 	Variable        string        `bson:"variable,omitempty"          json:"variable,omitempty"`
 	NumberOfOptions *int          `bson:"number_of_options,omitempty" json:"number_of_options,omitempty"`
-	IsAreaType      bool          `bson:"is_area_type,omitempty"      json:"is_area_type,omitempty"`
+	IsAreaType      *bool         `bson:"is_area_type,omitempty"      json:"is_area_type,omitempty"`
 }
 
 // DimensionLink contains all links needed for a dimension


### PR DESCRIPTION
### What

Made `IsAreaType` a pointer type so a provided` false` value will be recorded in Mongo instead of ignored due to the `omitempty` bson tag

 ### How to review

Check change makes sense

### Who can review

Anyone