### PR TITLE
Feature/links middleware poc

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,8 +1,10 @@
-FROM golang:1.22.6-bullseye as build
+FROM golang:1.23-bullseye as build
 
 ENV GOCACHE=/go/.go/cache GOPATH=/go/.go/path TZ=Europe/London
 
 RUN GOBIN=/bin go install github.com/cespare/reflex@latest
+
+RUN git config --global --add safe.directory /go
 
 # Map between the working directories of dev and live
 RUN ln -s /go /dp-dataset-api

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -527,51 +527,25 @@ func mapResultsAndRewriteLinks(ctx context.Context, results []*models.DatasetUpd
 }
 
 func rewriteAllLinks(ctx context.Context, oldLinks *models.DatasetLinks) error {
-	if oldLinks.AccessRights != nil && oldLinks.AccessRights.HRef != "" {
-		accessRights, err := links.URLBuild(ctx, oldLinks.AccessRights.HRef)
-		if err != nil {
-			log.Error(ctx, "error rewriting AccessRights link", err)
-			return err
-		}
-		oldLinks.AccessRights.HRef = accessRights
+	prevLinks := []*models.LinkObject{
+		oldLinks.AccessRights,
+		oldLinks.Editions,
+		oldLinks.LatestVersion,
+		oldLinks.Self,
+		oldLinks.Taxonomy,
 	}
 
-	if oldLinks.Editions != nil && oldLinks.Editions.HRef != "" {
-		editions, err := links.URLBuild(ctx, oldLinks.Editions.HRef)
-		if err != nil {
-			log.Error(ctx, "error rewriting Editions link", err)
-			return err
-		}
-		oldLinks.Editions.HRef = editions
-	}
+	var err error
 
-	if oldLinks.LatestVersion != nil && oldLinks.LatestVersion.HRef != "" {
-		latestVersion, err := links.URLBuild(ctx, oldLinks.LatestVersion.HRef)
-		if err != nil {
-			log.Error(ctx, "error rewriting LatestVersion link", err)
-			return err
+	for _, link := range prevLinks {
+		if link != nil && link.HRef != "" {
+			link.HRef, err = links.URLBuild(ctx, link.HRef)
+			if err != nil {
+				log.Error(ctx, "error rewriting link", err, log.Data{"link": link.HRef})
+				return err
+			}
 		}
-		oldLinks.LatestVersion.HRef = latestVersion
 	}
-
-	if oldLinks.Self != nil && oldLinks.Self.HRef != "" {
-		self, err := links.URLBuild(ctx, oldLinks.Self.HRef)
-		if err != nil {
-			log.Error(ctx, "error rewriting Self link", err)
-			return err
-		}
-		oldLinks.Self.HRef = self
-	}
-
-	if oldLinks.Taxonomy != nil && oldLinks.Taxonomy.HRef != "" {
-		taxonomy, err := links.URLBuild(ctx, oldLinks.Taxonomy.HRef)
-		if err != nil {
-			log.Error(ctx, "error rewriting Taxonomy link", err)
-			return err
-		}
-		oldLinks.Taxonomy.HRef = taxonomy
-	}
-
 	return nil
 }
 

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -488,31 +488,16 @@ func (api *DatasetAPI) deleteDataset(w http.ResponseWriter, r *http.Request) {
 func mapResultsAndRewriteLinks(ctx context.Context, results []*models.DatasetUpdate, authorised bool) ([]*models.Dataset, error) {
 	items := []*models.Dataset{}
 	for _, item := range results {
-		if authorised && item.Current == nil && item.Next != nil {
-			item.Next.ID = item.ID
-			err := rewriteAllLinks(ctx, item.Next.Links)
+		if item.Current != nil {
+			err := rewriteAllLinks(ctx, item.Current.Links)
 			if err != nil {
-				log.Error(ctx, "unable to rewrite 'next' links", err)
+				log.Error(ctx, "unable to rewrite 'current' links", err)
 				return nil, err
 			}
-			items = append(items, item.Next)
-			continue
+			items = append(items, item.Current)
 		}
-
-		if item.Current == nil {
-			continue
-		}
-
-		item.Current.ID = item.ID
-		err := rewriteAllLinks(ctx, item.Current.Links)
-		if err != nil {
-			log.Error(ctx, "unable to rewrite 'current' links", err)
-			return nil, err
-		}
-		items = append(items, item.Current)
 
 		if authorised && item.Next != nil {
-			item.Next.ID = item.ID
 			err := rewriteAllLinks(ctx, item.Next.Links)
 			if err != nil {
 				log.Error(ctx, "unable to rewrite 'next' links", err)
@@ -523,7 +508,6 @@ func mapResultsAndRewriteLinks(ctx context.Context, results []*models.DatasetUpd
 	}
 
 	return items, nil
-
 }
 
 func rewriteAllLinks(ctx context.Context, oldLinks *models.DatasetLinks) error {

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -189,11 +189,11 @@ func (api *DatasetAPI) addDataset(w http.ResponseWriter, r *http.Request) {
 		}
 
 		dataset.Links.Editions = &models.LinkObject{
-			HRef: fmt.Sprintf("%s/datasets/%s/editions", api.host, datasetID),
+			HRef: fmt.Sprintf("/datasets/%s/editions", datasetID),
 		}
 
 		dataset.Links.Self = &models.LinkObject{
-			HRef: fmt.Sprintf("%s/datasets/%s", api.host, datasetID),
+			HRef: fmt.Sprintf("/datasets/%s", datasetID),
 		}
 
 		// Remove latest version from new dataset resource, this cannot be added at this point

--- a/api/dimensions.go
+++ b/api/dimensions.go
@@ -78,6 +78,8 @@ func (api *DatasetAPI) getDimensions(w http.ResponseWriter, r *http.Request, lim
 			slicedResults = utils.Slice(results, offset, limit)
 		}
 
+		// TODO - rewrite links before returning results
+
 		return slicedResults, len(dimensions), nil
 	}()
 	if err != nil {
@@ -209,6 +211,8 @@ func (api *DatasetAPI) getDimensionOptions(w http.ResponseWriter, r *http.Reques
 		results[i].Links.Version.HRef = versionHref
 		results[i].Links.Version.ID = versionID
 	}
+
+	// TODO - rewrite links before returning results
 
 	return results, totalCount, nil
 }

--- a/api/editions.go
+++ b/api/editions.go
@@ -50,6 +50,7 @@ func (api *DatasetAPI) getEditions(w http.ResponseWriter, r *http.Request, limit
 		return nil, 0, err
 	}
 
+	// TODO - rewrite links before returning results
 	if authorised {
 		log.Info(ctx, "getEditions endpoint: get all edition with auth", logData)
 		return results, totalCount, nil
@@ -90,6 +91,8 @@ func (api *DatasetAPI) getEdition(w http.ResponseWriter, r *http.Request) {
 		}
 
 		var b []byte
+
+		// TODO - rewrite links before returning results
 
 		if authorised {
 			// User has valid authentication to get raw edition document

--- a/api/metadata.go
+++ b/api/metadata.go
@@ -108,6 +108,8 @@ func (api *DatasetAPI) getMetadata(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		// TODO - rewrite links before returning results, Download links also included here
+
 		b, err := json.Marshal(metaDataDoc)
 		if err != nil {
 			log.Error(ctx, "getMetadata endpoint: failed to marshal metadata resource into bytes", err, logData)

--- a/api/versions.go
+++ b/api/versions.go
@@ -88,6 +88,7 @@ func (api *DatasetAPI) getVersions(w http.ResponseWriter, r *http.Request, limit
 			return nil, 0, err
 		}
 
+		// TODO - rewrite links before returning results, Download links also included here
 		results, totalCount, err := api.dataStore.Backend.GetVersions(ctx, datasetID, edition, state, offset, limit)
 		if err != nil {
 			log.Error(ctx, "failed to find any versions for dataset edition", err, logData)
@@ -172,6 +173,7 @@ func (api *DatasetAPI) getVersion(w http.ResponseWriter, r *http.Request) {
 			return nil, err
 		}
 
+		// TODO - rewrite links before returning results, Download links also included here
 		version, err := api.dataStore.Backend.GetVersion(ctx, datasetID, edition, versionID, state)
 		if err != nil {
 			log.Error(ctx, "failed to find version for dataset edition", err, logData)


### PR DESCRIPTION
### What

Added middleware into service
Added functions for rewriting links (currently working for endpoint /datasets only)

### How to review

Dp-api-router and dp-net must both be on the feature/links-middleware-poc branch.
Use dataset-catalogue stack to test endpoints within dataset-api.

these lines must be added to go.mod:
`replace go.opentelemetry.io/otel/trace => go.opentelemetry.io/otel/trace v1.23.1`
`replace github.com/ONSdigital/dp-net/v2 => {path/to/your/dp-net}`

you must all add the following line to dp-compose/v2/manifests/core-ons/dp-dataset-api.yml volumes:
`- ${DP_REPO_DIR:-../../../..}/dp-net:{path/to/your/dp-net}`

### Who can review

anyone
