### PR TITLE
Spike a /distributions endpoint in spec to reduce /version size

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -484,6 +484,33 @@ paths:
           description: "No version was found for an edition of a dataset using the id, edition and version provided"
         500:
           $ref: '#/responses/InternalError'
+  /datasets/{identifier}/editions/{edition}/versions/{version}/distributions:
+    get:
+      tags:
+      - "Public"
+      summary: "Get a list of dimensions from a dataset"
+      description: "Get all dimensions which are used in the dataset"
+      parameters:
+      - $ref: '#/parameters/edition'
+      - $ref: '#/parameters/identifier'
+      - $ref: '#/parameters/version'
+      - $ref: '#/parameters/limit'
+      - $ref: '#/parameters/offset'
+      responses:
+        200:
+          description: "A json list of distributions"
+          schema:
+            $ref: '#/definitions/Distributions'
+        400:
+          description: |
+            Invalid request, reasons can be one of the following:
+              * dataset id was incorrect
+              * edition was incorrect
+              * version was incorrect
+        404:
+          description: "No distributions found for version of an edition of a dataset using the id, edition and version provided"
+        500:
+          $ref: '#/responses/InternalError'
   /datasets/{identifier}/editions/{edition}/versions/{version}/dimensions:
     get:
       tags:
@@ -992,9 +1019,7 @@ definitions:
           type: array
           items:
             type: string
-  dcatVersionCore:
-    description: "core quality, mangement and relationship fields for describing a dcat:dataset version. Used by both list and resource endpoints"
-    type: object
+  dcatDistributionCore:
     properties:
       distributions:
         description: "A selection of download objects containing information of downloadable files."
@@ -1007,6 +1032,21 @@ definitions:
                   description: "spdx:checksum - some guarantees, hence not etag. Could be a more complex object?"
                   type: string
             - $ref: '#/definitions/DownloadObject'
+  dcatVersionCore:
+    description: "core quality, mangement and relationship fields for describing a dcat:dataset version. Used by both list and resource endpoints"
+    type: object
+    properties:
+      # distributions:
+      #   description: "A selection of download objects containing information of downloadable files."
+      #   type: array
+      #   items:
+      #     allOf:
+      #       - type: object
+      #         properties:
+      #           checksum:
+      #             description: "spdx:checksum - some guarantees, hence not etag. Could be a more complex object?"
+      #             type: string
+      #       - $ref: '#/definitions/DownloadObject'
       version:
         description: "A number identifying the version for an edition from a dataset"
         example: 1
@@ -1029,13 +1069,13 @@ definitions:
         previous_version:
           type: string
           format: uri
-        distributions:
-          description: "A selection of download objects containing information of downloadable files."
-          type: array
-          items:
-            allOf:
-              - $ref: '#/definitions/CSVDownload'
-              - $ref: '#/definitions/DownloadObject'
+        # distributions:
+        #   description: "A selection of download objects containing information of downloadable files."
+        #   type: array
+        #   items:
+        #     allOf:
+        #       - $ref: '#/definitions/CSVDownload'
+        #       - $ref: '#/definitions/DownloadObject'
   Datasets:
     description: "A list of datasets"
     type: object
@@ -1083,7 +1123,9 @@ definitions:
   LDType:
     description: "The linked data vocabulary term for a dataset"
     default: "dcat:dataset"
-    type: string
+    type: array
+    items:
+      type: string
   Dataset:
     description: "The dataset"
     type: object
@@ -1332,6 +1374,34 @@ definitions:
         value:
           description: "A list of dimenions that will be added to the instance."
           example: "[{\"dimension\": \"dim1\", \"option\": \"op1\"}, {\"dimension\": \"dim1\", \"option\": \"op2\"}, {\"op\": \"add\", \"path\": \"/dim1/options/op1/order\", \"value\": 3}, {\"op\": \"add\", \"path\": \"/dim1/options/op2/node_id\", \"value\": \"node123\"}]"
+  Distributions:
+    type: object
+    allOf:
+      - $ref: '#/definitions/ListPagination'
+      - type: object
+        properties:
+          "@context":
+            $ref: '#/definitions/LDContext'
+          items:
+            type: array
+            items:
+              allOf:
+              - $ref: '#/definitions/CSVDownload'
+              - $ref: '#/definitions/DownloadObject'
+              - type: object
+                properties:
+                  etag:
+                    type: string
+                  "@type":
+                    allOf:
+                    - $ref: '#/definitions/LDType'
+                    - default: 'dcat:distribution'
+                  _links:
+                    properties:
+                      self:
+                        $ref: '#/links/Self'
+                      version:
+                        $ref: '#/links/Version'
   CSVDownload:
     description: "Additional fields available for CSV downloads"
     type: object
@@ -1402,6 +1472,10 @@ definitions:
                     type: array
                     items: 
                       type: string
+            latest_distributions:
+              type: array
+              items:
+                $ref: '#/definitions/dcatDistributionCore'
         is_based_on:
           $ref: '#/definitions/IsBasedOn'
         _links:
@@ -1606,17 +1680,17 @@ definitions:
             #   type: string
             title:
               type: string
-            property_url:
-              type: string
-              format: url
-            value_url:
-              type: string
-              format: url
-            codelist_url:
-              type: string
-              format: url
-            sub_property_of:
-              type: string
+            # property_url:
+            #   type: string
+            #   format: url
+            # value_url:
+            #   type: string
+            #   format: url
+            # codelist_url:
+            #   type: string
+            #   format: url
+            # sub_property_of:
+            #   type: string
   UpdateDatasetResponse:
     description: "A model for the response body when creating a new dataset"
     type: object
@@ -1684,9 +1758,15 @@ definitions:
         is_based_on:
           $ref: '#/definitions/IsBasedOn'
         _embedded:
-          type: array
-          items:
-              $ref: '#/definitions/DimensionCore'
+          properties:
+            dimensions:
+              type: array
+              items:
+                $ref: '#/definitions/DimensionCore'
+            distributions:
+              type: array
+              items:
+                $ref: '#/definitions/dcatDistributionCore'
         _links:
           $ref: '#/links/VersionLinks'
         type:


### PR DESCRIPTION
### What

Fundamentally, we face an issue with the complexity of returning dcat:dataset and dcat:distribution details as one joined response while meeting API user expectations. The issue is the nested table_schema within the distribution within the dataset. Having 3 layers of nested document on /editions/<id> creates a very messy API, and suggests that _at least one_ of those nested resources is a sub resource of another. As dcat:distribution is a known resource type, this is an attempt to see if the API could mirror that distinction while still providing utility for users.


This means /versions/<id> has no top level `distribution` or `table_schema` object, this is instead embedded like this
```json
"_embedded": {
    "dimensions": [
      {
        "code_list": "string",
        "identifier": "string",
        "label": "string",
        "name": "string"
      }
    ],
    "distributions": [
      {
        "distributions": [
          {
            "checksum": "string",
            "@id": "string",
            "byte_size": "string",
            "media_type": "string",
            "download_url": "string"
          }
        ]
      }
    ]
  },
```
The dimensions list is there for census reasons, relocated from previous top level field.

But that more complete view of distributions and table_schema for CSV distros is available on a `/distributions` endpoint with this response type:
```json
{
  "_links": {
    "self": {
      "href": "string"
    },
    "next": {
      "href": "string"
    },
    "prev": {
      "href": "string"
    }
  },
  "count": 0,
  "limit": 0,
  "offset": 0,
  "total_count": 0,
  "@context": "string",
  "items": [
    {
      "checksum": "string",
      "described_by": "string",
      "table_schema": {
        "about_url": "string",
        "column": [
          {
            "component_type": "string",
            "datatype": "string",
            "name": "string",
            "title": "string"
          }
        ]
      },
      "@id": "string",
      "byte_size": "string",
      "media_type": "string",
      "download_url": "string",
      "etag": "string",
      "@type": "dcat:distribution",
      "_links": {
        "self": {
          "href": "string"
        },
        "version": {
          "href": "string",
          "id": "string"
        }
      }
    }
  ]
}
```


### How to review

There are 3 main issues with this approach that I think I need feedback on:
1) LD users rely on information in the _embedded fields to get the full picture. I don't see this as too big an issue right now, we did accept that this was something we would trial and get feedback on, but we're leveraging it more so just flagging
2) These _embedded fields are _changing_ between the /editions/<id> and /versions/<id> endpoints, despite being part of the same `dcat:dataset` resource being represented (/editions/<id> embeds `versions` and `distributions`, /versions/<id> embeds `dimensions` and `distributions` - just based on my best guess of what would be useful). On the one hand we said the HAL fields _embedded and _links are generated and so it's acceptable for these to change between endpoints, but if they're forming part of the dcat resource is that still the case?
3) Because we decided that _embedded fields should never be returned in list responses, calls to /editions and /versions will never include download links unless we revise this principle.

### Who can review

@janderson2 @rossbowen 
