### PR TITLE
Add IsBasedOn to Metadata model for both generic and cantabular datasets

### DIFF
--- a/models/metadata.go
+++ b/models/metadata.go
@@ -45,6 +45,7 @@ type Metadata struct {
 	Version           int                  `json:"version,omitempty"`
 	DatasetLinks      *DatasetLinks        `json:"dataset_links,omitempty"`
 	RelatedContent    []GeneralDetails     `json:"related_content,omitempty"`
+	IsBasedOn         *IsBasedOn           `json:"is_based_on,omitempty"`
 }
 
 // MetadataLinks represents a link object to list of metadata relevant to a version
@@ -84,6 +85,7 @@ func CreateMetaDataDoc(datasetDoc *Dataset, versionDoc *Version, urlBuilder *url
 		UnitOfMeasure:     datasetDoc.UnitOfMeasure,
 		URI:               datasetDoc.URI,
 		UsageNotes:        versionDoc.UsageNotes,
+		IsBasedOn:         datasetDoc.IsBasedOn,
 	}
 
 	// Add relevant metdata links from dataset document
@@ -184,6 +186,7 @@ func CreateCantabularMetaDataDoc(d *Dataset, v *Version, urlBuilder *url.Builder
 		URI:            d.URI,
 		QMI:            d.QMI,
 		Version:        v.Version,
+		IsBasedOn:      d.IsBasedOn,
 	}
 
 	m.Distribution = getDistribution(v.Downloads)

--- a/models/metadata_test.go
+++ b/models/metadata_test.go
@@ -37,6 +37,10 @@ func TestCreateMetadata(t *testing.T) {
 			},
 			ReleaseFrequency: "yearly",
 			Theme:            "population",
+			IsBasedOn: &IsBasedOn{
+				ID:   "UR_HH",
+				Type: "All usual residents in households",
+			},
 			Links: &DatasetLinks{
 				AccessRights: &LinkObject{
 					HRef: "href-access-rights",
@@ -154,6 +158,11 @@ func TestCreateMetadata(t *testing.T) {
 				So(metaDataDoc.Downloads.XLSX.Size, ShouldEqual, xlsxDownload.Size)
 				So(metaDataDoc.Downloads.XLSX.Private, ShouldEqual, xlsxDownload.Private) // TODO: Should it be cleared?
 				So(metaDataDoc.Downloads.XLSX.Public, ShouldEqual, xlsxDownload.Public)   // TODO: Should it be cleared?
+				So(metaDataDoc.IsBasedOn, ShouldResemble, &IsBasedOn{
+					ID:   "UR_HH",
+					Type: "All usual residents in households",
+				})
+				So(metaDataDoc.Version, ShouldEqual, 1)
 
 				// TODO: Should it include xlsx?
 				So(metaDataDoc.Distribution, ShouldResemble, []string{"json", "csv", "csvw", "xls", "txt"})
@@ -236,6 +245,10 @@ func TestCreateMetadata(t *testing.T) {
 					websiteUrl, dataset.ID, version.Links.Edition.ID, version.Version)
 				So(metaDataDoc.Links.WebsiteVersion.HRef, ShouldEqual, expectedWebsiteHref)
 				So(metaDataDoc.Links.WebsiteVersion.ID, ShouldEqual, "")
+				So(metaDataDoc.IsBasedOn, ShouldResemble, &IsBasedOn{
+					ID:   "UR_HH",
+					Type: "All usual residents in households",
+				})
 
 				// TODO: Should it include xlsx?
 				So(metaDataDoc.Distribution, ShouldResemble, []string{"json", "csv", "csvw", "xls", "txt"})
@@ -249,5 +262,4 @@ func TestCreateMetadata(t *testing.T) {
 			})
 		})
 	})
-
 }


### PR DESCRIPTION
### What

Trello card: https://trello.com/c/0F6ifzuo/1257-extend-metadata-endpoint-to-return-cantabular-dataset-metadata

- Add `IsBasedOn` to Metadat model
- Map it from the dataset struct for both generic and cantabular datasets.

Missing values in Cantabular metadata have not been mapped, as there was a test to explicitly validate that they are not mapped.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

Anyone
