### PR TITLE
reinstate id validation for all dataset types

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -259,6 +259,12 @@ func (api *DatasetAPI) addDatasetNew(w http.ResponseWriter, r *http.Request) {
 
 	datasetID := dataset.ID
 
+	if datasetID == "" {
+		log.Error(ctx, "addDatasetNew endpoint: dataset ID is empty", nil)
+		handleDatasetAPIErr(ctx, errs.ErrMissingDatasetID, w, nil)
+		return
+	}
+
 	logData := log.Data{"dataset_id": datasetID}
 
 	_, err = api.dataStore.Backend.GetDataset(ctx, datasetID)

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -288,7 +288,7 @@ func TestGetDatasetReturnsError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(datasetPermissions.Required.Calls, ShouldEqual, 1)
 		So(permissions.Required.Calls, ShouldEqual, 0)
-		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 	})
 

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -50,6 +50,7 @@ var (
 	ErrInvalidVersion                    = errors.New("invalid version requested")
 	ErrVersionAlreadyExists              = errors.New("an unpublished version of this dataset already exists")
 	ErrNotFound                          = errors.New("not found")
+	ErrMissingDatasetID                  = errors.New("invalid fields: missing dataset id in request body")
 
 	ErrExpectedResourceStateOfCreated          = errors.New("unable to update resource, expected resource to have a state of created")
 	ErrExpectedResourceStateOfSubmitted        = errors.New("unable to update resource, expected resource to have a state of submitted")

--- a/features/private_datasets.feature
+++ b/features/private_datasets.feature
@@ -289,7 +289,7 @@ Feature: Private Dataset API
         Then the HTTP status code should be "400"
         And I should receive the following response:
             """
-            invalid fields: [ID]
+            invalid fields: missing dataset id in request body
             """
 
     Scenario: Missing dataset title in body when creating a new dataset


### PR DESCRIPTION
### What

Reinstate dataset id validation for all dataset types when creating a new dataset
This was previously removed in this PR - https://github.com/ONSdigital/dp-dataset-api/pull/466 - and added as part of the validation for static datasets, but we need the `id` field to be mandatory for all dataset types (not just static)

### How to review

Confirm the above has been done and changes make sense, tests pass

### Who can review

Anyone
