### PR TITLE
Update API spec to show changes for economic `static` type datasets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ acceptance-web: build
 lint:
 	golangci-lint run ./...
 
+.PHONY: lint-api-spec
+lint-api-spec:
+	redocly lint swagger.yaml
+
 .PHONY: test
 test:
 	go test -race -cover ./...

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ An ONS API used to navigate datasets, editions and versions - which are publishe
 * Run api auth stub, [see documentation](https://github.com/ONSdigital/dp-auth-api-stub)
 * Run `make debug`
 
+To run `make lint-api-spec` you require Node v20.x and to install `redocly/cli`:
+
+```sh
+   npm install -g @redocly/cli
+```
+
 ### State changes
 
 Normal sequential order of states:

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,4 @@
+extends:
+  - recommended
+rules:
+  operation-operationId: off

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2211,8 +2211,16 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/Dimension"
+      distributions:
+        description: A list of representations of the dataset available and how to access them.
+        type: array
+        items:
+          $ref: "#/definitions/Distribution"
       downloads:
-        description: "A selection of download objects containing information of downloadable files."
+        description: |
+          **Deprecated:** These fields have been deprecated and replaced by the `distributions` list.
+
+          A selection of download objects containing information of downloadable files.
         type: object
         properties:
           csv:
@@ -2248,6 +2256,19 @@ definitions:
       lowest_geography:
         description: "The lowest geography this dataset is available at (Census datasets only)"
         type: string
+      quality_designation:
+        description: |
+          The official statistics quality designation level of this dataset version.
+
+          Possible quality designations:
+            * `accredited-official`
+            * `official`
+            * `official-in-development`
+        type: string
+        enum:
+          - accredited-official
+          - official
+          - official-in-development
       release_date:
         description: "The release date of this version of the dataset"
         type: string
@@ -2268,6 +2289,61 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/UsageNotes"
+  Distribution:
+    description: The details of specific representation of a dataset and how to access it.
+    type: object
+    properties:
+      title:
+        description: The title or label of the distribution.
+        type: string
+        example: Full Dataset (CSV)
+      download_url:
+        description: URL to directly download a file for the distribution in the specified format.
+        type: string
+        example: https://download.ons.gov.uk/my-dataset-download.csv
+      byte_size:
+        description: The size in bytes of the download file referenced by `download_url`.
+        type: integer
+        minimum: 0
+        example: 4300000
+      format:
+        description: |
+          The format for the download file referenced by `download_url`.
+
+          Formats supported:
+            * `csv`
+            * `sdmx`
+            * `xls`
+            * `xlsx`
+            * `csdb`
+            * `csvw-metadata`
+        type: string
+        enum:
+          - csv
+          - sdmx
+          - xls
+          - xlsx
+          - csdb
+          - csvw-metadata
+      media_type:
+        description: |
+          The IANA media type for the download file referenced by `download_url`.
+
+          Media Types supported:
+            * `text/csv`: CSV files
+            * `application/vnd.sdmx.structurespecificdata+xml`: SDMX files
+            * `application/vnd.ms-excel`: Excel (XLS) files
+            * `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: Excel (XLSX) files
+            * `text/plain`: Plain text (used for CSDB output structured text files)
+            * `application/ld+json`: JSON-LD metadata file. Commonly used to annotate tabular data in an associated CSV file as outlined in the CSVW standard.
+        type: string
+        enum:
+          - text/csv
+          - application/vnd.sdmx.structurespecificdata+xml
+          - application/vnd.ms-excel
+          - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+          - text/plain
+          - application/ld+json
   # Link objects
   DatasetLinks:
     description: "Navigational links related to the dataset resource to aid in API navigation."

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1554,10 +1554,6 @@ definitions:
         example: "2017"
         readOnly: true
         type: string
-      id:
-        description: "An unique id for a dataset edition"
-        readOnly: true
-        type: string
       links:
         $ref: "#/definitions/EditionLinks"
       state:
@@ -2236,10 +2232,6 @@ definitions:
         readOnly: true
         type: string
         example: 2017
-      id:
-        description: "The dataset identifier of the dataset this version is an instance of."
-        type: string
-        example: my-dataset
       is_based_on:
         $ref: "#/definitions/IsBasedOn"
       dataset_id:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1289,6 +1289,11 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/RelatedLink"
+      publishers:
+        description: A list of the publishers for the dataset.
+        type: array
+        items:
+          $ref: "#/definitions/Publisher"
       qmi:
         $ref: "#/definitions/QMILink"
       related_datasets:
@@ -1874,8 +1879,11 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/RelatedLink"
-      publisher:
-        $ref: "#/definitions/Publisher"
+      publishers:
+        description: A list of the publishers for the dataset.
+        type: array
+        items:
+          $ref: "#/definitions/Publisher"
       qmi:
         $ref: "#/definitions/QMILink"
       related_datasets:
@@ -2013,12 +2021,11 @@ definitions:
       name:
         description: "The name of the publisher"
         type: string
-      type:
-        description: "The type of publisher"
-        type: string
+        example: Office for National Statistics
       href:
         description: "A link to the publishers homepage"
         type: string
+        example: "https://www.ons.gov.uk"
   State:
     description: |
       The state of the resource, can only be one of the following:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1146,6 +1146,10 @@ definitions:
   Alert:
     description: "Important notice relating to a version of a dataset"
     type: object
+    required:
+      - date
+      - description
+      - type
     properties:
       date:
         description: "The date and time of publication of the version"
@@ -1229,7 +1233,6 @@ definitions:
       - contacts
       - description
       - license
-      - links
       - title
       - type
       - topics
@@ -1250,6 +1253,7 @@ definitions:
       contacts:
         description: "A list containing contact details of statisticians for a dataset"
         type: array
+        minItems: 1
         items:
           $ref: "#/definitions/Contact"
       description:
@@ -1334,6 +1338,7 @@ definitions:
       topics:
         description: "A list of topic IDs that the dataset relates to within the topic taxonomy. This field consolidates the previously separate `canonical_topic` and `subtopics` fields."
         type: array
+        minItems: 1
         items:
           type: "string"
         example: ["7779", "7755"]
@@ -1923,7 +1928,7 @@ definitions:
         description: "The unit of measure for the dataset observations"
         type: string
       usage_notes:
-        $ref: "#/definitions/UsageNotes"
+        $ref: "#/definitions/UsageNote"
       topics:
         description: "A list of topics and subtopics that the dataset relates to within the topic taxonomy. This field consolidates the previously separate `canonical_topic` and `subtopics` fields."
         type: array
@@ -2024,15 +2029,18 @@ definitions:
   Publisher:
     description: "The publisher of the dataset"
     type: object
+    required:
+      - name
+      - href
     properties:
       name:
         description: "The name of the publisher"
         type: string
-        example: Office for National Statistics
+        default: Office for National Statistics
       href:
         description: "A link to the publishers homepage"
         type: string
-        example: "https://www.ons.gov.uk"
+        default: "https://www.ons.gov.uk"
   State:
     description: |
       The state of the resource, can only be one of the following:
@@ -2182,10 +2190,13 @@ definitions:
         description: "A list of usage notes relating to the dataset"
         type: array
         items:
-          $ref: "#/definitions/UsageNotes"
-  UsageNotes:
+          $ref: "#/definitions/UsageNote"
+  UsageNote:
     description: "A note relating to the dataset. This will appear in downloaded datasets"
     type: object
+    required:
+      - title
+      - note
     properties:
       title:
         description: "The title of the note"
@@ -2206,7 +2217,9 @@ definitions:
               $ref: "#/definitions/Version"
   Version:
     description: "An object containing information about published datasets from the ONS"
-    required: [release_date]
+    required:
+      - distributions
+      - release_date
     type: object
     properties:
       alerts:
@@ -2228,6 +2241,7 @@ definitions:
       distributions:
         description: A list of representations of the dataset available and how to access them.
         type: array
+        minItems: 1
         items:
           $ref: "#/definitions/Distribution"
       downloads:
@@ -2291,7 +2305,7 @@ definitions:
         description: "A list of usage notes relating to the dataset"
         type: array
         items:
-          $ref: "#/definitions/UsageNotes"
+          $ref: "#/definitions/UsageNote"
       version:
         description: "A number identifying the version for an edition from a dataset"
         example: 1
@@ -2300,6 +2314,10 @@ definitions:
   Distribution:
     description: The details of specific representation of a dataset and how to access it.
     type: object
+    required:
+      - title
+      - format
+      - download_url
     properties:
       title:
         description: The title or label of the distribution.
@@ -2665,4 +2683,4 @@ definitions:
         description: "The unit of measure for the dataset observations"
         type: string
       usage_notes:
-        $ref: "#/definitions/UsageNotes"
+        $ref: "#/definitions/UsageNote"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -31,12 +31,6 @@ parameters:
     in: path
     required: true
     type: string
-  dimension_options:
-    description: "The name of the dimension option and a single value; each option (dimension) and corresponding value (code) must exist against the version - e.g. `age=30` or one of the dimension options can be represented by a wildcard value `*` e.g. `geography=*`"
-    name: "<dimension_options>"
-    in: query
-    required: true
-    type: string
   patch_options:
     required: true
     name: patch
@@ -680,40 +674,6 @@ paths:
           description: "Version was not found for a dataset using the id and edition provided"
         409:
           description: "Instance does not match the expected eTag"
-        500:
-          $ref: "#/responses/InternalError"
-  /datasets/{id}/editions/{edition}/versions/{version}/observations:
-    get:
-      tags:
-        - "Public"
-      summary: "Get specific observations"
-      description: "Get observations from a version of the dataset. By providing a single option for each dimension, a single observation will be returned. A wildcard (*) can be provided for one dimension, to retrieve a list of observations."
-      parameters:
-        - $ref: "#/parameters/edition"
-        - $ref: "#/parameters/id"
-        - $ref: "#/parameters/version"
-        - $ref: "#/parameters/dimension_options"
-      security:
-        - {}
-        - Authorization: []
-      responses:
-        200:
-          description: "Json object containing all metadata for a version"
-          schema:
-            $ref: "#/definitions/ObservationsEndpoint"
-        400:
-          description: |
-            Invalid request, reasons can be one of the following:
-              * query parameters missing expected dimensions
-              * query parameters contain incorrect dimensions
-              * too many query parameters are set to wildcard (*) value; only one query parameter can be equal to *
-        404:
-          description: |
-            Resource not found, reasons can be one of the following:
-              * dataset id was incorrect
-              * edition was incorrect
-              * version was incorrect
-              * observations not found for selected query paramaters
         500:
           $ref: "#/responses/InternalError"
   /instances:
@@ -2145,84 +2105,6 @@ definitions:
             description: "An unique id for a dataset"
             example: "DE3BC0B6-D6C4-4E20-917E-95D7EA8C91CD"
       - $ref: "#/definitions/Version"
-  ObservationsEndpoint:
-    description: "An object containing information on a list of observations for a given version of a dataset"
-    type: object
-    properties:
-      dimensions:
-        description: "A list of dimensions for the given query"
-        type: object
-        properties:
-          <dimension name>:
-            description: "Each field is a dimension (<dimension name>) and will represent a query parameter in the request unless the query parameter is equal to a wildcard value (*)"
-            type: object
-            properties:
-              option:
-                description: "A list of links to the corresponding dimension codes for the given `dimension_options`"
-                type: object
-                properties:
-                  href:
-                    description: "A link to the corresponding dimension code for the given `dimension_option`"
-                    type: string
-                    example: "http://localhost:8080/codelists/AB12CD34/codes/K02000001"
-                  id:
-                    description: "The id of the corresponding dimension code for the given `dimension_option`"
-                    type: string
-      limit:
-        description: "The maximum number of observations requested when filtering on query parameters (limited to 10000). Defaults to 10000 observations."
-        type: integer
-      links:
-        $ref: "#/definitions/ObservationLinks"
-      observations:
-        description: "A list of observations found when filtering on query parameters"
-        type: array
-        items:
-          properties:
-            dimensions:
-              description: "Contains a list of dimension objects associated with an observation. Each dimension combined with the top level list of dimensions result in this single observation only"
-              type: object
-              properties:
-                <dimension name>:
-                  description: "Each field is a dimension (<dimension name>) and will represent a query parameter in the request as long as the query parameter is equal to a wildcard value (*)"
-                  type: object
-                  properties:
-                    href:
-                      description: "A link to the corresponding dimension code for the given `dimension_option`"
-                      example: "http://localhost:8080/codelists/AB12CD34/codes/K02000001"
-                      type: string
-                    id:
-                      description: "The id of the corresponding dimension code for the given `dimension_option`"
-                      type: "string"
-                    label:
-                      description: "The label corresponding to the dimension code for the given `dimension_option`"
-                      type: string
-            metadata:
-              description: "Metadata related to the observation found against version of a dataset"
-              type: array
-              items:
-                type: object
-                properties:
-                  <key>:
-                    description: "A single metadata key-value pair related to the observation found against version of a dataset, for example 'coefficients of variation' or 'data marking'"
-                    type: string
-            observation:
-              description: "The observation value for the selection of query parameters (dimensions) chosen"
-              type: string
-          required: [observation]
-      offset:
-        description: "The offset into the entire list of observations found"
-        type: integer
-      total_observations:
-        description: "The number of observations found"
-        type: integer
-      unit_of_measure:
-        description: "The unit of measure for the dataset observations"
-        type: string
-      usage_notes:
-        description: "A list of usage notes relating to the dataset"
-        type: array
-        items:
-          $ref: "#/definitions/UsageNotes"
   Publisher:
     description: "The publisher of the dataset"
     type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -243,7 +243,7 @@ paths:
         400:
           description: "Parameter is_based_on was sent but no value was provided"
         404:
-          description: "No dataset was found with the popultation-type provided"
+          description: "No dataset was found with the population-type provided"
         500:
           $ref: "#/responses/InternalError"
     post:
@@ -1144,16 +1144,17 @@ responses:
     description: "The token provided is unauthorised to carry out this operation"
 definitions:
   Alert:
-    description: "Important information relating to a version of a dataset"
+    description: "Important notice relating to a version of a dataset"
     type: object
     properties:
       date:
         description: "The date and time of publication of the version"
         type: string
+        format: date-time
       description:
         description: "Detail of what a user needs to be aware of for this dataset"
         type: string
-        example: "This is a description of the changes made as part of the correction."
+        example: "This is a description of the changes made as part of the correction or other important notice about this version."
       type:
         description: |
           The type of alert.
@@ -1185,10 +1186,13 @@ definitions:
         description: "A human readable label for dimension"
         type: string
   CollectionID:
-    description: "The id of the unpublished collection (of datasets) that this dataset is associated with. This is an internal only field and is not present once a dataset is published."
+    description: |
+      **Internal Only: This is an internal only field and is not present once a dataset is published.**
+
+      The id of the unpublished collection (of datasets) that this dataset is associated with."
     type: string
   Contact:
-    description: "A list of objects containing contact information for this dataset"
+    description: "Statistical point of contact for the dataset."
     type: object
     required:
       - name
@@ -1238,7 +1242,7 @@ definitions:
         description: |
           **Deprecated:** This field has been deprecated and replaced by the `topics` field.
 
-          The canonical topic id for this dataset.  This indicates which topic this dataset belongs to within the website taxonomy.
+          The canonical topic id for this dataset.  This indicates which topic this dataset belongs to within the topic taxonomy.
         type: string
         example: "7779"
       collection_id:
@@ -1279,9 +1283,7 @@ definitions:
           The flag indicating the latest version of the dataset has `accredited` designation as granted under the Code of Practice for Statistics.
         type: boolean
       next_release:
-        description: "The next release date for a dataset"
-        type: string
-        example: "To be announced"
+        $ref: "#/definitions/NextRelease"
       publications:
         description: "A list of publications related to this dataset."
         type: array
@@ -1309,7 +1311,7 @@ definitions:
         description: |
           **Deprecated:** This field is being deprecated and replaced by the `topics` field.
 
-          A list of subtopic ids that the dataset relates to within the website taxonomy.
+          A list of subtopic ids that the dataset relates to within the topic taxonomy.
         type: array
         items:
           type: "string"
@@ -1334,7 +1336,10 @@ definitions:
         items:
           type: "string"
         example: ["7779", "7755"]
-
+  NextRelease:
+    description: "The next release date for a dataset. This field is a free text field rather than a date-time format and may be a date range, to be confirmed or some other description."
+    type: string
+    example: "To be announced"
   DatasetType:
     description: |
       The type of dataset as determined by the backing data store. Used to determine which functionality is available for a dataset.
@@ -1529,7 +1534,7 @@ definitions:
               "/{dimension}/options/{option}/node_id",
             ]
         value:
-          description: "A list of dimenions that will be added to the instance."
+          description: "A list of dimensions that will be added to the instance."
           example: '[{"dimension": "dim1", "option": "op1"}, {"dimension": "dim1", "option": "op2"}, {"op": "add", "path": "/dim1/options/op1/order", "value": 3}, {"op": "add", "path": "/dim1/options/op2/node_id", "value": "node123"}]'
   DownloadObject:
     description: "Object containing information of a downloadable file"
@@ -1754,6 +1759,7 @@ definitions:
       release_date:
         description: "The release date of this version of the dataset"
         type: string
+        format: date-time
       state:
         $ref: "#/definitions/State"
       temporal:
@@ -1801,10 +1807,13 @@ definitions:
         items:
           $ref: "#/definitions/Alert"
       canonical_topic:
-        description: "The canonical topic id for this dataset.  This indicates which topic this dataset belongs to within the website taxonomy. **Deprecated** this field is being deprecated and replaced by the `Themes` field."
+        description: |
+          **Deprecated:** This field has been deprecated and replaced by the `topics` field.
+
+          The canonical topic id for this dataset.  This indicates which topic this dataset belongs to within the topic taxonomy.
         type: string
       contacts:
-        description: "A list containing contact details of staticians for a dataset"
+        description: "A list containing contact details of statisticians for a dataset"
         type: array
         items:
           $ref: "#/definitions/Contact"
@@ -1822,7 +1831,7 @@ definitions:
         items:
           type: string
       downloads:
-        description: "A selection of download objects containing information of downloadable files."
+        description: A selection of download objects containing information of downloadable files."
         type: object
         properties:
           csv:
@@ -1863,8 +1872,7 @@ definitions:
         description: "The flag indicating the resource is a national statistic. These are certified as compliant with the Code of Practice for Official Statistics"
         type: boolean
       next_release:
-        description: "The next release date for a dataset"
-        type: string
+        $ref: "#/definitions/NextRelease"
       publications:
         description: "A list of publications related to this dataset."
         type: array
@@ -1886,10 +1894,14 @@ definitions:
         description: "The release frequency of a dataset"
         type: string
       subtopics:
-        description: "A list of subtopic ids that the dataset relates to within the website taxonomy. **Deprecated** this field is being deprecated and replaced by the `Themes` field."
+        description: |
+          **Deprecated:** This field is being deprecated and replaced by the `topics` field.
+
+          A list of subtopic ids that the dataset relates to within the topic taxonomy.
         type: array
         items:
           type: "string"
+          example: "7755"
       temporal:
         $ref: "#/definitions/Temporal"
       title:
@@ -1902,7 +1914,7 @@ definitions:
       usage_notes:
         $ref: "#/definitions/UsageNotes"
       topics:
-        description: "A list of topics and subtopics that the dataset relates to within the website taxonomy. This field consolidates the previously separate `canonical_topic` and `subtopics` fields."
+        description: "A list of topics and subtopics that the dataset relates to within the topic taxonomy. This field consolidates the previously separate `canonical_topic` and `subtopics` fields."
         type: array
         items:
           type: "string"
@@ -2021,6 +2033,7 @@ definitions:
         * associated (not editions)
         * published
     type: string
+    example: published
     enum:
       - created
       - completed
@@ -2145,6 +2158,7 @@ definitions:
       release_date:
         description: "The release date of this version of the dataset"
         type: string
+        format: date-time
       state:
         $ref: "#/definitions/State"
       temporal:
@@ -2213,14 +2227,17 @@ definitions:
         description: "The dataset edition for this version"
         readOnly: true
         type: string
+        example: 2017
       id:
         description: "The dataset identifier of the dataset this version is an instance of."
         type: string
+        example: my-dataset
       is_based_on:
         $ref: "#/definitions/IsBasedOn"
       dataset_id:
         description: "The identifier for the dataset."
         type: string
+        example: my-dataset
       latest_changes:
         description: "A list of changes between version of an edition for a dataset and the previous version of the same dataset edition"
         type: array
@@ -2234,6 +2251,7 @@ definitions:
       release_date:
         description: "The release date of this version of the dataset"
         type: string
+        format: date-time
       state:
         $ref: "#/definitions/State"
       temporal:
@@ -2262,18 +2280,18 @@ definitions:
           href:
             description: "A URL to all editions for this dataset"
             type: string
+            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions"
       latest_version:
         $ref: "#/definitions/LatestVersionLink"
       self:
-        $ref: "#/definitions/SelfLink"
-    example:
-      editions:
-        href: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions"
-      latest_version:
-        href: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017/versions/5"
-        id: "5"
-      self:
-        href: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset"
+        description: "A link to this resource"
+        readOnly: true
+        type: object
+        properties:
+          href:
+            description: "A URL to this resource"
+            type: string
+            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset"
   EditionLinks:
     description: "A list of links related to this resource"
     readOnly: true
@@ -2284,7 +2302,14 @@ definitions:
       latest_version:
         $ref: "#/definitions/LatestVersionLink"
       self:
-        $ref: "#/definitions/SelfLink"
+        description: "A link to this resource"
+        readOnly: true
+        type: object
+        properties:
+          href:
+            description: "A URL to this resource"
+            type: string
+            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017"
       versions:
         type: object
         properties:
@@ -2298,7 +2323,14 @@ definitions:
     type: object
     properties:
       self:
-        $ref: "#/definitions/SelfLink"
+        description: "A link to this resource"
+        readOnly: true
+        type: object
+        properties:
+          href:
+            description: "A URL to this resource"
+            type: string
+            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017/versions/5/metadata"
       spatial:
         $ref: "#/definitions/SpatialLink"
       version:
@@ -2310,6 +2342,7 @@ definitions:
           href:
             description: "The uri to the location of this version of the dataset on the web"
             type: string
+            example: "https://www.ons.gov.uk/datasets/my-dataset/editions/2017/versions/5"
   VersionLinks:
     description: "A list of links related to this resource"
     type: object
@@ -2322,12 +2355,19 @@ definitions:
         properties:
           href:
             description: "A URL to list dimensions for this version"
-            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017/versions/2/dimensions"
+            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017/versions/5/dimensions"
             type: string
       edition:
         $ref: "#/definitions/EditionLink"
       self:
-        $ref: "#/definitions/SelfLink"
+        description: "A link to this resource"
+        readOnly: true
+        type: object
+        properties:
+          href:
+            description: "A URL to this resource"
+            type: string
+            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017/versions/5"
       spatial:
         $ref: "#/definitions/SpatialLink"
   DatasetLink:
@@ -2382,14 +2422,6 @@ definitions:
     properties:
       href:
         description: "A URL to a list of options for this dimension"
-        type: string
-  SelfLink:
-    description: "A link to this resource"
-    readOnly: true
-    type: object
-    properties:
-      href:
-        description: "A URL to this resource"
         type: string
   SpatialLink:
     type: object
@@ -2460,6 +2492,7 @@ definitions:
         readOnly: true
         type: integer
         example: 123
+
   MetadataUpdate:
     description: "An object containing all editable metadata fields on a dataset and a version resource"
     type: object
@@ -2470,7 +2503,7 @@ definitions:
         items:
           $ref: "#/definitions/Alert"
       canonical_topic:
-        description: "The canonical topic id for this dataset.  This indicates which topic this dataset belongs to within the website taxonomy."
+        description: "The canonical topic id for this dataset.  This indicates which topic this dataset belongs to within the topic taxonomy."
         type: string
       contacts:
         description: "A list containing contact details of statisticians for a dataset"
@@ -2508,8 +2541,7 @@ definitions:
         description: "The flag indicating the resource is a national statistic. These are certified as compliant with the Code of Practice for Official Statistics"
         type: boolean
       next_release:
-        description: "The next release date for a dataset"
-        type: string
+        $ref: "#/definitions/NextRelease"
       publications:
         description: "A list of publications related to this dataset."
         type: array
@@ -2534,7 +2566,7 @@ definitions:
         description: "The release frequency of a dataset"
         type: string
       subtopics:
-        description: "A list of subtopic ids that the dataset relates to within the website taxonomy."
+        description: "A list of subtopic ids that the dataset relates to within the topic taxonomy."
         type: array
         items:
           type: "string"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1264,6 +1264,8 @@ definitions:
         items:
           type: "string"
           example: "Inflation"
+      last_updated:
+        $ref: "#/definitions/LastUpdated"
       license:
         description: "The license the dataset is released under."
         type: string
@@ -1329,18 +1331,23 @@ definitions:
         description: "The title of the dataset"
         example: "Consumer Prices Index"
         type: string
-      type:
-        $ref: "#/definitions/DatasetType"
-      unit_of_measure:
-        description: "The unit of measure for the dataset observations"
-        type: string
-        example: "Number of people"
       topics:
         description: "A list of topic IDs that the dataset relates to within the topic taxonomy. This field consolidates the previously separate `canonical_topic` and `subtopics` fields."
         type: array
         items:
           type: "string"
         example: ["7779", "7755"]
+      type:
+        $ref: "#/definitions/DatasetType"
+      unit_of_measure:
+        description: "The unit of measure for the dataset observations"
+        type: string
+        example: "Number of people"
+  LastUpdated:
+    description: The date and time of the last update to the resource. For published resources this is the date and time the latest change was published.
+    type: string
+    format: date-time
+    readOnly: true
   NextRelease:
     description: "The next release date for a dataset. This field is a free text field rather than a date-time format and may be a date range, to be confirmed or some other description."
     type: string
@@ -2209,6 +2216,10 @@ definitions:
           $ref: "#/definitions/Alert"
       collection_id:
         $ref: "#/definitions/CollectionID"
+      dataset_id:
+        description: "The identifier for the dataset."
+        type: string
+        example: my-dataset
       dimensions:
         description: "A list of codelists for each dimension of this version"
         type: array
@@ -2241,10 +2252,8 @@ definitions:
         example: 2017
       is_based_on:
         $ref: "#/definitions/IsBasedOn"
-      dataset_id:
-        description: "The identifier for the dataset."
-        type: string
-        example: my-dataset
+      last_updated:
+        $ref: "#/definitions/LastUpdated"
       latest_changes:
         description: "A list of changes between version of an edition for a dataset and the previous version of the same dataset edition"
         type: array
@@ -2278,16 +2287,16 @@ definitions:
         $ref: "#/definitions/Temporal"
       type:
         $ref: "#/definitions/DatasetType"
-      version:
-        description: "A number identifying the version for an edition from a dataset"
-        example: 1
-        readOnly: true
-        type: integer
       usage_notes:
         description: "A list of usage notes relating to the dataset"
         type: array
         items:
           $ref: "#/definitions/UsageNotes"
+      version:
+        description: "A number identifying the version for an edition from a dataset"
+        example: 1
+        readOnly: true
+        type: integer
   Distribution:
     description: The details of specific representation of a dataset and how to access it.
     type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -233,6 +233,13 @@ paths:
           description: "A json list containing datasets which have been published"
           schema:
             $ref: "#/definitions/Datasets"
+          headers:
+            ETag:
+              description: The RFC7232 ETag header field the of the resource, where the resource is the response to the specific query paramaters. This is used for setting the `If-None-Match` headers on subsequent requests to check for changes.
+              type: string
+            Cache-Control:
+              description: The RFC9111 Cache-Control header field for the response which instructs how to handle caching the resource.
+              type: string
         400:
           description: "Parameter is_based_on was sent but no value was provided"
         404:
@@ -307,6 +314,13 @@ paths:
           description: "A json object for a single Dataset"
           schema:
             $ref: "#/definitions/Dataset"
+          headers:
+            ETag:
+              description: The RFC7232 ETag header field. Defines the unique entity tag for the current state of the resource. This is used for setting the `If-Match` and `If-None-Match` headers on subsequent requests.
+              type: string
+            Cache-Control:
+              description: The RFC9111 Cache-Control header field for the response which instructs how to handle caching the resource.
+              type: string
         404:
           description: "No dataset was found using the id provided"
         500:
@@ -368,6 +382,13 @@ paths:
           description: "A json list containing all editions for a dataset"
           schema:
             $ref: "#/definitions/Editions"
+          headers:
+            ETag:
+              description: The RFC7232 ETag header field the of the resource, where the resource is the response to the specific query paramaters. This is used for setting the `If-None-Match` headers on subsequent requests to check for changes.
+              type: string
+            Cache-Control:
+              description: The RFC9111 Cache-Control header field for the response which instructs how to handle caching the resource.
+              type: string
         400:
           description: "Invalid request, dataset id was incorrect"
         404:
@@ -391,6 +412,13 @@ paths:
           description: "A json object containing the latest version of the edition"
           schema:
             $ref: "#/definitions/Version"
+          headers:
+            ETag:
+              description: The RFC7232 ETag header field. Defines the unique entity tag for the current state of the resource. This is used for setting the `If-Match` and `If-None-Match` headers on subsequent requests.
+              type: string
+            Cache-Control:
+              description: The RFC9111 Cache-Control header field for the response which instructs how to handle caching the resource.
+              type: string
         400:
           description: "Invalid request, dataset id was incorrect"
         404:
@@ -418,6 +446,13 @@ paths:
           description: "A json list containing all versions for a set type of dataset and edition"
           schema:
             $ref: "#/definitions/Versions"
+          headers:
+            ETag:
+              description: The RFC7232 ETag header field the of the resource, where the resource is the response to the specific query paramaters. This is used for setting the `If-None-Match` headers on subsequent requests to check for changes.
+              type: string
+            Cache-Control:
+              description: The RFC9111 Cache-Control header field for the response which instructs how to handle caching the resource.
+              type: string
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -509,8 +544,11 @@ paths:
             $ref: "#/definitions/Version"
           headers:
             ETag:
+              description: The RFC7232 ETag header field. Defines the unique entity tag for the current state of the resource. This is used for setting the `If-Match` and `If-None-Match` headers on subsequent requests.
               type: string
-              description: "Defines the unique etag for this resource"
+            Cache-Control:
+              description: The RFC9111 Cache-Control header field for the response which instructs how to handle caching the resource.
+              type: string
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -567,6 +605,13 @@ paths:
           description: "A json list of dimensions"
           schema:
             $ref: "#/definitions/Dimensions"
+          headers:
+            ETag:
+              description: The RFC7232 ETag header field the of the resource, where the resource is the response to the specific query paramaters. This is used for setting the `If-None-Match` headers on subsequent requests to check for changes.
+              type: string
+            Cache-Control:
+              description: The RFC9111 Cache-Control header field for the response which instructs how to handle caching the resource.
+              type: string
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -581,7 +626,7 @@ paths:
     get:
       tags:
         - "Public"
-      summary: "Get a list of options from a dimension"
+      summary: "Get a list of options from a dimension (filterable and cantabular datasets only)"
       description: "Get a list of options which appear in this dimension and dataset. By default all options are returned, but a subset can be requested by providing offset and limit query parameters, or by providing the list of option IDs, only the IDs that are found will be returned."
       parameters:
         - $ref: "#/parameters/dimension"
@@ -599,6 +644,13 @@ paths:
           description: "Json object containing all options for a dimension"
           schema:
             $ref: "#/definitions/DimensionOptions"
+          headers:
+            ETag:
+              description: The RFC7232 ETag header field the of the resource, where the resource is the response to the specific query paramaters. This is used for setting the `If-None-Match` headers on subsequent requests to check for changes.
+              type: string
+            Cache-Control:
+              description: The RFC9111 Cache-Control header field for the response which instructs how to handle caching the resource.
+              type: string
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -630,6 +682,13 @@ paths:
           description: "Json object containing all metadata for a version"
           schema:
             $ref: "#/definitions/Metadata"
+          headers:
+            ETag:
+              description: The RFC7232 ETag header field. Defines the unique entity tag for the current state of the resource. This is used for setting the `If-Match` and `If-None-Match` headers on subsequent requests.
+              type: string
+            Cache-Control:
+              description: The RFC9111 Cache-Control header field for the response which instructs how to handle caching the resource.
+              type: string
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -690,6 +749,13 @@ paths:
           description: "Return a list of instance state"
           schema:
             $ref: "#/definitions/Instances"
+          headers:
+            ETag:
+              description: The RFC7232 ETag header field. Defines the unique entity tag for the current state of the resource. This is used for setting the `If-Match` and `If-None-Match` headers on subsequent requests.
+              type: string
+            Cache-Control:
+              description: The RFC9111 Cache-Control header field for the response which instructs how to handle caching the resource.
+              type: string
         400:
           $ref: "#/responses/InvalidRequestError"
         401:
@@ -745,8 +811,11 @@ paths:
             $ref: "#/definitions/Instance"
           headers:
             ETag:
+              description: The RFC7232 ETag header field. Defines the unique entity tag for the current state of the resource. This is used for setting the `If-Match` and `If-None-Match` headers on subsequent requests.
               type: string
-              description: "Defines a unique instance resource version"
+            Cache-Control:
+              description: The RFC9111 Cache-Control header field for the response which instructs how to handle caching the resource.
+              type: string
         401:
           $ref: "#/responses/UnauthorisedError"
         404:
@@ -809,8 +878,11 @@ paths:
               $ref: "#/definitions/DimensionOption"
           headers:
             ETag:
+              description: The RFC7232 ETag header field. Defines the unique entity tag for the current state of the resource. This is used for setting the `If-Match` and `If-None-Match` headers on subsequent requests.
               type: string
-              description: "Defines a unique instance resource version"
+            Cache-Control:
+              description: The RFC9111 Cache-Control header field for the response which instructs how to handle caching the resource.
+              type: string
         400:
           $ref: "#/responses/InvalidRequestError"
         401:
@@ -943,8 +1015,11 @@ paths:
                   type: string
           headers:
             ETag:
+              description: The RFC7232 ETag header field. Defines the unique entity tag for the current state of the resource. This is used for setting the `If-Match` and `If-None-Match` headers on subsequent requests.
               type: string
-              description: "Defines a unique instance resource version"
+            Cache-Control:
+              description: The RFC9111 Cache-Control header field for the response which instructs how to handle caching the resource.
+              type: string
         400:
           $ref: "#/responses/InvalidRequestError"
         401:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -96,13 +96,6 @@ parameters:
     required: true
     schema:
       $ref: "#/definitions/Dataset"
-  new_edition:
-    name: new_edition
-    description: "A new edition of the dataset"
-    in: body
-    required: true
-    schema:
-      $ref: "#/definitions/Edition"
   new_version:
     name: new_version
     description: "A new version for an edition of a dataset"
@@ -224,8 +217,8 @@ paths:
     get:
       tags:
         - "Public"
-      summary: "Get a list of datasets"
-      description: "Returns a list of all datasets provided by the ONS that can be filtered using the filter API"
+      summary: "List datasets"
+      description: "Returns a list of all datasets available via the ONS APIs."
       parameters:
         - $ref: "#/parameters/is_based_on"
         - $ref: "#/parameters/limit"
@@ -362,7 +355,7 @@ paths:
       tags:
         - "Public"
       summary: "Get a list of editions of a dataset"
-      description: "Get a list of editions of a type of dataset"
+      description: "Get a list of editions of a dataset. Each edition returns the latest version of that edition."
       parameters:
         - $ref: "#/parameters/dataset_id"
         - $ref: "#/parameters/limit"
@@ -386,7 +379,7 @@ paths:
       tags:
         - "Public"
       summary: "Get an edition of a dataset"
-      description: "The edition contains a link to all versions"
+      description: "Get the latest version of a dataset edition."
       parameters:
         - $ref: "#/parameters/edition"
         - $ref: "#/parameters/dataset_id"
@@ -395,9 +388,9 @@ paths:
         - Authorization: []
       responses:
         200:
-          description: "A json object containing an edition"
+          description: "A json object containing the latest version of the edition"
           schema:
-            $ref: "#/definitions/Edition"
+            $ref: "#/definitions/Version"
         400:
           description: "Invalid request, dataset id was incorrect"
         404:
@@ -408,8 +401,8 @@ paths:
     get:
       tags:
         - "Public"
-      summary: "Get a list of versions of an edition"
-      description: "Get a list of all versions for an edition of a dataset"
+      summary: "List the edition's version history"
+      description: "Get a list of all versions for a dataset edition."
       parameters:
         - $ref: "#/parameters/edition"
         - $ref: "#/parameters/dataset_id"
@@ -500,7 +493,7 @@ paths:
     get:
       tags:
         - "Public"
-      summary: "Get a version"
+      summary: "Get a specific version"
       description: "Get a specific version of an edition of a dataset"
       parameters:
         - $ref: "#/parameters/edition"
@@ -1544,12 +1537,7 @@ definitions:
           description: "Path to value that needs to be operated on."
           type: string
           example: "/-"
-          enum:
-            [
-              "/-",
-              "/{dimension}/options/{option}/order",
-              "/{dimension}/options/{option}/node_id",
-            ]
+          enum: ["/-", "/{dimension}/options/{option}/order", "/{dimension}/options/{option}/node_id"]
         value:
           description: "A list of dimensions that will be added to the instance."
           example: '[{"dimension": "dim1", "option": "op1"}, {"dimension": "dim1", "option": "op2"}, {"op": "add", "path": "/dim1/options/op1/order", "value": 3}, {"op": "add", "path": "/dim1/options/op2/node_id", "value": "node123"}]'
@@ -1563,18 +1551,6 @@ definitions:
       size:
         description: "The size of the file in bytes"
         type: string
-  Edition:
-    type: object
-    properties:
-      edition:
-        description: "The edition of the dataset"
-        example: "2017"
-        readOnly: true
-        type: string
-      links:
-        $ref: "#/definitions/EditionLinks"
-      state:
-        $ref: "#/definitions/State"
   Editions:
     description: "A list of editions of a dataset."
     type: object
@@ -1585,7 +1561,7 @@ definitions:
           items:
             type: array
             items:
-              $ref: "#/definitions/Edition"
+              $ref: "#/definitions/Version"
   Event:
     type: object
     properties:
@@ -2374,6 +2350,7 @@ definitions:
   DatasetLinks:
     description: "Navigational links related to the dataset resource to aid in API navigation."
     type: object
+    readOnly: true
     properties:
       editions:
         readOnly: true
@@ -2385,6 +2362,15 @@ definitions:
             example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions"
       latest_version:
         $ref: "#/definitions/LatestVersionLink"
+      latest_edition:
+        description: "An object containing a link to the latest edition of the dataset."
+        type: object
+        readOnly: true
+        properties:
+          href:
+            description: "A link to the latest edition of the dataset."
+            type: string
+            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017"
       self:
         description: "A link to this resource"
         readOnly: true
@@ -2394,31 +2380,6 @@ definitions:
             description: "A URL to this resource"
             type: string
             example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset"
-  EditionLinks:
-    description: "A list of links related to this resource"
-    readOnly: true
-    type: object
-    properties:
-      dataset:
-        $ref: "#/definitions/DatasetLink"
-      latest_version:
-        $ref: "#/definitions/LatestVersionLink"
-      self:
-        description: "A link to this resource"
-        readOnly: true
-        type: object
-        properties:
-          href:
-            description: "A URL to this resource"
-            type: string
-            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017"
-      versions:
-        type: object
-        properties:
-          href:
-            description: "A URL to all versions dor an edition of a dataset"
-            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/edition/2017/versions"
-            type: string
   MetadataLinks:
     description: "A list of links related to this resource"
     readOnly: true
@@ -2448,6 +2409,7 @@ definitions:
   VersionLinks:
     description: "A list of links related to this resource"
     type: object
+    readOnly: true
     properties:
       dataset:
         $ref: "#/definitions/DatasetLink"
@@ -2472,6 +2434,13 @@ definitions:
             example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017/versions/5"
       spatial:
         $ref: "#/definitions/SpatialLink"
+      versions:
+        type: object
+        properties:
+          href:
+            description: "A URL to all versions for an edition of a dataset"
+            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/edition/2017/versions"
+            type: string
   DatasetLink:
     description: "An object containing the dataset id and link"
     readOnly: true

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1268,9 +1268,6 @@ definitions:
         items:
           type: object
           properties:
-            description:
-              description: "The description of a methodology"
-              type: string
             href:
               description: "The url to a methodology"
               type: string
@@ -1289,24 +1286,16 @@ definitions:
         items:
           type: object
           properties:
-            description:
-              description: "The description of a publication"
-              type: string
             href:
               description: "The url to a publication"
               type: string
             title:
               description: "The title of a publication"
               type: string
-      publisher:
-        $ref: '#/definitions/Publisher'
       qmi:
         description: "Object containing information on the quality and methodology index of a dataset"
         type: object
         properties:
-          description:
-            description: "The description of a quality and methodology index"
-            type: string
           href:
             description: "The url to a quality and methodology index"
             type: string
@@ -1353,9 +1342,6 @@ definitions:
       survey:
         description: "The name of the survey the dataset was created from."
         type: string
-      theme:
-        description: "The theme for a dataset"
-        type: string
       title:
         description: "The title of the dataset"
         example: "CPI"
@@ -1367,10 +1353,7 @@ definitions:
       unit_of_measure:
         description: "The unit of measure for the dataset observations"
         type: string
-      uri:
-        description: "The uri to the location of this resource on the web"
-        type: string
-      themes:
+      topics:
         description: "A list of topics and subtopics that the dataset relates to within the website taxonomy. This field consolidates the previously separate `canonical_topic` and `subtopics` fields."
         type: array
         items:
@@ -2449,8 +2432,6 @@ definitions:
     description: "A list of links related to this resource"
     type: object
     properties:
-      access_rights:
-        $ref: '#/definitions/AccessRightsLink'
       editions:
         readOnly: true
         type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2380,6 +2380,16 @@ definitions:
             description: "A URL to this resource"
             type: string
             example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset"
+      taxonomy:
+        description: "The taxonomy path of the dataset's canonical topic."
+        type: object
+        properties:
+          href:
+            description: |
+              **Deprecated:** This field has been deprecated and will be removed in future. It is strongly advised that you do not use this field as topics will move in the hierarchy and therefore the value returned here will become outdated. Use the first entry in the `topics` list in combination with the Topics API instead.
+
+              The taxonomy path of the canonical topic for the dataset at the time of publish.
+            type: string
   MetadataLinks:
     description: "A list of links related to this resource"
     readOnly: true

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
   description: |
-    Used to find information about data published by the ONS.
+    Dataset catalogue used to find information about data published by the ONS.
 
     `Datasets` are published in unique `versions`, which are categorized by `edition`. Data in each version is broken down by `dimensions`, and a unique combination of dimension `options` in a version can be used to retrieve `observation` level data.
 
@@ -10,15 +10,16 @@ info:
   title: "Explore our data"
   license:
     name: "Open Government Licence v3.0"
-    url: "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+    url: "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
 basePath: "/v1"
 tags:
   - name: "Public"
     description: Endpoints available on public API.
   - name: "Private"
     description: Internal only endpoints.
+host: api.beta.ons.gov.uk
 schemes:
-  - "http"
+  - "https"
 parameters:
   dataset:
     name: dataset
@@ -57,9 +58,9 @@ parameters:
     in: body
     schema:
       $ref: "#/definitions/Event"
-  id:
+  dataset_id:
     name: id
-    description: "Id that represents a dataset"
+    description: "ID that represents a dataset"
     in: path
     required: true
     type: string
@@ -94,12 +95,7 @@ parameters:
     in: body
     required: true
     schema:
-      allOf:
-        - type: object
-          properties:
-            type:
-              $ref: "#/definitions/Type"
-        - $ref: "#/definitions/Dataset"
+      $ref: "#/definitions/Dataset"
   new_edition:
     name: new_edition
     description: "A new edition of the dataset"
@@ -173,16 +169,21 @@ parameters:
       $ref: "#/definitions/UpdateVersion"
   limit:
     name: limit
-    description: "Maximum number of items that will be returned. A value of zero will return zero items. The default value is 20, and the maximum limit allowed is 1000"
+    description: "Maximum number of items that will be returned. A value of zero will return zero items."
     in: query
     required: false
     type: integer
+    default: 20
+    minimum: 0
+    maximum: 1000
   offset:
     name: offset
     description: "Starting index of the items array that will be returned. By default it is zero, meaning that the returned items will start from the beginning."
     in: query
     required: false
     type: integer
+    default: 0
+    minimum: 0
   ids:
     name: id
     description: "List of ids, as comma separated values and/or as multiple query parameters with the same key (e.g. 'id=op1,op2&id=op3'). It defines the IDs that we want to retrieve. If provided, it takes precedence over offset and limit."
@@ -279,7 +280,7 @@ paths:
         **Deprecated:** This endpoint is being replaced by `POST /datasets`. Please use `POST /datasets` and provide the dataset ID in the request body. This endpoint may be removed in a future release.
       deprecated: true
       parameters:
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
         - $ref: "#/parameters/new_dataset"
       security:
         - Authorization: []
@@ -304,7 +305,7 @@ paths:
       summary: "Get a dataset"
       description: "The dataset contains all high level information, for additional details see editions or versions of a dataset. "
       parameters:
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
       security:
         - {}
         - Authorization: []
@@ -312,7 +313,7 @@ paths:
         200:
           description: "A json object for a single Dataset"
           schema:
-            $ref: "#/definitions/DatasetResponse"
+            $ref: "#/definitions/Dataset"
         404:
           description: "No dataset was found using the id provided"
         500:
@@ -323,7 +324,7 @@ paths:
       summary: "Update a dataset"
       description: "Update the metadata for the next release of the dataset. The dataset contains all high level information, for additional details see editions or versions of a dataset."
       parameters:
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
         - $ref: "#/parameters/update_dataset"
       security:
         - Authorization: []
@@ -344,7 +345,7 @@ paths:
       summary: "Delete a dataset"
       description: "Delete an existing dataset"
       parameters:
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
       security:
         - Authorization: []
       responses:
@@ -363,7 +364,7 @@ paths:
       summary: "Get a list of editions of a dataset"
       description: "Get a list of editions of a type of dataset"
       parameters:
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
         - $ref: "#/parameters/limit"
         - $ref: "#/parameters/offset"
       security:
@@ -388,7 +389,7 @@ paths:
       description: "The edition contains a link to all versions"
       parameters:
         - $ref: "#/parameters/edition"
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
       security:
         - {}
         - Authorization: []
@@ -411,7 +412,7 @@ paths:
       description: "Get a list of all versions for an edition of a dataset"
       parameters:
         - $ref: "#/parameters/edition"
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
         - $ref: "#/parameters/limit"
         - $ref: "#/parameters/offset"
       security:
@@ -439,7 +440,7 @@ paths:
       summary: "Create a version"
       description: "Create a version for a dataset series.  This will set the state of the version and dataset series to be associated."
       parameters:
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
         - $ref: "#/parameters/edition"
         - $ref: "#/parameters/new_version"
       security:
@@ -469,7 +470,7 @@ paths:
       summary: "Update a version"
       description: "Update a version for an edition of a dataset, if the state is changed to associated or published, the parent documents(dataset and edition resources) will also be updated. A version can only be updated if the state is not published"
       parameters:
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
         - $ref: "#/parameters/edition"
         - $ref: "#/parameters/version"
         - $ref: "#/parameters/version_update"
@@ -503,7 +504,7 @@ paths:
       description: "Get a specific version of an edition of a dataset"
       parameters:
         - $ref: "#/parameters/edition"
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
         - $ref: "#/parameters/version"
       security:
         - {}
@@ -533,7 +534,7 @@ paths:
       description: "detaches a version from a collection. Effectively a soft delete."
       parameters:
         - $ref: "#/parameters/edition"
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
         - $ref: "#/parameters/version"
       security:
         - Authorization: []
@@ -557,11 +558,11 @@ paths:
     get:
       tags:
         - "Public"
-      summary: "Get a list of dimensions from a dataset"
+      summary: "Get a list of dimensions from a dataset (filterable and cantabular datasets only)"
       description: "Get all dimensions which are used in the dataset"
       parameters:
         - $ref: "#/parameters/edition"
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
         - $ref: "#/parameters/version"
         - $ref: "#/parameters/limit"
         - $ref: "#/parameters/offset"
@@ -592,7 +593,7 @@ paths:
       parameters:
         - $ref: "#/parameters/dimension"
         - $ref: "#/parameters/edition"
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
         - $ref: "#/parameters/version"
         - $ref: "#/parameters/limit"
         - $ref: "#/parameters/offset"
@@ -626,7 +627,7 @@ paths:
       description: "Get all metadata relevant to a version"
       parameters:
         - $ref: "#/parameters/edition"
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
         - $ref: "#/parameters/version"
       security:
         - {}
@@ -651,7 +652,7 @@ paths:
       summary: "Update metadata for a dataset and a version"
       description: "Update metadata for a dataset and a version. The editable metadata can be updated only if both the dataset and the version have a state of associated"
       parameters:
-        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/dataset_id"
         - $ref: "#/parameters/edition"
         - $ref: "#/parameters/version"
         - $ref: "#/parameters/if_match"
@@ -1142,12 +1143,6 @@ responses:
   UnauthorisedError:
     description: "The token provided is unauthorised to carry out this operation"
 definitions:
-  AccessRightsLink:
-    type: object
-    properties:
-      href:
-        description: "A url to the standard Government access right text for the dataset"
-        type: string
   Alert:
     description: "Important information relating to a version of a dataset"
     type: object
@@ -1158,10 +1153,19 @@ definitions:
       description:
         description: "Detail of what a user needs to be aware of for this dataset"
         type: string
+        example: "This is a description of the changes made as part of the correction."
       type:
-        description: "The type of alert"
-        example: "correction"
+        description: |
+          The type of alert.
+
+          Available types:
+            * `alert`: Important contextual information relevant to the interpretation of a specific version of the dataset.
+            * `correction`: A correction notice summarising the data changes made in the corrected as compared to the superseded version.
         type: string
+        enum:
+          - alert
+          - correction
+        example: "correction"
   Codelist:
     type: object
     properties:
@@ -1181,74 +1185,62 @@ definitions:
         description: "A human readable label for dimension"
         type: string
   CollectionID:
-    description: "The id of the unpublished collection (of datasets) that this dataset is associated with"
+    description: "The id of the unpublished collection (of datasets) that this dataset is associated with. This is an internal only field and is not present once a dataset is published."
     type: string
   Contact:
     description: "A list of objects containing contact information for this dataset"
     type: object
+    required:
+      - name
+      - email
     properties:
       email:
-        description: "An email address to contact the statistician"
+        description: "Email address to contact the statistician or statistician group responsible for the dataset."
         type: string
+        example: "example@ons.gov.uk"
       name:
-        description: "The name of the statistician"
+        description: "The name of the statistician or statistician group contact point responsible for the dataset."
         type: string
+        example: "Expert Statistical Team"
       telephone:
-        description: "Telephone number to contact the statistician"
+        description: "Telephone number to contact the statistician or statistician group responsible for the dataset."
         type: string
+        example: "+44 1234 111111"
   Datasets:
     description: "A list of datasets"
     type: object
-    properties:
-      count:
-        description: "The number of datasets returned"
-        readOnly: true
-        type: integer
-      items:
-        type: array
-        items:
-          $ref: "#/definitions/DatasetResponse"
-      limit:
-        description: "The number of datasets requested"
-        type: integer
-      offset:
-        description: "The first row of datasets to retrieve, starting at 0. Use this parameter as a pagination mechanism along with the limit parameter"
-        type: integer
-      total_count:
-        description: "The total number of datasets"
-        readOnly: true
-        type: integer
-  DatasetResponse:
-    description: "A model for the response body when getting a dataset"
     allOf:
+      - $ref: "#/definitions/PaginationFields"
       - type: object
         properties:
-          id:
-            description: "An unique id for a dataset"
-            example: "DE3BC0B6-D6C4-4E20-917E-95D7EA8C91DC"
-            readOnly: true
-            type: string
-          type:
-            $ref: "#/definitions/Type"
-      - $ref: "#/definitions/Dataset"
+          items:
+            type: array
+            items:
+              $ref: "#/definitions/Dataset"
   Dataset:
     description: "The dataset"
     type: object
     required:
-      - "id"
-      - "contacts"
-      - "description"
-      - "license"
-      - "links"
-      - "national_statistics"
-      - "title"
+      - id
+      - contacts
+      - description
+      - license
+      - links
+      - title
+      - type
+      - topics
     properties:
       id:
-        description: "The unique id for the dataset"
+        description: "The unique dataset id."
+        example: "my-dataset"
         type: string
       canonical_topic:
-        description: "The canonical topic id for this dataset.  This indicates which topic this dataset belongs to within the website taxonomy. **Deprecated** this field is being deprecated and replaced by the `Themes` field."
+        description: |
+          **Deprecated:** This field has been deprecated and replaced by the `topics` field.
+
+          The canonical topic id for this dataset.  This indicates which topic this dataset belongs to within the website taxonomy.
         type: string
+        example: "7779"
       collection_id:
         $ref: "#/definitions/CollectionID"
       contacts:
@@ -1259,6 +1251,7 @@ definitions:
       description:
         description: "A description for a dataset"
         type: string
+        example: "This dataset contains some very interesting data about the UK."
       is_based_on:
         $ref: "#/definitions/IsBasedOn"
       keywords:
@@ -1266,113 +1259,99 @@ definitions:
         type: array
         items:
           type: "string"
+          example: "Inflation"
       license:
-        description: "The standard Government license right text for the dataset"
+        description: "The license the dataset is released under."
         type: string
+        default: "Open Government Licence v3.0"
       links:
+        readOnly: true
         $ref: "#/definitions/DatasetLinks"
       methodologies:
-        description: "A list of methodologies for a dataset"
+        description: "A list of methodologies for the dataset."
         type: array
         items:
-          type: object
-          properties:
-            href:
-              description: "The url to a methodology"
-              type: string
-            title:
-              description: "The title of a methodology"
-              type: string
+          $ref: "#/definitions/RelatedLink"
       national_statistic:
-        description: "The flag indicating the resource is a national statistic. These are certified as compliant with the Code of Practice for Official Statistics"
+        description: |
+          **Deprecated:** This field has been deprecated and replaced with the `quality_designation` field under at the edition level in order to correctly represent the three potential quality designations under the updated Code of Practice for Statistics.
+
+          The flag indicating the latest version of the dataset has `accredited` designation as granted under the Code of Practice for Statistics.
         type: boolean
       next_release:
         description: "The next release date for a dataset"
         type: string
+        example: "To be announced"
       publications:
-        description: "A list of publications for a dataset"
+        description: "A list of publications related to this dataset."
         type: array
         items:
-          type: object
-          properties:
-            href:
-              description: "The url to a publication"
-              type: string
-            title:
-              description: "The title of a publication"
-              type: string
+          $ref: "#/definitions/RelatedLink"
       qmi:
-        description: "Object containing information on the quality and methodology index of a dataset"
-        type: object
-        properties:
-          href:
-            description: "The url to a quality and methodology index"
-            type: string
-          title:
-            description: "The title of a quality and methodology index"
-            type: string
+        $ref: "#/definitions/QMILink"
       related_datasets:
-        description: "A list of objects containing information of datasets related to a dataset"
+        description: "A list of other datasets related to this dataset."
         type: array
         items:
-          type: object
-          properties:
-            href:
-              description: "The url to a related dataset"
-              type: string
-            title:
-              description: "The title of a related dataset"
-              type: string
+          $ref: "#/definitions/RelatedLink"
       related_content:
-        description: "A list of objects containing information of content related to a dataset"
+        description: "A list of website content related to this dataset."
         type: array
         items:
-          type: object
-          properties:
-            href:
-              description: "The url to related content"
-              type: string
-            description:
-              description: "The description of the related content"
-              type: string
-            title:
-              description: "The title of the related content"
-              type: string
+          $ref: "#/definitions/RelatedLink"
       release_frequency:
         description: "The release frequency of a dataset"
         type: string
+        example: "Monthly"
       state:
         $ref: "#/definitions/State"
       subtopics:
-        description: "A list of subtopic ids that the dataset relates to within the website taxonomy. **Deprecated** this field is being deprecated and replaced by the `Themes` field."
+        description: |
+          **Deprecated:** This field is being deprecated and replaced by the `topics` field.
+
+          A list of subtopic ids that the dataset relates to within the website taxonomy.
         type: array
         items:
           type: "string"
+          example: "7755"
       survey:
         description: "The name of the survey the dataset was created from."
         type: string
+        example: "census"
       title:
         description: "The title of the dataset"
-        example: "CPI"
+        example: "Consumer Prices Index"
         type: string
       type:
-        description: "The type of dataset"
-        example: "cantabular_flexible_table"
-        type: string
+        $ref: "#/definitions/DatasetType"
       unit_of_measure:
         description: "The unit of measure for the dataset observations"
         type: string
+        example: "Number of people"
       topics:
-        description: "A list of topics and subtopics that the dataset relates to within the website taxonomy. This field consolidates the previously separate `canonical_topic` and `subtopics` fields."
+        description: "A list of topic IDs that the dataset relates to within the topic taxonomy. This field consolidates the previously separate `canonical_topic` and `subtopics` fields."
         type: array
         items:
           type: "string"
+        example: ["7779", "7755"]
 
-  Type:
-    description: "The type for a dataset"
+  DatasetType:
+    description: |
+      The type of dataset as determined by the backing data store. Used to determine which functionality is available for a dataset.
+
+      Available types:
+        * `filterable`: Datasets provided by Customise My Data product providing ability to filter observations by specific dimension options.
+        * `cantabular_flexible_table`: Dataset derived from a `cantabular_blob` allowing the option to change the geography level and filter on specific areas.
+        * `cantabular_multivariate_table`: Dataset with multiple variables derived from a `cantabular_blob` allowing the option to customise the dataset by adding or removing dimensions as well as by changing the geography level and dimension categorisation.
+        * `static`: Datasets available as a flat file download without additional querying capabilities.
     type: string
-    enum: [filterable]
+    enum:
+      - filterable
+      - cantabular_flexible_table
+      - cantabular_multivariate_table
+      - static
     default: "filterable"
+    example: "static"
   IsBasedOn:
     description: "Information about the population-type that the dataset is based on (census 2021 only)"
     type: object
@@ -1431,49 +1410,27 @@ definitions:
         description: "The variable name (census datasets only)"
         type: string
   Dimensions:
+    description: "List of dimensions for a specific dataset version."
     type: object
-    properties:
-      count:
-        description: "The number of dimensions returned for a version from an edition of a dataset"
-        readOnly: true
-        type: integer
-      items:
-        description: "An array of dimensions"
-        type: array
-        items:
-          $ref: "#/definitions/Dimension"
-      limit:
-        description: "The number of dimensions requested for a version from an edition of a dataset"
-        type: integer
-      offset:
-        description: "The first row of dimension for a version from an edition of a dataset to retrieve, starting at 0. Use this parameter as a pagination mechanism along with the limit parameter"
-        type: integer
-      total_count:
-        description: "The total number of dimensions against a version from an edition of a dataset"
-        readOnly: true
-        type: integer
+    allOf:
+      - $ref: "#/definitions/PaginationFields"
+      - type: object
+        properties:
+          items:
+            type: array
+            items:
+              $ref: "#/definitions/Dimension"
   DimensionOptions:
+    description: "A list of options for a specific dimension."
     type: object
-    properties:
-      count:
-        description: "The number of dimensions returned for a version from an edition of a dataset"
-        readOnly: true
-        type: integer
-      items:
-        description: "An array of dimension options"
-        type: array
-        items:
-          $ref: "#/definitions/DimensionOption"
-      limit:
-        description: "The number of dimensions requested for a version from an edition of a dataset"
-        type: integer
-      offset:
-        description: "The first row of dimension for a version from an edition of a dataset to retrieve, starting at 0. Use this parameter as a pagination mechanism along with the limit parameter"
-        type: integer
-      total_count:
-        description: "The total number of dimensions against a version from an edition of a dataset"
-        readOnly: true
-        type: integer
+    allOf:
+      - $ref: "#/definitions/PaginationFields"
+      - type: object
+        properties:
+          items:
+            type: array
+            items:
+              $ref: "#/definitions/DimensionOption"
   DimensionOption:
     type: object
     properties:
@@ -1601,26 +1558,16 @@ definitions:
       state:
         $ref: "#/definitions/State"
   Editions:
+    description: "A list of editions of a dataset."
     type: object
-    properties:
-      count:
-        description: "The number of editions returned for a dataset"
-        readOnly: true
-        type: integer
-      items:
-        type: array
-        items:
-          $ref: "#/definitions/Edition"
-      limit:
-        description: "The number of editions requested for a dataset"
-        type: integer
-      offset:
-        description: "The first row of editions for a dataset to retrieve, starting at 0. Use this parameter as a pagination mechanism along with the limit parameter"
-        type: integer
-      total_count:
-        description: "The total number of editions against a dataset"
-        readOnly: true
-        type: integer
+    allOf:
+      - $ref: "#/definitions/PaginationFields"
+      - type: object
+        properties:
+          items:
+            type: array
+            items:
+              $ref: "#/definitions/Edition"
   Event:
     type: object
     properties:
@@ -1734,11 +1681,11 @@ definitions:
             properties:
               href:
                 description: "The URL for the dataset associated with this instance"
-                example: "http://localhost:22000/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c"
+                example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset"
                 type: string
               id:
                 description: "The ID of the dataset associated with this instance"
-                example: "95c4669b-3ae9-4ba7-b690-87e890a1c67c"
+                example: "my-dataset"
                 type: string
           dimensions:
             description: "An object describing the URL for the dimensions which are associated with this instance"
@@ -1747,7 +1694,7 @@ definitions:
             properties:
               href:
                 description: "The URL for a list of dimensions associated with this instance"
-                example: "http://localhost:22000/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2017/versions/1/dimensions"
+                example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017/versions/1/dimensions"
                 type: string
           edition:
             description: "An object describing the ID and URL for the dataset edition that is associated with this instance"
@@ -1756,7 +1703,7 @@ definitions:
             properties:
               href:
                 description: "The URL for the dataset edition associated with this instance"
-                example: "http://localhost:22000/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2017"
+                example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017"
                 type: string
               id:
                 description: "The ID for the dataset edition associated with this instance"
@@ -1769,7 +1716,7 @@ definitions:
             properties:
               href:
                 description: "The URL for the job containing this instance"
-                example: "http://localhost:21800/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35"
+                example: "https://api.beta.ons.gov.uk/v1/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35"
                 type: string
               id:
                 description: "The ID of the job containing this instance"
@@ -1782,7 +1729,7 @@ definitions:
             properties:
               href:
                 description: "The URL for this resource"
-                example: "http://localhost:22000/instances/45c4669b-3ae9-4ba7-b690-87e890a1c67f"
+                example: "https://api.beta.ons.gov.uk/v1/instances/45c4669b-3ae9-4ba7-b690-87e890a1c67f"
                 type: string
           spatial:
             description: "A link object describing the url to a list of geography ranges for the version of the dataset"
@@ -1798,11 +1745,11 @@ definitions:
             properties:
               href:
                 description: "The URL for the dataset version associated with this instance"
-                example: "http://localhost:21800/dataset/042e216a-7822-4fa0-a3d6-e3f5248ffc35/edition/2017/version/1"
+                example: "https://api.beta.ons.gov.uk/v1/dataset/my-dataset/edition/2017/version/1"
                 type: string
               id:
                 description: "The ID of the dataset version associated with this instance"
-                example: "042e216a-7822-4fa0-a3d6-e3f5248ffc35"
+                example: "1"
                 type: string
       release_date:
         description: "The release date of this version of the dataset"
@@ -1821,23 +1768,14 @@ definitions:
   Instances:
     description: "A list of instance resources, if query parameter state is set return all instances with that state"
     type: object
-    properties:
-      count:
-        description: "The number of instances returned"
-        type: integer
-      items:
-        type: array
-        items:
-          $ref: "#/definitions/Instance"
-      limit:
-        description: "The number of instances requested"
-        type: integer
-      offset:
-        description: "The first row of instances to retrieve, starting at 0. Use this parameter as a pagination mechanism along with the limit parameter"
-        type: integer
-      total_count:
-        description: "The total number of instances"
-        type: integer
+    allOf:
+      - $ref: "#/definitions/PaginationFields"
+      - type: object
+        properties:
+          items:
+            type: array
+            items:
+              $ref: "#/definitions/Instance"
   LatestChange:
     description: "A single change between this version and the previous version of an edition for a dataset"
     type: object
@@ -1911,25 +1849,16 @@ definitions:
         items:
           $ref: "#/definitions/LatestChange"
       license:
-        description: "The standard Government license right text for the dataset"
+        description: "The license the dataset is released under."
         type: string
+        default: "Open Government Licence v3.0"
       dataset_links:
         $ref: "#/definitions/MetadataLinks"
       methodologies:
-        description: "A list of methodologies for a dataset"
+        description: "A list of methodologies for the dataset."
         type: array
         items:
-          type: object
-          properties:
-            description:
-              description: "The description of a methodology"
-              type: string
-            href:
-              description: "The url to a methodology"
-              type: string
-            title:
-              description: "The title of a methodology"
-              type: string
+          $ref: "#/definitions/RelatedLink"
       national_statistic:
         description: "The flag indicating the resource is a national statistic. These are certified as compliant with the Code of Practice for Official Statistics"
         type: boolean
@@ -1937,47 +1866,19 @@ definitions:
         description: "The next release date for a dataset"
         type: string
       publications:
-        description: "A list of publications for a dataset"
+        description: "A list of publications related to this dataset."
         type: array
         items:
-          type: object
-          properties:
-            description:
-              description: "The description of a publication"
-              type: string
-            href:
-              description: "The url to a publication"
-              type: string
-            title:
-              description: "The title of a publication"
-              type: string
+          $ref: "#/definitions/RelatedLink"
       publisher:
         $ref: "#/definitions/Publisher"
       qmi:
-        description: "Object containing information on the quality and methodology index of a dataset"
-        type: object
-        properties:
-          description:
-            description: "The description of a quality and methodology index"
-            type: string
-          href:
-            description: "The url to a quality and methodology index"
-            type: string
-          title:
-            description: "The title of a quality and methodology index"
-            type: string
+        $ref: "#/definitions/QMILink"
       related_datasets:
-        description: "A list of objects containing information of datasets related to a dataset"
+        description: "A list of other datasets related to this dataset."
         type: array
         items:
-          type: object
-          properties:
-            href:
-              description: "The url to a related dataset"
-              type: string
-            title:
-              description: "The title of a related dataset"
-              type: string
+          $ref: "#/definitions/RelatedLink"
       release_date:
         description: "The release date of this version of the dataset"
         type: string
@@ -1991,9 +1892,6 @@ definitions:
           type: "string"
       temporal:
         $ref: "#/definitions/Temporal"
-      theme:
-        description: "The theme for a dataset"
-        type: string
       title:
         description: "The title of the dataset"
         example: "CPI"
@@ -2001,12 +1899,9 @@ definitions:
       unit_of_measure:
         description: "The unit of measure for the dataset observations"
         type: string
-      uri:
-        description: "The uri to the location of the dataset on the web"
-        type: string
       usage_notes:
         $ref: "#/definitions/UsageNotes"
-      themes:
+      topics:
         description: "A list of topics and subtopics that the dataset relates to within the website taxonomy. This field consolidates the previously separate `canonical_topic` and `subtopics` fields."
         type: array
         items:
@@ -2026,7 +1921,7 @@ definitions:
               collection_id:
                 $ref: "#/definitions/CollectionID"
               type:
-                $ref: "#/definitions/Type"
+                $ref: "#/definitions/DatasetType"
           - $ref: "#/definitions/Dataset"
       next:
         allOf:
@@ -2035,7 +1930,7 @@ definitions:
               collection_id:
                 $ref: "#/definitions/CollectionID"
               type:
-                $ref: "#/definitions/Type"
+                $ref: "#/definitions/DatasetType"
           - $ref: "#/definitions/Dataset"
   NewInstance:
     description: "A model for the request and response body for creating a new instance"
@@ -2061,11 +1956,11 @@ definitions:
             properties:
               href:
                 description: "The URL for the dataset associated with this instance"
-                example: "http://localhost:22000/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c"
+                example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset"
                 type: string
               id:
                 description: "The ID of the dataset associated with this instance"
-                example: "95c4669b-3ae9-4ba7-b690-87e890a1c67c"
+                example: "my-dataset"
                 type: string
           job:
             description: "An object describing the ID and URL of the job containing this instance"
@@ -2074,7 +1969,7 @@ definitions:
             properties:
               href:
                 description: "The URL for the job containing this instance"
-                example: "http://localhost:21800/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35"
+                example: "https://api.beta.ons.gov.uk/v1/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35"
                 type: string
               id:
                 description: "The ID of the job containing this instance"
@@ -2087,12 +1982,10 @@ definitions:
             properties:
               href:
                 description: "The URL for this resource"
-                example: "http://localhost:22000/instances/45c4669b-3ae9-4ba7-b690-87e890a1c67f"
+                example: "https://api.beta.ons.gov.uk/v1/instances/45c4669b-3ae9-4ba7-b690-87e890a1c67f"
                 type: string
       state:
-        description: "The state of the resource, this can only have a value of `created`"
-        type: string
-        readOnly: true
+        $ref: "#/definitions/State"
   NewVersionResponse:
     description: "A model for the response body when creating a new version for an edition of a dataset"
     allOf:
@@ -2128,6 +2021,13 @@ definitions:
         * associated (not editions)
         * published
     type: string
+    enum:
+      - created
+      - completed
+      - failed
+      - edition-confirmed
+      - associated
+      - published
   Temporal:
     description: "A list of frequencies the dataset covers for a particular period of time"
     type: array
@@ -2270,27 +2170,16 @@ definitions:
         description: "The content of the note"
         type: string
   Versions:
+    description: "A list of version history for a specific dataset edition."
     type: object
-    properties:
-      count:
-        description: "The number of versions returned for an edition of a dataset"
-        readOnly: true
-        type: integer
-      items:
-        description: "An array of Datasets"
-        type: array
-        items:
-          $ref: "#/definitions/Version"
-      limit:
-        description: "The number of versions requested for an edition of a dataset"
-        type: integer
-      offset:
-        description: "The first row of versions for an edition of a dataset to retrieve, starting at 0. Use this parameter as a pagination mechanism along with the limit parameter"
-        type: integer
-      total_count:
-        description: "The total number of versions for an edition of a dataset"
-        readOnly: true
-        type: integer
+    allOf:
+      - $ref: "#/definitions/PaginationFields"
+      - type: object
+        properties:
+          items:
+            type: array
+            items:
+              $ref: "#/definitions/Version"
   Version:
     description: "An object containing information about published datasets from the ONS"
     required: [release_date]
@@ -2325,7 +2214,7 @@ definitions:
         readOnly: true
         type: string
       id:
-        description: "The identifier for this version of an edition for a dataset"
+        description: "The dataset identifier of the dataset this version is an instance of."
         type: string
       is_based_on:
         $ref: "#/definitions/IsBasedOn"
@@ -2350,8 +2239,7 @@ definitions:
       temporal:
         $ref: "#/definitions/Temporal"
       type:
-        description: "The type of dataset - e.g. cantabular_flexible_table"
-        type: string
+        $ref: "#/definitions/DatasetType"
       version:
         description: "A number identifying the version for an edition from a dataset"
         example: 1
@@ -2364,7 +2252,7 @@ definitions:
           $ref: "#/definitions/UsageNotes"
   # Link objects
   DatasetLinks:
-    description: "A list of links related to this resource"
+    description: "Navigational links related to the dataset resource to aid in API navigation."
     type: object
     properties:
       editions:
@@ -2373,14 +2261,19 @@ definitions:
         properties:
           href:
             description: "A URL to all editions for this dataset"
-            example: "http://localhost:8080/datasets/DE3BC0B6-D6C4-4E20-917E-95D7EA8C91DC/editions"
             type: string
       latest_version:
         $ref: "#/definitions/LatestVersionLink"
       self:
         $ref: "#/definitions/SelfLink"
-      taxonomy:
-        $ref: "#/definitions/TaxonomyLink"
+    example:
+      editions:
+        href: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions"
+      latest_version:
+        href: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017/versions/5"
+        id: "5"
+      self:
+        href: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset"
   EditionLinks:
     description: "A list of links related to this resource"
     readOnly: true
@@ -2397,15 +2290,13 @@ definitions:
         properties:
           href:
             description: "A URL to all versions dor an edition of a dataset"
-            example: "http://localhost:8080/datasets/DE3BC0B6-D6C4-4E20-917E-95D7EA8C91DC/edition/2017/versions"
+            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/edition/2017/versions"
             type: string
   MetadataLinks:
     description: "A list of links related to this resource"
     readOnly: true
     type: object
     properties:
-      access_right:
-        $ref: "#/definitions/AccessRightsLink"
       self:
         $ref: "#/definitions/SelfLink"
       spatial:
@@ -2419,17 +2310,6 @@ definitions:
           href:
             description: "The uri to the location of this version of the dataset on the web"
             type: string
-  ObservationLinks:
-    description: "A list of links related to this resource"
-    readOnly: true
-    type: object
-    properties:
-      dataset_metadata:
-        $ref: "#/definitions/MetadataLink"
-      self:
-        $ref: "#/definitions/SelfLink"
-      version:
-        $ref: "#/definitions/VersionLink"
   VersionLinks:
     description: "A list of links related to this resource"
     type: object
@@ -2442,7 +2322,7 @@ definitions:
         properties:
           href:
             description: "A URL to list dimensions for this version"
-            example: "http://localhost:8080/datasets/DE3BC0B6-D6C4-4E20-917E-95D7EA8C91DC/editions/2017/versions/2/dimensions"
+            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017/versions/2/dimensions"
             type: string
       edition:
         $ref: "#/definitions/EditionLink"
@@ -2457,11 +2337,12 @@ definitions:
     properties:
       href:
         description: "A URL to the parent dataset for this resource"
-        example: "http://localhost:8080/datasets/DE3BC0B6-D6C4-4E20-917E-95D7EA8C91DC"
+        example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset"
         type: string
       id:
         description: "The unique id for the dataset of this version"
         type: string
+        example: "my-dataset"
   EditionLink:
     description: "An object containing the edition and link"
     readOnly: true
@@ -2469,11 +2350,12 @@ definitions:
     properties:
       href:
         description: "A URL to the dataset edition for a version"
-        example: "http://localhost:8080/datasets/DE3BC0B6-D6C4-4E20-917E-95D7EA8C91DC/editions/2017"
+        example: "https://api.beta.ons.gov.uk/v1/datasets/my-datasets/editions/2017"
         type: string
       id:
         description: "The unique id for the dataset edition for a version"
         type: string
+        example: "2017"
   LatestVersionLink:
     description: "An object containing the latest version id and link"
     type: object
@@ -2481,11 +2363,12 @@ definitions:
     properties:
       href:
         description: "A link to the latest version and edition of the dataset"
-        example: "http://localhost:8080/datasets/DE3BC0B6-D6C4-4E20-917E-95D7EA8C91DC/editions/2017/versions/2"
+        example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017/versions/5"
         type: string
       id:
         description: "The unique id for the latest version of a dataset"
         type: "string"
+        example: "5"
   MetadataLink:
     description: "The version metadata that is associated with this resource"
     type: object
@@ -2514,22 +2397,6 @@ definitions:
       href:
         description: "A url to a list of geography ranges for the version of the dataset"
         type: string
-  JobLink:
-    type: object
-    properties:
-      href:
-        description: "A URL to list dimensions for this version"
-        type: string
-      id:
-        description: "A Job id"
-        type: string
-  TaxonomyLink:
-    description: "A link to the taxonomy of the dataset"
-    type: object
-    properties:
-      href:
-        description: "A url to the taxonomy of the dataset"
-        type: string
   VersionLink:
     description: "The dataset version this resource belongs to"
     type: object
@@ -2537,9 +2404,62 @@ definitions:
       href:
         description: "A URL to the version this resource relates to"
         type: string
+        example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/2017/versions/5"
       id:
         description: "The version number this resource relates to"
         type: string
+        example: "5"
+  RelatedLink:
+    type: object
+    required:
+      - href
+      - title
+    properties:
+      href:
+        description: "The url of the linked item."
+        type: string
+        example: "https://www.ons.gov.uk/my-related-page"
+      title:
+        description: "The title of the linked item."
+        type: string
+        example: "Related Link Title"
+      description:
+        description: "The description of the linked item."
+        type: string
+        example: "This is a description of the linked resource."
+  QMILink:
+    type: object
+    required:
+      - href
+    properties:
+      href:
+        description: "The url to the quality and methodology information sheet for the dataset."
+        type: string
+        example: "https://www.ons.gov.uk/businessindustryandtrade/retailindustry/methodologies/retailsalesindexrsiqmi"
+  PaginationFields:
+    type: object
+    properties:
+      count:
+        description: "The number of items returned."
+        readOnly: true
+        type: integer
+        example: 20
+      limit:
+        description: "The number of items requested."
+        type: integer
+        default: 20
+        minimum: 0
+        maximum: 1000
+      offset:
+        description: "The offset of the first item to retrieve, starting at 0. Use this parameter as a pagination mechanism along with the limit parameter"
+        type: integer
+        example: 0
+        default: 0
+      total_count:
+        description: "The total number of items available."
+        readOnly: true
+        type: integer
+        example: 123
   MetadataUpdate:
     description: "An object containing all editable metadata fields on a dataset and a version resource"
     type: object
@@ -2576,23 +2496,14 @@ definitions:
         items:
           $ref: "#/definitions/LatestChange"
       license:
-        description: "The standard Government license right text for the dataset"
+        description: "The license the dataset is released under."
         type: string
+        default: "Open Government Licence v3.0"
       methodologies:
-        description: "A list of methodologies for a dataset"
+        description: "A list of methodologies for the dataset."
         type: array
         items:
-          type: object
-          properties:
-            description:
-              description: "The description of a methodology"
-              type: string
-            href:
-              description: "The url to a methodology"
-              type: string
-            title:
-              description: "The title of a methodology"
-              type: string
+          $ref: "#/definitions/RelatedLink"
       national_statistic:
         description: "The flag indicating the resource is a national statistic. These are certified as compliant with the Code of Practice for Official Statistics"
         type: boolean
@@ -2600,60 +2511,22 @@ definitions:
         description: "The next release date for a dataset"
         type: string
       publications:
-        description: "A list of publications for a dataset"
+        description: "A list of publications related to this dataset."
         type: array
         items:
-          type: object
-          properties:
-            description:
-              description: "The description of a publication"
-              type: string
-            href:
-              description: "The url to a publication"
-              type: string
-            title:
-              description: "The title of a publication"
-              type: string
+          $ref: "#/definitions/RelatedLink"
       qmi:
-        description: "Object containing information on the quality and methodology index of a dataset"
-        type: object
-        properties:
-          description:
-            description: "The description of a quality and methodology index"
-            type: string
-          href:
-            description: "The url to a quality and methodology index"
-            type: string
-          title:
-            description: "The title of a quality and methodology index"
-            type: string
+        $ref: "#/definitions/QMILink"
       related_content:
-        description: "A list of objects containing information of content related to a dataset"
+        description: "A list of website content related to this dataset."
         type: array
         items:
-          type: object
-          properties:
-            href:
-              description: "The url to related content"
-              type: string
-            description:
-              description: "The description of the related content"
-              type: string
-            title:
-              description: "The title of the related content"
-              type: string
+          $ref: "#/definitions/RelatedLink"
       related_datasets:
-        description: "A list of objects containing information of datasets related to a dataset"
+        description: "A list of other datasets related to this dataset."
         type: array
         items:
-          type: object
-          properties:
-            href:
-              description: "The url to a related dataset"
-              type: string
-            title:
-              description: "The title of a related dataset"
-              type: string
+          $ref: "#/definitions/RelatedLink"
       release_date:
         description: "The release date of this version of the dataset"
         type: string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,11 +1,11 @@
 swagger: "2.0"
 info:
-  description: "Used to find information about data published by the ONS.
-  `Datasets` are published in unique `versions`, which are categorized by `edition`.
-  Data in each version is broken down by `dimensions`, and a unique combination
-  of dimension `options` in a version can be used to retrieve `observation` level data.
-  
-  Note: As of the latest update, the `@context` field has been removed from all dataset endpoints to improve response performance and correct data structure."
+  description: |
+    Used to find information about data published by the ONS.
+
+    `Datasets` are published in unique `versions`, which are categorized by `edition`. Data in each version is broken down by `dimensions`, and a unique combination of dimension `options` in a version can be used to retrieve `observation` level data.
+
+    Note: As of the latest update, the `@context` field has been removed from all dataset endpoints to improve response performance and correct data structure."
   version: "1.0.0"
   title: "Explore our data"
   license:
@@ -13,11 +13,12 @@ info:
     url: "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
 basePath: "/v1"
 tags:
-- name: "Public"
-- name: "Private user"
-- name: "Private"
+  - name: "Public"
+    description: Endpoints available on public API.
+  - name: "Private"
+    description: Internal only endpoints.
 schemes:
-- "http"
+  - "http"
 parameters:
   dataset:
     name: dataset
@@ -40,14 +41,14 @@ parameters:
     required: true
     name: patch
     schema:
-      $ref: '#/definitions/PatchOptions'
+      $ref: "#/definitions/PatchOptions"
     description: "A list of patch operations for a dimension option"
     in: body
   patch_dimensions:
     required: true
     name: patch
     schema:
-      $ref: '#/definitions/PatchDimensions'
+      $ref: "#/definitions/PatchDimensions"
     description: "A list of patch operations for a dimension"
     in: body
   edition:
@@ -61,7 +62,7 @@ parameters:
     description: "An event that occurs when importing a dataset"
     in: body
     schema:
-      $ref: '#/definitions/Event'
+      $ref: "#/definitions/Event"
   id:
     name: id
     description: "Id that represents a dataset"
@@ -73,7 +74,7 @@ parameters:
     description: "A request body to update the state of an import task"
     in: body
     schema:
-      $ref: '#/definitions/ImportTasks'
+      $ref: "#/definitions/ImportTasks"
   inserted_observations:
     name: inserted_observations
     description: "A value to increment the inserted_observations within an instance"
@@ -92,18 +93,18 @@ parameters:
     in: body
     required: true
     schema:
-      $ref: '#/definitions/Instance'
+      $ref: "#/definitions/Instance"
   new_dataset:
     name: dataset
     description: "A new dataset"
     in: body
     required: true
     schema:
-     allOf:
+      allOf:
         - type: object
           properties:
-            type:  
-              $ref: '#/definitions/Type'
+            type:
+              $ref: "#/definitions/Type"
         - $ref: "#/definitions/Dataset"
   new_edition:
     name: new_edition
@@ -111,33 +112,33 @@ parameters:
     in: body
     required: true
     schema:
-      $ref: '#/definitions/Edition'
+      $ref: "#/definitions/Edition"
   new_version:
     name: new_version
     description: "A new version for an edition of a dataset"
     in: body
     required: true
     schema:
-      $ref: '#/definitions/Version'
+      $ref: "#/definitions/Version"
   node_id:
-   name: node_id
-   description: "An unique node id"
-   in: path
-   required: true
-   type: string
+    name: node_id
+    description: "An unique node id"
+    in: path
+    required: true
+    type: string
   newInstance:
     name: instance
     description: "An instance related to an import job"
     in: body
     required: true
     schema:
-      $ref: '#/definitions/NewInstance'
+      $ref: "#/definitions/NewInstance"
   option:
-   name: option
-   description: "A option to set within a type"
-   in: path
-   required: true
-   type: string
+    name: option
+    description: "A option to set within a type"
+    in: path
+    required: true
+    type: string
   state:
     name: "state"
     description: "A comma separated list of state values to filter on (e.g. ‘completed,edition-confirmed’)"
@@ -156,13 +157,13 @@ parameters:
     in: body
     required: true
     schema:
-      $ref: '#/definitions/UpdateInstanceDimension'
+      $ref: "#/definitions/UpdateInstanceDimension"
   update_dimension_option_request:
     name: dimension_option
     description: "A dimension option from an instance"
     in: body
     schema:
-      $ref: '#/definitions/UpdateDimensionOptionRequest'
+      $ref: "#/definitions/UpdateDimensionOptionRequest"
   version:
     name: version
     description: "A version of a dataset"
@@ -175,7 +176,7 @@ parameters:
     in: body
     required: true
     schema:
-      $ref: '#/definitions/UpdateVersion'
+      $ref: "#/definitions/UpdateVersion"
   limit:
     name: limit
     description: "Maximum number of items that will be returned. A value of zero will return zero items. The default value is 20, and the maximum limit allowed is 1000"
@@ -213,18 +214,13 @@ parameters:
     schema:
       $ref: "#/definitions/MetadataUpdate"
 securityDefinitions:
-  FlorenceAPIKey:
-    name: florence-token
-    description: "API key used to allow florence users to create and query the progress of importing a dataset"
-    in: header
-    type: apiKey
-  InternalAPIKey:
-    name: internal-token
-    description: "API key used to allow only internal services to update the state of an import job"
+  Authorization:
+    name: Authorization
+    description: "Access token provided by Auth Service in a Bearer format. Can be a human or service user token."
     in: header
     type: apiKey
   DownloadServiceAPIKey:
-    name: x-download-service-token
+    name: X-Download-Service-Token
     description: "API key used to allow the download service to access public and private links to a download"
     in: header
     type: apiKey
@@ -232,40 +228,45 @@ paths:
   /datasets:
     get:
       tags:
-      - "Public"
+        - "Public"
       summary: "Get a list of datasets"
       description: "Returns a list of all datasets provided by the ONS that can be filtered using the filter API"
-      parameters: 
-      - $ref: '#/parameters/is_based_on'
-      - $ref: '#/parameters/limit'
-      - $ref: '#/parameters/offset'
+      parameters:
+        - $ref: "#/parameters/is_based_on"
+        - $ref: "#/parameters/limit"
+        - $ref: "#/parameters/offset"
+      security:
+        - {}
+        - Authorization: []
       produces:
-      - "application/json"
+        - "application/json"
       responses:
         200:
           description: "A json list containing datasets which have been published"
           schema:
-            $ref: '#/definitions/Datasets'
+            $ref: "#/definitions/Datasets"
         400:
           description: "Parameter is_based_on was sent but no value was provided"
         404:
           description: "No dataset was found with the popultation-type provided"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
     post:
       tags:
-      - "Private user"
+        - "Private"
       summary: "Create a new dataset"
       description: "Allows an authenticated and authorised user to create a new dataset. The dataset ID should be included in the request body."
       parameters:
-      - $ref: '#/parameters/new_dataset'
+        - $ref: "#/parameters/new_dataset"
+      security:
+        - Authorization: []
       produces:
-      - "application/json"
+        - "application/json"
       responses:
         201:
           description: "A JSON object containing the newly created dataset"
           schema:
-            $ref: '#/definitions/NewDatasetResponse'
+            $ref: "#/definitions/NewDatasetResponse"
         400:
           description: "Invalid request body"
         401:
@@ -273,26 +274,28 @@ paths:
         403:
           description: "Forbidden to overwrite dataset, dataset already exists"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
 
   /datasets/{id}:
     post:
       tags:
-      - "Private user"
+        - "Private"
       summary: "Create a dataset (deprecated)"
       description: |
         **Deprecated:** This endpoint is being replaced by `POST /datasets`. Please use `POST /datasets` and provide the dataset ID in the request body. This endpoint may be removed in a future release.
       deprecated: true
       parameters:
-      - $ref: '#/parameters/id'
-      - $ref: '#/parameters/new_dataset'
+        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/new_dataset"
+      security:
+        - Authorization: []
       produces:
-      - "application/json"
+        - "application/json"
       responses:
         201:
           description: "A json object containing a dataset which has been created"
           schema:
-            $ref: '#/definitions/NewDatasetResponse'
+            $ref: "#/definitions/NewDatasetResponse"
         400:
           description: "Invalid request body"
         401:
@@ -300,31 +303,36 @@ paths:
         403:
           description: "Forbidden to overwrite dataset, already published"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
     get:
       tags:
-      - "Public"
+        - "Public"
       summary: "Get a dataset"
       description: "The dataset contains all high level information, for additional details see editions or versions of a dataset. "
       parameters:
-      - $ref: '#/parameters/id'
+        - $ref: "#/parameters/id"
+      security:
+        - {}
+        - Authorization: []
       responses:
         200:
           description: "A json object for a single Dataset"
           schema:
-            $ref: '#/definitions/DatasetResponse'
+            $ref: "#/definitions/DatasetResponse"
         404:
           description: "No dataset was found using the id provided"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
     put:
       tags:
-      - "Private user"
+        - "Private"
       summary: "Update a dataset"
       description: "Update the metadata for the next release of the dataset. The dataset contains all high level information, for additional details see editions or versions of a dataset."
       parameters:
-      - $ref: '#/parameters/id'
-      - $ref: '#/parameters/update_dataset'
+        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/update_dataset"
+      security:
+        - Authorization: []
       responses:
         200:
           description: "A json object for a single Dataset"
@@ -335,14 +343,16 @@ paths:
         404:
           description: "No dataset was found using the id provided"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
     delete:
       tags:
-      - "Private user"
+        - "Private"
       summary: "Delete a dataset"
       description: "Delete an existing dataset"
       parameters:
-      - $ref: '#/parameters/id'
+        - $ref: "#/parameters/id"
+      security:
+        - Authorization: []
       responses:
         204:
           description: "The dataset was successfully deleted"
@@ -351,64 +361,75 @@ paths:
         403:
           description: "Forbidden to delete dataset, already published"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /datasets/{id}/editions:
     get:
       tags:
-      - "Public"
+        - "Public"
       summary: "Get a list of editions of a dataset"
       description: "Get a list of editions of a type of dataset"
       parameters:
-      - $ref: '#/parameters/id'
-      - $ref: '#/parameters/limit'
-      - $ref: '#/parameters/offset'
+        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/limit"
+        - $ref: "#/parameters/offset"
+      security:
+        - {}
+        - Authorization: []
       responses:
         200:
           description: "A json list containing all editions for a dataset"
           schema:
-            $ref: '#/definitions/Editions'
+            $ref: "#/definitions/Editions"
         400:
           description: "Invalid request, dataset id was incorrect"
         404:
           description: "No editions were found for the id provided"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /datasets/{id}/editions/{edition}:
     get:
       tags:
-      - "Public"
+        - "Public"
       summary: "Get an edition of a dataset"
       description: "The edition contains a link to all versions"
       parameters:
-      - $ref: '#/parameters/edition'
-      - $ref: '#/parameters/id'
+        - $ref: "#/parameters/edition"
+        - $ref: "#/parameters/id"
+      security:
+        - {}
+        - Authorization: []
       responses:
         200:
           description: "A json object containing an edition"
           schema:
-            $ref: '#/definitions/Edition'
+            $ref: "#/definitions/Edition"
         400:
           description: "Invalid request, dataset id was incorrect"
         404:
           description: "No edition of a dataset was found using the id and edition provided"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /datasets/{id}/editions/{edition}/versions:
     get:
       tags:
-      - "Public"
+        - "Public"
       summary: "Get a list of versions of an edition"
       description: "Get a list of all versions for an edition of a dataset"
       parameters:
-      - $ref: '#/parameters/edition'
-      - $ref: '#/parameters/id'
-      - $ref: '#/parameters/limit'
-      - $ref: '#/parameters/offset'
+        - $ref: "#/parameters/edition"
+        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/limit"
+        - $ref: "#/parameters/offset"
+      security:
+        - {}
+        - Authorization: []
+        - Authorization: []
+          DownloadServiceAPIKey: []
       responses:
         200:
           description: "A json list containing all versions for a set type of dataset and edition"
           schema:
-            $ref: '#/definitions/Versions'
+            $ref: "#/definitions/Versions"
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -417,21 +438,24 @@ paths:
         404:
           description: "No versions found using the id and edition provided"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
     post:
       tags:
-      - "Private user"
+        - "Private"
       summary: "Create a version"
       description: "Create a version for a dataset series.  This will set the state of the version and dataset series to be associated."
       parameters:
-        - $ref: '#/parameters/id'
-        - $ref: '#/parameters/edition'
-        - $ref: '#/parameters/new_version'
+        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/edition"
+        - $ref: "#/parameters/new_version"
+      security:
+        - {}
+        - Authorization: []
       responses:
         201:
           description: "A json object containing a version"
           schema:
-            $ref: '#/definitions/NewVersionResponse'
+            $ref: "#/definitions/NewVersionResponse"
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -443,23 +467,27 @@ paths:
         404:
           description: "Dataset series was not found for a dataset using the id and edition provided"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /datasets/{id}/editions/{edition}/versions/{version}:
     put:
       tags:
-      - "Private user"
+        - "Private"
       summary: "Update a version"
       description: "Update a version for an edition of a dataset, if the state is changed to associated or published, the parent documents(dataset and edition resources) will also be updated. A version can only be updated if the state is not published"
       parameters:
-      - $ref: '#/parameters/id'
-      - $ref: '#/parameters/edition'
-      - $ref: '#/parameters/version'
-      - $ref: '#/parameters/version_update'
+        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/edition"
+        - $ref: "#/parameters/version"
+        - $ref: "#/parameters/version_update"
+      security:
+        - Authorization: []
+        - Authorization: []
+          DownloadServiceAPIKey: []
       responses:
         201:
           description: "A json object containing a version"
           schema:
-            $ref: '#/definitions/NewVersionResponse'
+            $ref: "#/definitions/NewVersionResponse"
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -473,21 +501,24 @@ paths:
         404:
           description: "Version was not found for a dataset using the id and edition provided"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
     get:
       tags:
-      - "Public"
+        - "Public"
       summary: "Get a version"
       description: "Get a specific version of an edition of a dataset"
       parameters:
-      - $ref: '#/parameters/edition'
-      - $ref: '#/parameters/id'
-      - $ref: '#/parameters/version'
+        - $ref: "#/parameters/edition"
+        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/version"
+      security:
+        - {}
+        - Authorization: []
       responses:
         200:
           description: "A json object containing the edition and version of a dataset"
           schema:
-            $ref: '#/definitions/Version'
+            $ref: "#/definitions/Version"
           headers:
             ETag:
               type: string
@@ -500,23 +531,23 @@ paths:
         404:
           description: "No version was found for an edition of a dataset using the id, edition and version provided"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
     delete:
       tags:
-      - "Private"
+        - "Private"
       summary: "Delete a version"
       description: "detaches a version from a collection. Effectively a soft delete."
       parameters:
-      - $ref: '#/parameters/edition'
-      - $ref: '#/parameters/id'
-      - $ref: '#/parameters/version'
+        - $ref: "#/parameters/edition"
+        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/version"
       security:
-            - InternalAPIKey: []
+        - Authorization: []
       responses:
         200:
           description: "A json object containing the edition and version of a dataset"
           schema:
-            $ref: '#/definitions/Version'
+            $ref: "#/definitions/Version"
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -527,24 +558,27 @@ paths:
         404:
           description: "No version was found for an edition of a dataset using the id, edition and version provided"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /datasets/{id}/editions/{edition}/versions/{version}/dimensions:
     get:
       tags:
-      - "Public"
+        - "Public"
       summary: "Get a list of dimensions from a dataset"
       description: "Get all dimensions which are used in the dataset"
       parameters:
-      - $ref: '#/parameters/edition'
-      - $ref: '#/parameters/id'
-      - $ref: '#/parameters/version'
-      - $ref: '#/parameters/limit'
-      - $ref: '#/parameters/offset'
+        - $ref: "#/parameters/edition"
+        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/version"
+        - $ref: "#/parameters/limit"
+        - $ref: "#/parameters/offset"
+      security:
+        - {}
+        - Authorization: []
       responses:
         200:
           description: "A json list of dimensions"
           schema:
-            $ref: '#/definitions/Dimensions'
+            $ref: "#/definitions/Dimensions"
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -554,26 +588,29 @@ paths:
         404:
           description: "No dimensions found for version of an edition of a dataset using the id, edition and version provided"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /datasets/{id}/editions/{edition}/versions/{version}/dimensions/{dimension}/options:
     get:
       tags:
-      - "Public"
+        - "Public"
       summary: "Get a list of options from a dimension"
       description: "Get a list of options which appear in this dimension and dataset. By default all options are returned, but a subset can be requested by providing offset and limit query parameters, or by providing the list of option IDs, only the IDs that are found will be returned."
       parameters:
-      - $ref: '#/parameters/dimension'
-      - $ref: '#/parameters/edition'
-      - $ref: '#/parameters/id'
-      - $ref: '#/parameters/version'
-      - $ref: '#/parameters/limit'
-      - $ref: '#/parameters/offset'
-      - $ref: '#/parameters/ids'
+        - $ref: "#/parameters/dimension"
+        - $ref: "#/parameters/edition"
+        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/version"
+        - $ref: "#/parameters/limit"
+        - $ref: "#/parameters/offset"
+        - $ref: "#/parameters/ids"
+      security:
+        - {}
+        - Authorization: []
       responses:
         200:
           description: "Json object containing all options for a dimension"
           schema:
-            $ref: '#/definitions/DimensionOptions'
+            $ref: "#/definitions/DimensionOptions"
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -586,22 +623,25 @@ paths:
         404:
           description: "No dimension options were found for dimension"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /datasets/{id}/editions/{edition}/versions/{version}/metadata:
     get:
       tags:
-      - "Public"
+        - "Public"
       summary: "Get metadata for a version"
       description: "Get all metadata relevant to a version"
       parameters:
-      - $ref: '#/parameters/edition'
-      - $ref: '#/parameters/id'
-      - $ref: '#/parameters/version'
+        - $ref: "#/parameters/edition"
+        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/version"
+      security:
+        - {}
+        - Authorization: []
       responses:
         200:
           description: "Json object containing all metadata for a version"
           schema:
-            $ref: '#/definitions/Metadata'
+            $ref: "#/definitions/Metadata"
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -610,18 +650,20 @@ paths:
         404:
           description: "Version not found"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
     put:
       tags:
-      - "Private"
+        - "Private"
       summary: "Update metadata for a dataset and a version"
       description: "Update metadata for a dataset and a version. The editable metadata can be updated only if both the dataset and the version have a state of associated"
       parameters:
-      - $ref: '#/parameters/id'
-      - $ref: '#/parameters/edition'
-      - $ref: '#/parameters/version'
-      - $ref: '#/parameters/if_match'
-      - $ref: '#/parameters/metadata_update'
+        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/edition"
+        - $ref: "#/parameters/version"
+        - $ref: "#/parameters/if_match"
+        - $ref: "#/parameters/metadata_update"
+      security:
+        - Authorization: []
       responses:
         200:
           description: "The editable metadata has been updated"
@@ -639,26 +681,26 @@ paths:
         409:
           description: "Instance does not match the expected eTag"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /datasets/{id}/editions/{edition}/versions/{version}/observations:
     get:
       tags:
-      - "Public"
+        - "Public"
       summary: "Get specific observations"
-      description: "Get observations from a version of the dataset. By providing
-      a single option for each dimension, a single observation will be returned.
-      A wildcard (*) can be provided for one dimension, to retrieve a list of
-      observations."
+      description: "Get observations from a version of the dataset. By providing a single option for each dimension, a single observation will be returned. A wildcard (*) can be provided for one dimension, to retrieve a list of observations."
       parameters:
-        - $ref: '#/parameters/edition'
-        - $ref: '#/parameters/id'
-        - $ref: '#/parameters/version'
-        - $ref: '#/parameters/dimension_options'
+        - $ref: "#/parameters/edition"
+        - $ref: "#/parameters/id"
+        - $ref: "#/parameters/version"
+        - $ref: "#/parameters/dimension_options"
+      security:
+        - {}
+        - Authorization: []
       responses:
         200:
           description: "Json object containing all metadata for a version"
           schema:
-            $ref: '#/definitions/ObservationsEndpoint'
+            $ref: "#/definitions/ObservationsEndpoint"
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -673,105 +715,105 @@ paths:
               * version was incorrect
               * observations not found for selected query paramaters
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /instances:
     get:
       tags:
-      - "Private user"
+        - "Private"
       summary: "Get instances"
       description: "Get a list of instances which has been paged"
       parameters:
-        - $ref: '#/parameters/state'
-        - $ref: '#/parameters/dataset'
-        - $ref: '#/parameters/limit'
-        - $ref: '#/parameters/offset'
+        - $ref: "#/parameters/state"
+        - $ref: "#/parameters/dataset"
+        - $ref: "#/parameters/limit"
+        - $ref: "#/parameters/offset"
       produces:
-      - "application/json"
+        - "application/json"
       security:
-      - FlorenceAPIKey: []
+        - Authorization: []
       responses:
         200:
           description: "Return a list of instance state"
           schema:
-            $ref: '#/definitions/Instances'
+            $ref: "#/definitions/Instances"
         400:
-          $ref: '#/responses/InvalidRequestError'
+          $ref: "#/responses/InvalidRequestError"
         401:
-          $ref: '#/responses/UnauthorisedError'
+          $ref: "#/responses/UnauthorisedError"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
     post:
       tags:
-      - "Private"
+        - "Private"
       summary: "Create an instance"
-      description:  |
+      description: |
         Create an instance which will be imported. To create an instance an import job id and href is required. This is to allow a link back to the import job
       parameters:
-      - $ref: '#/parameters/newInstance'
+        - $ref: "#/parameters/newInstance"
       produces:
-      - "application/json"
+        - "application/json"
       security:
-      - InternalAPIKey: []
+        - Authorization: []
       responses:
         201:
           description: "Successfully created instance"
           schema:
-            $ref: '#/definitions/NewInstance'
+            $ref: "#/definitions/NewInstance"
           headers:
             ETag:
               type: string
               description: "Defines a unique instance resource version"
         400:
-          $ref: '#/responses/InvalidRequestError'
+          $ref: "#/responses/InvalidRequestError"
         401:
-          $ref: '#/responses/UnauthorisedError'
+          $ref: "#/responses/UnauthorisedError"
         403:
-          $ref: '#/responses/ForbiddenError'
+          $ref: "#/responses/ForbiddenError"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /instances/{instance_id}:
     get:
       tags:
-      - "Private user"
+        - "Private"
       summary: "Get an instance"
       description: "Get the current state of an instance, this includes all events which have happened."
       parameters:
-      - $ref: '#/parameters/instance_id'
-      - $ref: '#/parameters/if_match'
+        - $ref: "#/parameters/instance_id"
+        - $ref: "#/parameters/if_match"
       produces:
-      - "application/json"
+        - "application/json"
       security:
-      - FlorenceAPIKey: []
+        - Authorization: []
       responses:
         200:
           description: "Return a single instance state"
           schema:
-            $ref: '#/definitions/Instance'
+            $ref: "#/definitions/Instance"
           headers:
             ETag:
               type: string
               description: "Defines a unique instance resource version"
         401:
-          $ref: '#/responses/UnauthorisedError'
+          $ref: "#/responses/UnauthorisedError"
         404:
-          $ref: '#/responses/InstanceNotFound'
+          $ref: "#/responses/InstanceNotFound"
         409:
-          $ref: '#/responses/ConflictError'
+          $ref: "#/responses/ConflictError"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
     put:
       tags:
-      - "Private"
+        - "Private"
       summary: "Update an instance"
       description: "Update an instance by providing an unique id and a set of properties to over write"
       parameters:
-      - $ref: '#/parameters/instance_id'
-      - $ref: '#/parameters/instance'
-      - $ref: '#/parameters/if_match'
+        - $ref: "#/parameters/instance_id"
+        - $ref: "#/parameters/instance"
+        - $ref: "#/parameters/if_match"
       produces:
-      - "application/json"
+        - "application/json"
       security:
-      - InternalAPIKey: []
+        - Authorization: []
       responses:
         200:
           description: "The instance has been updated"
@@ -780,65 +822,65 @@ paths:
               type: string
               description: "Defines a unique instance resource version"
         400:
-          $ref: '#/responses/InvalidRequestError'
+          $ref: "#/responses/InvalidRequestError"
         401:
-          $ref: '#/responses/UnauthorisedError'
+          $ref: "#/responses/UnauthorisedError"
         403:
-          $ref: '#/responses/ForbiddenError'
+          $ref: "#/responses/ForbiddenError"
         404:
-          $ref: '#/responses/InstanceNotFound'
+          $ref: "#/responses/InstanceNotFound"
         409:
-          $ref: '#/responses/ConflictError'
+          $ref: "#/responses/ConflictError"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /instances/{instance_id}/dimensions:
     get:
       tags:
-      - "Private user"
+        - "Private"
       summary: "Get a list of dimensions for an instance"
       description: "Get all dimensions from an instance"
       parameters:
-      - $ref: '#/parameters/instance_id'
-      - $ref: '#/parameters/if_match'
+        - $ref: "#/parameters/instance_id"
+        - $ref: "#/parameters/if_match"
       produces:
-      - "application/json"
+        - "application/json"
       security:
-      - InternalAPIKey: []
+        - Authorization: []
       responses:
         200:
           description: "Return a list of dimensions"
           schema:
             type: array
             items:
-              $ref: '#/definitions/DimensionOption'
+              $ref: "#/definitions/DimensionOption"
           headers:
             ETag:
               type: string
               description: "Defines a unique instance resource version"
         400:
-          $ref: '#/responses/InvalidRequestError'
+          $ref: "#/responses/InvalidRequestError"
         401:
-          $ref: '#/responses/UnauthorisedError'
+          $ref: "#/responses/UnauthorisedError"
         403:
-          $ref: '#/responses/ForbiddenError'
+          $ref: "#/responses/ForbiddenError"
         404:
-          $ref: '#/responses/InstanceNotFound'
+          $ref: "#/responses/InstanceNotFound"
         409:
-          $ref: '#/responses/ConflictError'
+          $ref: "#/responses/ConflictError"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
     post:
       deprecated: true
       tags:
-      - "Private"
+        - "Private"
       summary: "Create a dimension"
       description: "Create a new dimension which is related to an instance"
       parameters:
-      - $ref: '#/parameters/instance_id'
-      - $ref: '#/parameters/update_dimension_option_request'
-      - $ref: '#/parameters/if_match'
+        - $ref: "#/parameters/instance_id"
+        - $ref: "#/parameters/update_dimension_option_request"
+        - $ref: "#/parameters/if_match"
       security:
-      - InternalAPIKey: []
+        - Authorization: []
       responses:
         201:
           description: "Dimension was created"
@@ -847,57 +889,57 @@ paths:
               type: string
               description: "Defines a unique instance resource version"
         400:
-          $ref: '#/responses/InvalidRequestError'
+          $ref: "#/responses/InvalidRequestError"
         404:
-          $ref: '#/responses/InstanceNotFound'
+          $ref: "#/responses/InstanceNotFound"
         409:
-          $ref: '#/responses/ConflictError'
+          $ref: "#/responses/ConflictError"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
     patch:
       tags:
-      - "Private"
+        - "Private"
       summary: "Create one or more dimensions"
       description: "Create one or more dimensions which are related to an instance"
       parameters:
-      - $ref: '#/parameters/instance_id'
-      - $ref: '#/parameters/patch_dimensions'
-      - $ref: '#/parameters/if_match'
+        - $ref: "#/parameters/instance_id"
+        - $ref: "#/parameters/patch_dimensions"
+        - $ref: "#/parameters/if_match"
       produces:
-      - "application/json-patch+json"
+        - "application/json-patch+json"
       security:
-      - InternalAPIKey: []
+        - Authorization: []
       responses:
         200:
           description: "All dimensions were successfully created"
           schema:
-            $ref: '#/definitions/PatchDimensions'
+            $ref: "#/definitions/PatchDimensions"
           headers:
             ETag:
               type: string
               description: "Defines a unique instance resource version"
         400:
-          $ref: '#/responses/InvalidRequestError'
+          $ref: "#/responses/InvalidRequestError"
         404:
-          $ref: '#/responses/InstanceNotFound'
+          $ref: "#/responses/InstanceNotFound"
         409:
-          $ref: '#/responses/ConflictError'
+          $ref: "#/responses/ConflictError"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
 
   /instances/{instance_id}/dimensions/{dimension}:
     put:
       tags:
-      - "Private user"
+        - "Private"
       summary: "Update dimension"
       description: "Update the label and/or description of a dimension within an instance, by providing dimension name and properties to over write"
       parameters:
-      - $ref: '#/parameters/instance_id'
-      - $ref: '#/parameters/dimension'
-      - $ref: '#/parameters/update_dimension'
-      - $ref: '#/parameters/if_match'
+        - $ref: "#/parameters/instance_id"
+        - $ref: "#/parameters/dimension"
+        - $ref: "#/parameters/update_dimension"
+        - $ref: "#/parameters/if_match"
       security:
-      - InternalAPIKey: []
+        - Authorization: []
       responses:
         200:
           description: "The instance has been updated"
@@ -906,31 +948,31 @@ paths:
               type: string
               description: "Defines a unique instance resource version"
         400:
-          $ref: '#/responses/InvalidRequestError'
+          $ref: "#/responses/InvalidRequestError"
         401:
-          $ref: '#/responses/UnauthorisedError'
+          $ref: "#/responses/UnauthorisedError"
         403:
-          $ref: '#/responses/ForbiddenError'
+          $ref: "#/responses/ForbiddenError"
         404:
-          $ref: '#/responses/InstanceNotFound'
+          $ref: "#/responses/InstanceNotFound"
         409:
-          $ref: '#/responses/ConflictError'
+          $ref: "#/responses/ConflictError"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /instances/{instance_id}/dimensions/{dimension}/options:
     get:
       tags:
-      - "Private user"
+        - "Private"
       summary: "Get a list of options for a dimension"
       description: "Get all unique options from a dimension"
       parameters:
-      - $ref: '#/parameters/instance_id'
-      - $ref: '#/parameters/dimension'
-      - $ref: '#/parameters/if_match'
+        - $ref: "#/parameters/instance_id"
+        - $ref: "#/parameters/dimension"
+        - $ref: "#/parameters/if_match"
       produces:
-      - "application/json"
+        - "application/json"
       security:
-      - InternalAPIKey: []
+        - Authorization: []
       responses:
         200:
           description: "Return a list of unique options"
@@ -950,32 +992,32 @@ paths:
               type: string
               description: "Defines a unique instance resource version"
         400:
-          $ref: '#/responses/InvalidRequestError'
+          $ref: "#/responses/InvalidRequestError"
         401:
-          $ref: '#/responses/UnauthorisedError'
+          $ref: "#/responses/UnauthorisedError"
         403:
-          $ref: '#/responses/ForbiddenError'
+          $ref: "#/responses/ForbiddenError"
         404:
           description: "dimension does not match any dimensions within the instance"
         409:
-          $ref: '#/responses/ConflictError'
+          $ref: "#/responses/ConflictError"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /instances/{instance_id}/events:
     post:
       tags:
-       - "Private"
+        - "Private"
       summary: "Add an event to an instance"
       description: |
         Add a new event into an instance. Events can be for information or error messages.
         Each event must contain a type of event (Info or Error), a message to explain
         the event, time of the event and finally the message offset in kafka
       parameters:
-      - $ref: '#/parameters/instance_id'
-      - $ref: '#/parameters/event'
-      - $ref: '#/parameters/if_match'
+        - $ref: "#/parameters/instance_id"
+        - $ref: "#/parameters/event"
+        - $ref: "#/parameters/if_match"
       security:
-      - InternalAPIKey: []
+        - Authorization: []
       responses:
         201:
           description: "The event was added to the instance"
@@ -984,27 +1026,27 @@ paths:
               type: string
               description: "Defines a unique instance resource version"
         400:
-          $ref: '#/responses/InvalidRequestError'
+          $ref: "#/responses/InvalidRequestError"
         401:
-          $ref: '#/responses/UnauthorisedError'
+          $ref: "#/responses/UnauthorisedError"
         404:
           description: "InstanceId does not match any instances"
         409:
-          $ref: '#/responses/ConflictError'
+          $ref: "#/responses/ConflictError"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /instances/{instance_id}/inserted_observations/{inserted_observations}:
     put:
       tags:
-      - "Private"
+        - "Private"
       summary: "Increment the inserted observation count"
       description: "This will add to the number already store in the api"
       parameters:
-      - $ref: '#/parameters/instance_id'
-      - $ref: '#/parameters/inserted_observations'
-      - $ref: '#/parameters/if_match'
+        - $ref: "#/parameters/instance_id"
+        - $ref: "#/parameters/inserted_observations"
+        - $ref: "#/parameters/if_match"
       security:
-      - InternalAPIKey: []
+        - Authorization: []
       responses:
         200:
           description: "Added value to inserted observation"
@@ -1013,27 +1055,27 @@ paths:
               type: string
               description: "Defines a unique instance resource version"
         400:
-          $ref: '#/responses/InvalidRequestError'
+          $ref: "#/responses/InvalidRequestError"
         401:
-          $ref: '#/responses/UnauthorisedError'
+          $ref: "#/responses/UnauthorisedError"
         404:
           description: "InstanceId does not match any instances"
         409:
-          $ref: '#/responses/ConflictError'
+          $ref: "#/responses/ConflictError"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /instances/{instance_id}/import_tasks:
     put:
       tags:
-      - "Private"
+        - "Private"
       summary: "Update import tasks for an instance"
       description: "The instance import process involves multiple tasks. This endpoint updates the state of an import task."
       parameters:
-      - $ref: '#/parameters/instance_id'
-      - $ref: '#/parameters/import_tasks'
-      - $ref: '#/parameters/if_match'
+        - $ref: "#/parameters/instance_id"
+        - $ref: "#/parameters/import_tasks"
+        - $ref: "#/parameters/if_match"
       security:
-      - InternalAPIKey: []
+        - Authorization: []
       responses:
         200:
           description: "Updated the state of the import task"
@@ -1042,71 +1084,71 @@ paths:
               type: string
               description: "Defines a unique instance resource version"
         400:
-          $ref: '#/responses/InvalidRequestError'
+          $ref: "#/responses/InvalidRequestError"
         401:
-          $ref: '#/responses/UnauthorisedError'
+          $ref: "#/responses/UnauthorisedError"
         404:
           description: "InstanceId does not match any instances"
         409:
-          $ref: '#/responses/ConflictError'
+          $ref: "#/responses/ConflictError"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /instances/{instance_id}/dimensions/{dimension}/options/{option}:
     patch:
       tags:
-      - "Private"
+        - "Private"
       summary: "Modify a dimension option for an instance"
       description: |
         Modify a dimension option for an instance by setting values for node_id or order
       parameters:
-      - $ref: '#/parameters/instance_id'
-      - $ref: '#/parameters/dimension'
-      - $ref: '#/parameters/option'
-      - $ref: '#/parameters/patch_options'
-      - $ref: '#/parameters/if_match'
+        - $ref: "#/parameters/instance_id"
+        - $ref: "#/parameters/dimension"
+        - $ref: "#/parameters/option"
+        - $ref: "#/parameters/patch_options"
+        - $ref: "#/parameters/if_match"
       produces:
-      - "application/json-patch+json"
+        - "application/json-patch+json"
       security:
-      - InternalAPIKey: []
+        - Authorization: []
       responses:
         200:
           description: "The dimension option was modified and the successfully applied patch operations are returned"
           schema:
-            $ref: '#/definitions/PatchOptions'
+            $ref: "#/definitions/PatchOptions"
           headers:
             ETag:
               type: string
               description: "Defines a unique instance resource version"
         400:
-          $ref: '#/responses/InvalidRequestError'
+          $ref: "#/responses/InvalidRequestError"
         401:
-          $ref: '#/responses/UnauthorisedError'
+          $ref: "#/responses/UnauthorisedError"
         403:
-          $ref: '#/responses/ForbiddenError'
+          $ref: "#/responses/ForbiddenError"
         404:
           description: "InstanceId does not match any instances"
         409:
-          $ref: '#/responses/ConflictError'
+          $ref: "#/responses/ConflictError"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
   /instances/{instance_id}/dimensions/{dimension}/options/{option}/node_id/{node_id}:
     put:
       deprecated: true
       tags:
-      - "Private"
+        - "Private"
       summary: "Update a dimension with the node_id"
       description: |
         Update the dimension with a nodeId
       parameters:
-      - $ref: '#/parameters/instance_id'
-      - $ref: '#/parameters/dimension'
-      - $ref: '#/parameters/node_id'
-      - $ref: '#/parameters/option'
-      - $ref: '#/parameters/if_match'
+        - $ref: "#/parameters/instance_id"
+        - $ref: "#/parameters/dimension"
+        - $ref: "#/parameters/node_id"
+        - $ref: "#/parameters/option"
+        - $ref: "#/parameters/if_match"
       produces:
-      - "application/json"
+        - "application/json"
       security:
-      - InternalAPIKey: []
+        - Authorization: []
       responses:
         200:
           description: "Updated the dimension with the nodeId"
@@ -1115,17 +1157,17 @@ paths:
               type: string
               description: "Defines a unique instance resource version"
         400:
-          $ref: '#/responses/InvalidRequestError'
+          $ref: "#/responses/InvalidRequestError"
         401:
-          $ref: '#/responses/UnauthorisedError'
+          $ref: "#/responses/UnauthorisedError"
         403:
-          $ref: '#/responses/ForbiddenError'
+          $ref: "#/responses/ForbiddenError"
         404:
           description: "InstanceId does not match any instances"
         409:
-          $ref: '#/responses/ConflictError'
+          $ref: "#/responses/ConflictError"
         500:
-          $ref: '#/responses/InternalError'
+          $ref: "#/responses/InternalError"
 responses:
   ConflictError:
     description: "Failed to process the request due to a conflict"
@@ -1205,7 +1247,7 @@ definitions:
       items:
         type: array
         items:
-          $ref: '#/definitions/DatasetResponse'
+          $ref: "#/definitions/DatasetResponse"
       limit:
         description: "The number of datasets requested"
         type: integer
@@ -1219,20 +1261,27 @@ definitions:
   DatasetResponse:
     description: "A model for the response body when getting a dataset"
     allOf:
-    - type: object
-      properties:
-        id:
-          description: "An unique id for a dataset"
-          example: "DE3BC0B6-D6C4-4E20-917E-95D7EA8C91DC"
-          readOnly: true
-          type: string
-        type:
-          $ref: "#/definitions/Type"
-    - $ref: "#/definitions/Dataset"
+      - type: object
+        properties:
+          id:
+            description: "An unique id for a dataset"
+            example: "DE3BC0B6-D6C4-4E20-917E-95D7EA8C91DC"
+            readOnly: true
+            type: string
+          type:
+            $ref: "#/definitions/Type"
+      - $ref: "#/definitions/Dataset"
   Dataset:
     description: "The dataset"
     type: object
-    required: ["id", "contacts", "description", "license", "links", "national_statistics", "title"]
+    required:
+      - "id"
+      - "contacts"
+      - "description"
+      - "license"
+      - "links"
+      - "national_statistics"
+      - "title"
     properties:
       id:
         description: "The unique id for the dataset"
@@ -1241,17 +1290,17 @@ definitions:
         description: "The canonical topic id for this dataset.  This indicates which topic this dataset belongs to within the website taxonomy. **Deprecated** this field is being deprecated and replaced by the `Themes` field."
         type: string
       collection_id:
-        $ref: '#/definitions/CollectionID'
+        $ref: "#/definitions/CollectionID"
       contacts:
-        description: "A list containing contact details of staticians for a dataset"
+        description: "A list containing contact details of statisticians for a dataset"
         type: array
         items:
-          $ref: '#/definitions/Contact'
+          $ref: "#/definitions/Contact"
       description:
         description: "A description for a dataset"
         type: string
       is_based_on:
-        $ref: '#/definitions/IsBasedOn'
+        $ref: "#/definitions/IsBasedOn"
       keywords:
         description: "A list of keywords for a dataset"
         type: array
@@ -1261,7 +1310,7 @@ definitions:
         description: "The standard Government license right text for the dataset"
         type: string
       links:
-        $ref: '#/definitions/DatasetLinks'
+        $ref: "#/definitions/DatasetLinks"
       methodologies:
         description: "A list of methodologies for a dataset"
         type: array
@@ -1333,7 +1382,7 @@ definitions:
         description: "The release frequency of a dataset"
         type: string
       state:
-        $ref: '#/definitions/State'
+        $ref: "#/definitions/State"
       subtopics:
         description: "A list of subtopic ids that the dataset relates to within the website taxonomy. **Deprecated** this field is being deprecated and replaced by the `Themes` field."
         type: array
@@ -1358,15 +1407,14 @@ definitions:
         type: array
         items:
           type: "string"
-    
 
   Type:
-    description: "The type for a dataset" 
+    description: "The type for a dataset"
     type: string
     enum: [filterable]
-    default: "filterable"    
+    default: "filterable"
   IsBasedOn:
-    description: "Information about the population-type that the dataset is based on (census 2021 only)" 
+    description: "Information about the population-type that the dataset is based on (census 2021 only)"
     type: object
     properties:
       id:
@@ -1413,9 +1461,9 @@ definitions:
                 description: "The unique id for the code list"
                 type: string
           options:
-            $ref: '#/definitions/OptionsLink'
+            $ref: "#/definitions/OptionsLink"
           version:
-            $ref: '#/definitions/VersionLink'
+            $ref: "#/definitions/VersionLink"
       number_of_options:
         description: "The number of options available for this dimension"
         type: integer
@@ -1433,7 +1481,7 @@ definitions:
         description: "An array of dimensions"
         type: array
         items:
-          $ref: '#/definitions/Dimension'
+          $ref: "#/definitions/Dimension"
       limit:
         description: "The number of dimensions requested for a version from an edition of a dataset"
         type: integer
@@ -1455,7 +1503,7 @@ definitions:
         description: "An array of dimension options"
         type: array
         items:
-          $ref: '#/definitions/DimensionOption'
+          $ref: "#/definitions/DimensionOption"
       limit:
         description: "The number of dimensions requested for a version from an edition of a dataset"
         type: integer
@@ -1557,10 +1605,15 @@ definitions:
           description: "Path to value that needs to be operated on."
           type: string
           example: "/-"
-          enum: ["/-", "/{dimension}/options/{option}/order", "/{dimension}/options/{option}/node_id"]
+          enum:
+            [
+              "/-",
+              "/{dimension}/options/{option}/order",
+              "/{dimension}/options/{option}/node_id",
+            ]
         value:
           description: "A list of dimenions that will be added to the instance."
-          example: "[{\"dimension\": \"dim1\", \"option\": \"op1\"}, {\"dimension\": \"dim1\", \"option\": \"op2\"}, {\"op\": \"add\", \"path\": \"/dim1/options/op1/order\", \"value\": 3}, {\"op\": \"add\", \"path\": \"/dim1/options/op2/node_id\", \"value\": \"node123\"}]"
+          example: '[{"dimension": "dim1", "option": "op1"}, {"dimension": "dim1", "option": "op2"}, {"op": "add", "path": "/dim1/options/op1/order", "value": 3}, {"op": "add", "path": "/dim1/options/op2/node_id", "value": "node123"}]'
   DownloadObject:
     description: "Object containing information of a downloadable file"
     type: object
@@ -1584,9 +1637,9 @@ definitions:
         readOnly: true
         type: string
       links:
-        $ref: '#/definitions/EditionLinks'
+        $ref: "#/definitions/EditionLinks"
       state:
-        $ref: '#/definitions/State'
+        $ref: "#/definitions/State"
   Editions:
     type: object
     properties:
@@ -1597,7 +1650,7 @@ definitions:
       items:
         type: array
         items:
-          $ref: '#/definitions/Edition'
+          $ref: "#/definitions/Edition"
       limit:
         description: "The number of editions requested for a dataset"
         type: integer
@@ -1671,26 +1724,26 @@ definitions:
         readOnly: true
         type: array
         items:
-          $ref: '#/definitions/Alert'
+          $ref: "#/definitions/Alert"
       id:
         description: "A unique id for an instance"
         readOnly: true
         type: string
       collection_id:
-        $ref: '#/definitions/CollectionID'
+        $ref: "#/definitions/CollectionID"
       dimensions:
         description: "A list of codelists for each dimension of this instance"
         type: array
         items:
-          $ref: '#/definitions/Codelist'
+          $ref: "#/definitions/Codelist"
       downloads:
         description: "A selection of download objects containing information of downloadable files."
         type: object
         properties:
           csv:
-            $ref: '#/definitions/DownloadObject'
+            $ref: "#/definitions/DownloadObject"
           xls:
-            $ref: '#/definitions/DownloadObject'
+            $ref: "#/definitions/DownloadObject"
       edition:
         description: "The edition of the dataset version"
         type: string
@@ -1699,14 +1752,14 @@ definitions:
         readOnly: true
         type: array
         items:
-          $ref: '#/definitions/Event'
+          $ref: "#/definitions/Event"
       headers:
         description: "The header information from a V4 file"
         type: array
         items:
           type: string
       import_tasks:
-        $ref: '#/definitions/ImportTasks'
+        $ref: "#/definitions/ImportTasks"
       last_updated:
         description: "The last time an event happened"
         readOnly: true
@@ -1785,7 +1838,7 @@ definitions:
             properties:
               href:
                 description: "The URL for the dataset version associated with this instance"
-                example: 'http://localhost:21800/dataset/042e216a-7822-4fa0-a3d6-e3f5248ffc35/edition/2017/version/1'
+                example: "http://localhost:21800/dataset/042e216a-7822-4fa0-a3d6-e3f5248ffc35/edition/2017/version/1"
                 type: string
               id:
                 description: "The ID of the dataset version associated with this instance"
@@ -1795,9 +1848,9 @@ definitions:
         description: "The release date of this version of the dataset"
         type: string
       state:
-        $ref: '#/definitions/State'
+        $ref: "#/definitions/State"
       temporal:
-        $ref: '#/definitions/Temporal'
+        $ref: "#/definitions/Temporal"
       total_observations:
         description: "The number of observations in this instance"
         type: integer
@@ -1815,7 +1868,7 @@ definitions:
       items:
         type: array
         items:
-          $ref: '#/definitions/Instance'
+          $ref: "#/definitions/Instance"
       limit:
         description: "The number of instances requested"
         type: integer
@@ -1848,7 +1901,7 @@ definitions:
         description: "A list of alerts, for example corrections after the resource has been published"
         type: array
         items:
-          $ref: '#/definitions/Alert'
+          $ref: "#/definitions/Alert"
       canonical_topic:
         description: "The canonical topic id for this dataset.  This indicates which topic this dataset belongs to within the website taxonomy. **Deprecated** this field is being deprecated and replaced by the `Themes` field."
         type: string
@@ -1856,7 +1909,7 @@ definitions:
         description: "A list containing contact details of staticians for a dataset"
         type: array
         items:
-          $ref: '#/definitions/Contact'
+          $ref: "#/definitions/Contact"
       description:
         description: "A description for a dataset"
         type: string
@@ -1864,7 +1917,7 @@ definitions:
         description: "A list of codelists for each dimension of this version"
         type: array
         items:
-          $ref: '#/definitions/Dimension'
+          $ref: "#/definitions/Dimension"
       distribution:
         description: "A list of media types that the version data of an edition of a dataset can be accessed"
         type: array
@@ -1875,13 +1928,13 @@ definitions:
         type: object
         properties:
           csv:
-            $ref: '#/definitions/DownloadObject'
+            $ref: "#/definitions/DownloadObject"
           csvw:
-            $ref: '#/definitions/DownloadObject'
+            $ref: "#/definitions/DownloadObject"
           txt:
-            $ref: '#/definitions/DownloadObject'
+            $ref: "#/definitions/DownloadObject"
           xls:
-            $ref: '#/definitions/DownloadObject'
+            $ref: "#/definitions/DownloadObject"
       headers:
         description: "A list of headers for a census dataset"
         type: array
@@ -1896,12 +1949,12 @@ definitions:
         description: "A list of changes between version of an edition for a dataset and the previous version of the same dataset edition"
         type: array
         items:
-          $ref: '#/definitions/LatestChange'
+          $ref: "#/definitions/LatestChange"
       license:
         description: "The standard Government license right text for the dataset"
         type: string
       dataset_links:
-        $ref: '#/definitions/MetadataLinks'
+        $ref: "#/definitions/MetadataLinks"
       methodologies:
         description: "A list of methodologies for a dataset"
         type: array
@@ -1939,7 +1992,7 @@ definitions:
               description: "The title of a publication"
               type: string
       publisher:
-        $ref: '#/definitions/Publisher'
+        $ref: "#/definitions/Publisher"
       qmi:
         description: "Object containing information on the quality and methodology index of a dataset"
         type: object
@@ -1977,7 +2030,7 @@ definitions:
         items:
           type: "string"
       temporal:
-        $ref: '#/definitions/Temporal'
+        $ref: "#/definitions/Temporal"
       theme:
         description: "The theme for a dataset"
         type: string
@@ -1992,7 +2045,7 @@ definitions:
         description: "The uri to the location of the dataset on the web"
         type: string
       usage_notes:
-        $ref: '#/definitions/UsageNotes'
+        $ref: "#/definitions/UsageNotes"
       themes:
         description: "A list of topics and subtopics that the dataset relates to within the website taxonomy. This field consolidates the previously separate `canonical_topic` and `subtopics` fields."
         type: array
@@ -2008,22 +2061,22 @@ definitions:
         type: string
       current:
         allOf:
-        - type: object
-          properties:
-            collection_id:
-              $ref: '#/definitions/CollectionID'
-            type:  
-              $ref: '#/definitions/Type'
-        - $ref: "#/definitions/Dataset"
+          - type: object
+            properties:
+              collection_id:
+                $ref: "#/definitions/CollectionID"
+              type:
+                $ref: "#/definitions/Type"
+          - $ref: "#/definitions/Dataset"
       next:
         allOf:
-        - type: object
-          properties:
-            collection_id:
-              $ref: '#/definitions/CollectionID'
-            type:  
-              $ref: '#/definitions/Type'
-        - $ref: "#/definitions/Dataset"
+          - type: object
+            properties:
+              collection_id:
+                $ref: "#/definitions/CollectionID"
+              type:
+                $ref: "#/definitions/Type"
+          - $ref: "#/definitions/Dataset"
   NewInstance:
     description: "A model for the request and response body for creating a new instance"
     type: object
@@ -2032,13 +2085,13 @@ definitions:
         description: "A list of codelists for each dimension of this instance"
         type: array
         items:
-          $ref: '#/definitions/Codelist'
+          $ref: "#/definitions/Codelist"
       id:
         description: "A unique id for an instance"
         readOnly: true
         type: string
       import_tasks:
-        $ref: '#/definitions/ImportTasks'
+        $ref: "#/definitions/ImportTasks"
       links:
         type: object
         properties:
@@ -2086,7 +2139,7 @@ definitions:
       - type: object
         properties:
           collection_id:
-            $ref: '#/definitions/CollectionID'
+            $ref: "#/definitions/CollectionID"
           id:
             type: string
             description: "An unique id for a dataset"
@@ -2119,7 +2172,7 @@ definitions:
         description: "The maximum number of observations requested when filtering on query parameters (limited to 10000). Defaults to 10000 observations."
         type: integer
       links:
-        $ref: '#/definitions/ObservationLinks'
+        $ref: "#/definitions/ObservationLinks"
       observations:
         description: "A list of observations found when filtering on query parameters"
         type: array
@@ -2169,7 +2222,7 @@ definitions:
         description: "A list of usage notes relating to the dataset"
         type: array
         items:
-          $ref: '#/definitions/UsageNotes'
+          $ref: "#/definitions/UsageNotes"
   Publisher:
     description: "The publisher of the dataset"
     type: object
@@ -2218,18 +2271,18 @@ definitions:
         type: string
       current:
         allOf:
-        - type: object
-          properties:
-            collection_id:
-              $ref: '#/definitions/CollectionID'
-        - $ref: "#/definitions/Dataset"
+          - type: object
+            properties:
+              collection_id:
+                $ref: "#/definitions/CollectionID"
+          - $ref: "#/definitions/Dataset"
       next:
         allOf:
-        - type: object
-          properties:
-            collection_id:
-              $ref: '#/definitions/CollectionID'
-        - $ref: "#/definitions/Dataset"
+          - type: object
+            properties:
+              collection_id:
+                $ref: "#/definitions/CollectionID"
+          - $ref: "#/definitions/Dataset"
   UpdateDimensionOptionRequest:
     description: "A cached dimension. (Only used by the Private API)"
     type: object
@@ -2289,31 +2342,31 @@ definitions:
         description: "A list of alerts, for example corrections after the resource has been published"
         type: array
         items:
-          $ref: '#/definitions/Alert'
+          $ref: "#/definitions/Alert"
       collection_id:
-        $ref: '#/definitions/CollectionID'
+        $ref: "#/definitions/CollectionID"
       downloads:
         description: "A selection of download objects containing information of downloadable files. These can only be updated via an authorised caller."
         type: object
         properties:
           csv:
-            $ref: '#/definitions/DownloadObject'
+            $ref: "#/definitions/DownloadObject"
           xls:
-            $ref: '#/definitions/DownloadObject'
+            $ref: "#/definitions/DownloadObject"
       latest_changes:
         description: "A list of changes between version of an edition for a dataset and the previous version of the same dataset edition"
         type: array
         items:
-          $ref: '#/definitions/LatestChange'
+          $ref: "#/definitions/LatestChange"
       links:
-        $ref: '#/definitions/VersionLinks'
+        $ref: "#/definitions/VersionLinks"
       release_date:
         description: "The release date of this version of the dataset"
         type: string
       state:
-        $ref: '#/definitions/State'
+        $ref: "#/definitions/State"
       temporal:
-        $ref: '#/definitions/Temporal'
+        $ref: "#/definitions/Temporal"
       version:
         description: "A number identifying the version for an edition from a dataset"
         example: 1
@@ -2323,7 +2376,7 @@ definitions:
         description: "A list of usage notes relating to the dataset"
         type: array
         items:
-          $ref: '#/definitions/UsageNotes'
+          $ref: "#/definitions/UsageNotes"
   UsageNotes:
     description: "A note relating to the dataset. This will appear in downloaded datasets"
     type: object
@@ -2345,7 +2398,7 @@ definitions:
         description: "An array of Datasets"
         type: array
         items:
-          $ref: '#/definitions/Version'
+          $ref: "#/definitions/Version"
       limit:
         description: "The number of versions requested for an edition of a dataset"
         type: integer
@@ -2358,33 +2411,33 @@ definitions:
         type: integer
   Version:
     description: "An object containing information about published datasets from the ONS"
-    required: ["title", "description", "type", "next_release", "release_date", "state", "themes"]
+    required: [release_date]
     type: object
     properties:
       alerts:
         description: "A list of alerts, for example corrections after the resource has been published"
         type: array
         items:
-          $ref: '#/definitions/Alert'
+          $ref: "#/definitions/Alert"
       collection_id:
-        $ref: '#/definitions/CollectionID'
+        $ref: "#/definitions/CollectionID"
       dimensions:
         description: "A list of codelists for each dimension of this version"
         type: array
         items:
-          $ref: '#/definitions/Dimension'
+          $ref: "#/definitions/Dimension"
       downloads:
         description: "A selection of download objects containing information of downloadable files."
         type: object
         properties:
           csv:
-            $ref: '#/definitions/DownloadObject'
+            $ref: "#/definitions/DownloadObject"
           csvw:
-            $ref: '#/definitions/DownloadObject'
+            $ref: "#/definitions/DownloadObject"
           txt:
-            $ref: '#/definitions/DownloadObject'
+            $ref: "#/definitions/DownloadObject"
           xls:
-            $ref: '#/definitions/DownloadObject'
+            $ref: "#/definitions/DownloadObject"
       edition:
         description: "The dataset edition for this version"
         readOnly: true
@@ -2393,7 +2446,7 @@ definitions:
         description: "The identifier for this version of an edition for a dataset"
         type: string
       is_based_on:
-        $ref: '#/definitions/IsBasedOn'
+        $ref: "#/definitions/IsBasedOn"
       dataset_id:
         description: "The identifier for the dataset."
         type: string
@@ -2401,9 +2454,9 @@ definitions:
         description: "A list of changes between version of an edition for a dataset and the previous version of the same dataset edition"
         type: array
         items:
-          $ref: '#/definitions/LatestChange'
+          $ref: "#/definitions/LatestChange"
       links:
-        $ref: '#/definitions/VersionLinks'
+        $ref: "#/definitions/VersionLinks"
       lowest_geography:
         description: "The lowest geography this dataset is available at (Census datasets only)"
         type: string
@@ -2411,9 +2464,9 @@ definitions:
         description: "The release date of this version of the dataset"
         type: string
       state:
-        $ref: '#/definitions/State'
+        $ref: "#/definitions/State"
       temporal:
-        $ref: '#/definitions/Temporal'
+        $ref: "#/definitions/Temporal"
       type:
         description: "The type of dataset - e.g. cantabular_flexible_table"
         type: string
@@ -2426,7 +2479,7 @@ definitions:
         description: "A list of usage notes relating to the dataset"
         type: array
         items:
-          $ref: '#/definitions/UsageNotes'
+          $ref: "#/definitions/UsageNotes"
   # Link objects
   DatasetLinks:
     description: "A list of links related to this resource"
@@ -2441,22 +2494,22 @@ definitions:
             example: "http://localhost:8080/datasets/DE3BC0B6-D6C4-4E20-917E-95D7EA8C91DC/editions"
             type: string
       latest_version:
-        $ref: '#/definitions/LatestVersionLink'
+        $ref: "#/definitions/LatestVersionLink"
       self:
-        $ref: '#/definitions/SelfLink'
+        $ref: "#/definitions/SelfLink"
       taxonomy:
-        $ref: '#/definitions/TaxonomyLink'
+        $ref: "#/definitions/TaxonomyLink"
   EditionLinks:
     description: "A list of links related to this resource"
     readOnly: true
     type: object
     properties:
       dataset:
-        $ref: '#/definitions/DatasetLink'
+        $ref: "#/definitions/DatasetLink"
       latest_version:
-        $ref: '#/definitions/LatestVersionLink'
+        $ref: "#/definitions/LatestVersionLink"
       self:
-        $ref: '#/definitions/SelfLink'
+        $ref: "#/definitions/SelfLink"
       versions:
         type: object
         properties:
@@ -2470,13 +2523,13 @@ definitions:
     type: object
     properties:
       access_right:
-        $ref: '#/definitions/AccessRightsLink'
+        $ref: "#/definitions/AccessRightsLink"
       self:
-        $ref: '#/definitions/SelfLink'
+        $ref: "#/definitions/SelfLink"
       spatial:
-        $ref: '#/definitions/SpatialLink'
+        $ref: "#/definitions/SpatialLink"
       version:
-        $ref: '#/definitions/VersionLink'
+        $ref: "#/definitions/VersionLink"
       website_version:
         description: "A link to the location of this version of the dataset on the web"
         type: object
@@ -2490,17 +2543,17 @@ definitions:
     type: object
     properties:
       dataset_metadata:
-        $ref: '#/definitions/MetadataLink'
+        $ref: "#/definitions/MetadataLink"
       self:
-        $ref: '#/definitions/SelfLink'
+        $ref: "#/definitions/SelfLink"
       version:
-        $ref: '#/definitions/VersionLink'
+        $ref: "#/definitions/VersionLink"
   VersionLinks:
     description: "A list of links related to this resource"
     type: object
     properties:
       dataset:
-        $ref: '#/definitions/DatasetLink'
+        $ref: "#/definitions/DatasetLink"
       dimensions:
         readOnly: true
         type: object
@@ -2510,13 +2563,11 @@ definitions:
             example: "http://localhost:8080/datasets/DE3BC0B6-D6C4-4E20-917E-95D7EA8C91DC/editions/2017/versions/2/dimensions"
             type: string
       edition:
-        $ref: '#/definitions/EditionLink'
+        $ref: "#/definitions/EditionLink"
       self:
-        $ref: '#/definitions/SelfLink'
+        $ref: "#/definitions/SelfLink"
       spatial:
-        $ref: '#/definitions/SpatialLink'
-      job:
-        $ref: '#/definitions/JobLink'
+        $ref: "#/definitions/SpatialLink"
   DatasetLink:
     description: "An object containing the dataset id and link"
     readOnly: true
@@ -2584,12 +2635,12 @@ definitions:
   JobLink:
     type: object
     properties:
-          href:
-            description: "A URL to list dimensions for this version"
-            type: string
-          id:
-            description: "A Job id"
-            type: string
+      href:
+        description: "A URL to list dimensions for this version"
+        type: string
+      id:
+        description: "A Job id"
+        type: string
   TaxonomyLink:
     description: "A link to the taxonomy of the dataset"
     type: object
@@ -2615,7 +2666,7 @@ definitions:
         description: "A list of alerts against a version"
         type: array
         items:
-          $ref: '#/definitions/Alert'
+          $ref: "#/definitions/Alert"
       canonical_topic:
         description: "The canonical topic id for this dataset.  This indicates which topic this dataset belongs to within the website taxonomy."
         type: string
@@ -2623,7 +2674,7 @@ definitions:
         description: "A list containing contact details of statisticians for a dataset"
         type: array
         items:
-          $ref: '#/definitions/Contact'
+          $ref: "#/definitions/Contact"
       description:
         description: "A description for a dataset"
         type: string
@@ -2631,7 +2682,7 @@ definitions:
         description: "A list of codelists for each dimension of this version"
         type: array
         items:
-          $ref: '#/definitions/Dimension'
+          $ref: "#/definitions/Dimension"
       keywords:
         description: "A list of keywords for a dataset"
         type: array
@@ -2641,7 +2692,7 @@ definitions:
         description: "A list of changes between version of an edition for a dataset and the previous version of the same dataset edition"
         type: array
         items:
-          $ref: '#/definitions/LatestChange'
+          $ref: "#/definitions/LatestChange"
       license:
         description: "The standard Government license right text for the dataset"
         type: string
@@ -2743,4 +2794,4 @@ definitions:
         description: "The unit of measure for the dataset observations"
         type: string
       usage_notes:
-        $ref: '#/definitions/UsageNotes'
+        $ref: "#/definitions/UsageNotes"


### PR DESCRIPTION
### What

Update the public endpoints in the API spec (aka swagger spec) to be inline with the current API behaviour and then layer the planned changes to the API to support the required model for the `static` datasets on top.

Further work will be required to review the write endpoints to ensure they align where the models used differ.

Linting has been introduced for the API spec. This is only currently configured to be run locally and has not been added to the CI job yet.

#### Summary of proposed changes to the API

The following are the changes proposed to be made to the API to support the current work to add `static` datasets to the catalogue:
* Rename the newly added `themes` array which is a list of taxonomy topics for the dataset to `topics` to be inline with common terminology across the API to be more intuitive for users
* Remove the unused `theme` field as it was never used [1] and could cause confusion with `topics` for users who are familiar with DCAT terminology
* Remove the unused `uri` field which was intended to point to the dataset landing page as it was never used [1]
* Remove the `access_rights` link from the dataset links as this field has never been used and could be confused with the DCAT term.
* Remove `cantabular_table`, `cantabular_blob` and `nomis`  types from the dataset type enum as they have never been [1] and will not be used.
* Add the `static` dataset type to the dataset type enum
* Add `distributions` list which will replace the `downloads` map to enable a wider range of file types to be published as well as allowing the additional metadata to be provided. This will better align with DCAT and provide the necessary flexibility for the various formats of static dataset published. Backwards compatibility can be provided for CMD and Cantabular datasets by continuing to populate the `downloads` map, while also populating the new distributions list. `static` type datasets should not populate the deprecated `downloads` map.
* Add `quality_designation` field at the Version level. This field replaces the current `national_statistic` boolean at the dataset level. This change is to support the 3 current designations a dataset can have Official, Accredited Official and Official in Development as well as to represent change in designation over time (e.g. a developmental dataset may become accredited or an accredited dataset may lose its accreditation). Backwards compatibility can be achieved by setting the `national_statistic` boolean to `true` when updating the `latest_version` link if the latest version is `accredited-official`, otherwise setting the boolean to `false`.
* Remove the internal `id` fields from editions and versions as these are the UUID database IDs and should not be exposed publicly.
* Replace the singular `publisher` field which has never been used [1] with a new `publishers` array field to support the requirement to be able to have multiple publishers for a dataset. This field will be defaulted to a single publisher of ONS if not specified.
* Remove the unnecessary `type` field from the publisher. As mentioned above `publisher` has never been used [1] so this is non-breaking.
* Add `last_updated` as a publicly exposed field on both the dataset and version levels to be transparent about when any changes have been made.
* Updated required fields on both the dataset and version models to match the minimal metadata standard. Validation rules _may_ need to be updated to match.
* Add a `latest_edition` link to the dataset links to aid users in navigating to the latest edition. This value can be set at the same time as the current `latest_version` is being set.
* Merge the version model down into the editions endpoints such the the getting the editions list returns the latest version for each edition and getting a specific edition returns the latest version for that edition. This can be done with only one breaking change, which is the removal of the `latest_version` link in the editions endpoint responses. This change is deemed acceptable as the use of this link will no longer be necessary as the response is the latest version. This partially addresses one of the main complaints from users of the API, that the deep nesting and need to traverse down to the deepest level to get the download links is frustrating.
* Add appropriate `ETag` and `Cache-Control` headers to all GET responses. The `Cache-Control` should prevent caching of all authenticated requests and set appropriate cache options for public requests.

[1] "never used" means that the field has never been populated and therefore has never been publicly visible nor has it been utilised by any of our internal systems

##### Outstanding considerations

While these changes cover the key points, the following still need to be addressed:
1. Standardisation and documentation of error responses
2. How to address user frustration that the dataset level response does not return the information about the latest version of the latest edition or a a list of the latest version of all editions. Further discussion is needed to decide how to address this.
3. How to address the user frustration that metadata is split between the dataset and version level. The metadata endpoint was created to solve this, but that requires an additional request and is also not available at the edition level so will negate some of the benefits of merging the version model down into the editions endpoints.
4. JSON-LD implementation and the development of an appropriate context file to aid in ingesting our API for those familiar with DCAT and the semantic web.

#### Summary of changes to bring the spec up to standard

The following changes were made to the API spec to bring it up to standard and inline with the current API implementation and therefore do not result in any API changes needing to be implemented:
* Introduce linting for the API spec using `redocly`
* All linting failures have been addressed
* Formatting has been updated to be consistent
* Several grammar and spelling errors have been fixed
* All auth methods are updated to align to the current implementation
* Tags have been rationalised to merge the two "Private" tag variants as the distinction was confusing and unnecessary. Descriptions have been added to the tags for clarity.
* Removal of the observations endpoint as this was split into a separate API years ago
* Add default host and scheme for the public API to the spec.
* Clarify that the alert type is an enum by including the enum options and descriptions of the options
* Add the missing dataset types to the dataset type enum inline with the current
* Standardise related content links with a common model and indicate the required title and href fields
* Correct the QMI link to a new model to highlight that it differs from the related content links and only has the href field and that the href is required
* Add examples, defaults and min/max ranges to numerous fields to improve expectations and clarity for end users (focusing primarily on public endpoint fields that will be used by `static` type datasets)
* Standardised the pagination fields with a common model to ensure consistency
* Ensure the models used by GET endpoints have the correct required fields specified and that arrays that are required to be populated have a min length of 1
* Update various descriptions (focusing on public endpoints) for clarity and accuracy
* Add the `format` attribute to all `date-time` properties

### How to review

Ensure the API spec is valid, clear and aligned to the minimal metadata model.

Try running the new spec linting locally to ensure it works correctly and finds no issues.

### Who can review

!me