### PR TITLE
Remove links.versions

### DIFF
--- a/features/versions.feature
+++ b/features/versions.feature
@@ -173,10 +173,6 @@ Feature: Dataset API
                         },
                         "self": {
                             "href": "someurl"
-                        },
-                        "version": {
-                          "id": "1",
-                          "href": "someurl"
                         }
                     },
                     "edition": "2021",


### PR DESCRIPTION
### What

Remove links.versions from the loaded version data as they are ignored and never stored in database. See https://github.com/ONSdigital/dp-dataset-api/blob/00c24a5a02a0c68fcfe3f2d26a221cd9d9c488bd/models/dataset.go#L293

Keeping it only creates confusion. A call to the `these versions need to be published:` step is required if we do want to have links versions in database.

### How to review

Component tests pass

### Who can review

Anyone
