### PR TITLE
Update swagger spec

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -429,6 +429,10 @@ paths:
           description: "A json object containing the edition and version of a dataset"
           schema:
             $ref: '#/definitions/Version'
+          headers:
+            ETag:
+              type: string
+              description: "Defines the unique etag for this resource"
         400:
           description: |
             Invalid request, reasons can be one of the following:


### PR DESCRIPTION
### What

Add the `Etag` response header to the swagger definition of the GET version endpoint

Missed from https://github.com/ONSdigital/dp-dataset-api/pull/416

### How to review

Ensure spec is correct and aligns with implementation

### Who can review

Anyone
