### PR TITLE
Returns etag in the getVersion response header

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/models"
+	dpresponse "github.com/ONSdigital/dp-net/v2/handlers/response"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
 	dprequest "github.com/ONSdigital/dp-net/v2/request"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -205,7 +206,7 @@ func (api *DatasetAPI) getVersion(w http.ResponseWriter, r *http.Request) {
 
 	setJSONContentType(w)
 	if v.ETag != "" {
-		w.Header().Add("Etag", v.ETag)
+		dpresponse.SetETag(w, v.ETag)
 	}
 
 	versionBytes, err := json.Marshal(v)

--- a/api/versions.go
+++ b/api/versions.go
@@ -210,7 +210,9 @@ func (api *DatasetAPI) getVersion(w http.ResponseWriter, r *http.Request) {
 	}
 
 	setJSONContentType(w)
-	w.Header().Add("Etag", eTag)
+	if eTag != "" {
+		w.Header().Add("Etag", eTag)
+	}
 
 	_, err := w.Write(b)
 	if err != nil {

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -232,6 +232,7 @@ func TestGetVersionsReturnsError(t *testing.T) {
 func TestGetVersionReturnsOK(t *testing.T) {
 	t.Parallel()
 	Convey("A successful request to get version returns 200 OK response", t, func() {
+		etag := "version-etag"
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678/versions/1", nil)
 
 		w := httptest.NewRecorder()
@@ -251,6 +252,7 @@ func TestGetVersionReturnsOK(t *testing.T) {
 							HRef: "href",
 						},
 					},
+					ETag: etag,
 				}, nil
 			},
 		}
@@ -261,6 +263,7 @@ func TestGetVersionReturnsOK(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
+		So(w.Header().Get("Etag"), ShouldEqual, etag)
 		So(datasetPermissions.Required.Calls, ShouldEqual, 1)
 		So(permissions.Required.Calls, ShouldEqual, 0)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)

--- a/dimension/dimension.go
+++ b/dimension/dimension.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store"
 	"github.com/ONSdigital/dp-dataset-api/utils"
+	dpresponse "github.com/ONSdigital/dp-net/v2/handlers/response"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
 	dprequest "github.com/ONSdigital/dp-net/v2/request"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -75,7 +76,7 @@ func (s *Store) GetDimensionsHandler(w http.ResponseWriter, r *http.Request, lim
 	}
 
 	log.Info(ctx, "successfully get dimensions for an instance resource", logData)
-	setETag(w, instance.ETag)
+	dpresponse.SetETag(w, instance.ETag)
 	return dimensions, totalCount, nil
 }
 
@@ -129,7 +130,7 @@ func (s *Store) GetUniqueDimensionAndOptionsHandler(w http.ResponseWriter, r *ht
 	}
 
 	log.Info(ctx, "successfully get unique dimension options for an instance resource", logData)
-	setETag(w, instance.ETag)
+	dpresponse.SetETag(w, instance.ETag)
 	return slicedOptions, totalCount, nil
 }
 
@@ -168,7 +169,7 @@ func (s *Store) AddHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Info(ctx, "added dimension to instance resource", logData)
 
-	setETag(w, newETag)
+	dpresponse.SetETag(w, newETag)
 }
 
 // PatchDimensionsHandler represents adding multiple dimensions to a specific instance
@@ -208,7 +209,7 @@ func (s *Store) PatchDimensionsHandler(w http.ResponseWriter, r *http.Request) {
 
 	// set content type and write response body
 	setJSONPatchContentType(w)
-	setETag(w, newETag)
+	dpresponse.SetETag(w, newETag)
 	writeBody(ctx, w, b, logData)
 	log.Info(ctx, "successfully patched dimensions of an instance resource", logData)
 }
@@ -433,7 +434,7 @@ func (s *Store) PatchOptionHandler(w http.ResponseWriter, r *http.Request) {
 
 	// set content type and write response body
 	setJSONPatchContentType(w)
-	setETag(w, newETag)
+	dpresponse.SetETag(w, newETag)
 	writeBody(ctx, w, b, logData)
 	log.Info(ctx, "successfully patched dimension option of an instance resource", logData)
 }
@@ -511,5 +512,5 @@ func (s *Store) AddNodeIDHandler(w http.ResponseWriter, r *http.Request) {
 
 	logData["action"] = AddDimensionAction
 	log.Info(ctx, "added node id to dimension of an instance resource", logData)
-	setETag(w, newETag)
+	dpresponse.SetETag(w, newETag)
 }

--- a/dimension/helpers.go
+++ b/dimension/helpers.go
@@ -152,10 +152,6 @@ func setJSONPatchContentType(w http.ResponseWriter) {
 	w.Header().Add("Content-Type", "application/json-patch+json")
 }
 
-func setETag(w http.ResponseWriter, eTag string) {
-	w.Header().Add("ETag", eTag)
-}
-
 func writeBody(ctx context.Context, w http.ResponseWriter, b []byte, data log.Data) {
 	if _, err := w.Write(b); err != nil {
 		log.Error(ctx, "failed to write response body", err, data)

--- a/instance/dimensions.go
+++ b/instance/dimensions.go
@@ -7,6 +7,7 @@ import (
 
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/models"
+	dpresponse "github.com/ONSdigital/dp-net/v2/handlers/response"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
@@ -107,5 +108,5 @@ func (s *Store) UpdateDimension(w http.ResponseWriter, r *http.Request) {
 
 	log.Info(ctx, "updated instance dimension: request successful", logData)
 
-	setETag(w, newETag)
+	dpresponse.SetETag(w, newETag)
 }

--- a/instance/event.go
+++ b/instance/event.go
@@ -8,6 +8,7 @@ import (
 
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/models"
+	dpresponse "github.com/ONSdigital/dp-net/v2/handlers/response"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
 )
@@ -73,5 +74,5 @@ func (s *Store) AddEvent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Info(ctx, "add instance event: request successful", data)
-	setETag(w, newETag)
+	dpresponse.SetETag(w, newETag)
 }

--- a/instance/import.go
+++ b/instance/import.go
@@ -11,6 +11,7 @@ import (
 
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/models"
+	dpresponse "github.com/ONSdigital/dp-net/v2/handlers/response"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
@@ -56,7 +57,7 @@ func (s *Store) UpdateObservations(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Info(ctx, "update imported observations: request successful", logData)
-	setETag(w, newETag)
+	dpresponse.SetETag(w, newETag)
 }
 
 // UpdateImportTask updates any task in the request body against an instance
@@ -190,7 +191,7 @@ func (s *Store) UpdateImportTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Info(ctx, "updateImportTask endpoint: request successful", logData)
-	setETag(w, eTag)
+	dpresponse.SetETag(w, eTag)
 }
 
 func unmarshalImportTasks(reader io.Reader) (*models.InstanceImportTasks, error) {

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/mongo"
 	"github.com/ONSdigital/dp-dataset-api/store"
+	dpresponse "github.com/ONSdigital/dp-net/v2/handlers/response"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
@@ -21,7 +22,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-//Store provides a backend for instances
+// Store provides a backend for instances
 type Store struct {
 	store.Storer
 	Host                string
@@ -40,7 +41,7 @@ func (e taskError) Error() string {
 	return ""
 }
 
-//GetList returns a list of instances, the total count of instances that match the query parameters and an error
+// GetList returns a list of instances, the total count of instances that match the query parameters and an error
 func (s *Store) GetList(w http.ResponseWriter, r *http.Request, limit int, offset int) (interface{}, int, error) {
 	ctx := r.Context()
 	stateFilterQuery := r.URL.Query().Get("state")
@@ -125,7 +126,7 @@ func (s *Store) Get(w http.ResponseWriter, r *http.Request) {
 	}
 
 	setJSONContentType(w)
-	setETag(w, instance.ETag)
+	dpresponse.SetETag(w, instance.ETag)
 	writeBody(ctx, w, b, logData)
 	log.Info(ctx, "get instance: request successful", logData)
 }
@@ -169,7 +170,7 @@ func (s *Store) Add(w http.ResponseWriter, r *http.Request) {
 	}
 
 	setJSONContentType(w)
-	setETag(w, instance.ETag)
+	dpresponse.SetETag(w, instance.ETag)
 	w.WriteHeader(http.StatusCreated)
 	writeBody(ctx, w, b, logData)
 
@@ -305,7 +306,7 @@ func (s *Store) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	setJSONContentType(w)
-	setETag(w, newETag)
+	dpresponse.SetETag(w, newETag)
 	w.WriteHeader(http.StatusOK)
 	writeBody(ctx, w, b, logData)
 
@@ -452,10 +453,6 @@ func getIfMatch(r *http.Request) string {
 		return mongo.AnyETag
 	}
 	return ifMatch
-}
-
-func setETag(w http.ResponseWriter, eTag string) {
-	w.Header().Set("ETag", eTag)
 }
 
 func writeBody(ctx context.Context, w http.ResponseWriter, b []byte, logData log.Data) {


### PR DESCRIPTION
### What

- returns the `Etag`, if set, in the response header of the `getVersion` request
- refactor to avoid code duplication and use function from dp-net to set etag headers

### How to review

- check code and make sure the unit and component tests pass

### Who can review

Not me nor Valentina
