### PR TITLE
supports related content field in dataset model

### DIFF
--- a/features/private_datasets.feature
+++ b/features/private_datasets.feature
@@ -93,29 +93,38 @@ Feature: Private Dataset API
                 "subtopics": ["subtopic-ID"]
             }
         """
-
-    Scenario: Removing a survey from a dataset
+    
+    Scenario: Adding related content to a dataset
         Given I have these datasets:
             """
             [
                 {
-                    "id": "population-estimates",
-                    "survey": "mockSurvey"
+                    "id": "population-estimates"
                 }
             ]
             """
         When I PUT "/datasets/population-estimates"
             """
             {
-                "survey": ""
+                	"related_content": [{
+		                "description": "Related content description",
+		                "href": "http://localhost:22000/datasets/123/relatedContent",
+		                "title": "Related content"
+	                }]
             }
             """
-        Then the document in the database for id "population-estimates" should be:
-            """
+        Then the HTTP status code should be "200"
+        And the document in the database for id "population-estimates" should be:
+        """
             {
-                "id": "population-estimates"
+                "id": "population-estimates",
+                "related_content": [{
+		                "description": "Related content description",
+		                "href": "http://localhost:22000//datasets/123/relatedContent",
+		                "title": "Related content"
+	                }]
             }
-            """
+        """
 
     Scenario: GET /datasets
         Given I have these datasets:

--- a/features/public_datasets.feature
+++ b/features/public_datasets.feature
@@ -63,3 +63,24 @@ Feature: Dataset API
             }
             """
         Then the HTTP status code should be "405"
+
+    Scenario: Adding related content to a dataset
+        Given I have these datasets:
+            """
+            [
+                {
+                    "id": "population-estimates"
+                }
+            ]
+            """
+        When I PUT "/datasets/population-estimates"
+            """
+            {
+                	"related_content": [{
+		                "description": "Related content description",
+		                "href": "http://localhost:22000/datasets/123/relatedContent",
+		                "title": "Related content"
+	                }]
+            }
+            """
+        Then the HTTP status code should be "405"

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -113,6 +113,7 @@ type Dataset struct {
 	CanonicalTopic    string           `bson:"canonical_topic,omitempty"        json:"canonical_topic,omitempty"`
 	Subtopics         []string         `bson:"subtopics,omitempty"              json:"subtopics,omitempty"`
 	Survey            string           `bson:"survey,omitempty"                 json:"survey,omitempty"`
+	RelatedContent    []GeneralDetails `bson:"related_content,omitempty"        json:"related_content,omitempty"`
 }
 
 // DatasetLinks represents a list of specific links related to the dataset resource

--- a/models/dataset_test.go
+++ b/models/dataset_test.go
@@ -179,6 +179,7 @@ func TestCreateDataset(t *testing.T) {
 			So(dataset.CanonicalTopic, ShouldResemble, canonicalTopic)
 			So(dataset.Subtopics[0], ShouldResemble, subtopic)
 			So(dataset.Survey, ShouldEqual, survey)
+			So(dataset.RelatedContent, ShouldResemble, relatedContent)
 		})
 	})
 

--- a/models/test_data.go
+++ b/models/test_data.go
@@ -49,6 +49,16 @@ var subtopic = "subtopicID"
 
 var survey = "mockSurvey"
 
+var relatedContent = []GeneralDetails{{
+	Description: "related content description 1",
+	HRef:        "http://localhost:22000//datasets/123/relatedContent1",
+	Title:       "Related content 1",
+}, {
+	Description: "related content description 2",
+	HRef:        "http://localhost:22000//datasets/123/relatedContent2",
+	Title:       "Related content 2",
+}}
+
 // Create a fully populated dataset object to use in testing.
 func createTestDataset() *Dataset {
 	return &Dataset{
@@ -89,6 +99,7 @@ func createTestDataset() *Dataset {
 		CanonicalTopic:    canonicalTopic,
 		Subtopics:         []string{subtopic},
 		Survey:            survey,
+		RelatedContent:    relatedContent,
 	}
 }
 
@@ -128,6 +139,7 @@ func expectedDataset() Dataset {
 		CanonicalTopic:    canonicalTopic,
 		Subtopics:         []string{subtopic},
 		Survey:            survey,
+		RelatedContent:    relatedContent,
 	}
 }
 

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -426,6 +426,10 @@ func createDatasetUpdateQuery(ctx context.Context, id string, dataset *models.Da
 		updates["next.survey"] = dataset.Survey
 	}
 
+	if dataset.RelatedContent != nil {
+		updates["next.related_content"] = dataset.RelatedContent
+	}
+
 	log.Info(ctx, "built update query for dataset resource", log.Data{"dataset_id": id, "dataset": dataset, "updates": updates})
 	return updates
 }

--- a/mongo/dataset_test.go
+++ b/mongo/dataset_test.go
@@ -185,6 +185,16 @@ func TestDatasetUpdateQuery(t *testing.T) {
 
 		survey := "mockSurvey"
 
+		relatedContent := []models.GeneralDetails{{
+			Description: "related content description 1",
+			HRef:        "http://localhost:22000//datasets/123/relatedContent1",
+			Title:       "Related content 1",
+		}, {
+			Description: "related content description 2",
+			HRef:        "http://localhost:22000//datasets/123/relatedContent2",
+			Title:       "Related content 2",
+		}}
+
 		var methodologies, publications, relatedDatasets []models.GeneralDetails
 		methodologies = append(methodologies, methodology)
 		publications = append(publications, publication)
@@ -218,6 +228,7 @@ func TestDatasetUpdateQuery(t *testing.T) {
 			"next.canonical_topic":          canonicalTopic,
 			"next.subtopics":                subtopics,
 			"next.survey":                   survey,
+			"next.related_content":			 relatedContent,
 		}
 
 		dataset := &models.Dataset{
@@ -251,6 +262,7 @@ func TestDatasetUpdateQuery(t *testing.T) {
 			CanonicalTopic:    canonicalTopic,
 			Subtopics:         subtopics,
 			Survey:            survey,
+			RelatedContent:    relatedContent,
 		}
 
 		selector := createDatasetUpdateQuery(testContext, "123", dataset, models.CreatedState)


### PR DESCRIPTION
### What

Adds related content field to dataset model, and updates test to reflect this new feature (developed for the Cantabular metadata journey).

### How to review

Read the code, run the unit tests, check and run the component tests.

### Who can review

Anyone