### PR TITLE
updated getVersions & getVersion method for the static datasets

### DIFF
--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -49,6 +49,9 @@ func TestGetVersionsReturnsOK(t *testing.T) {
 			CheckEditionExistsFunc: func(context.Context, string, string, string) error {
 				return nil
 			},
+			CheckEditionExistsStaticFunc: func(context.Context, string, string, string) error {
+				return nil
+			},
 			GetVersionsFunc: func(context.Context, string, string, string, int, int) ([]models.Version, int, error) {
 				return results, 2, nil
 			},
@@ -61,6 +64,7 @@ func TestGetVersionsReturnsOK(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.CheckEditionExistsStaticCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.GetVersionsCalls()), ShouldEqual, 1)
 		So(mockedDataStore.GetVersionsCalls()[0].Limit, ShouldEqual, 20)
 		So(mockedDataStore.GetVersionsCalls()[0].Offset, ShouldEqual, 0)
@@ -80,7 +84,7 @@ func TestGetVersionsReturnsOK(t *testing.T) {
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
 			},
-			CheckEditionExistsFunc: func(context.Context, string, string, string) error {
+			CheckEditionExistsStaticFunc: func(context.Context, string, string, string) error {
 				return nil
 			},
 			GetVersionsWithDatasetIDFunc: func(context.Context, string, int, int) ([]models.Version, int, error) {
@@ -94,7 +98,8 @@ func TestGetVersionsReturnsOK(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.CheckEditionExistsStaticCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetVersionsWithDatasetIDCalls()), ShouldEqual, 1)
 		So(mockedDataStore.GetVersionsWithDatasetIDCalls()[0].Limit, ShouldEqual, 20)
 		So(mockedDataStore.GetVersionsWithDatasetIDCalls()[0].Offset, ShouldEqual, 0)
@@ -115,6 +120,9 @@ func TestGetVersionsReturnsError(t *testing.T) {
 				return nil, errs.ErrDatasetNotFound
 			},
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return errs.ErrInternalServer
+			},
+			CheckEditionExistsStaticFunc: func(context.Context, string, string, string) error {
 				return errs.ErrInternalServer
 			},
 		}
@@ -161,7 +169,7 @@ func TestGetVersionsReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
-				return nil, nil
+				return &models.DatasetUpdate{ID: "123-456", Next: &models.Dataset{ID: "123-456"}}, nil
 			},
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
@@ -300,6 +308,9 @@ func TestGetVersionReturnsOK(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{ID: "123-456", Next: &models.Dataset{ID: "123-456"}}, nil
+			},
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
 			},
@@ -412,6 +423,9 @@ func TestGetVersionReturnsError(t *testing.T) {
 		r.Header.Add("internal_token", "coffee")
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{ID: "123-456", Next: &models.Dataset{ID: "123-456"}}, nil
+			},
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
 			},
@@ -440,6 +454,9 @@ func TestGetVersionReturnsError(t *testing.T) {
 		r.Header.Add("internal_token", "coffee")
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{ID: "123-456", Next: &models.Dataset{ID: "123-456"}}, nil
+			},
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
 			},
@@ -470,6 +487,9 @@ func TestGetVersionReturnsError(t *testing.T) {
 		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678/versions/1", http.NoBody)
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{ID: "123-456", Next: &models.Dataset{ID: "123-456"}}, nil
+			},
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
 			},
@@ -561,6 +581,9 @@ func TestGetVersionReturnsError(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{ID: "123-456", Next: &models.Dataset{ID: "123-456"}}, nil
+			},
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
 			},

--- a/api/webendpoints_test.go
+++ b/api/webendpoints_test.go
@@ -197,6 +197,9 @@ func TestWebSubnetVersionEndpoint(t *testing.T) {
 		var versionSearchState, editionSearchState, datasetSearchState string
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{ID: "123-456", Next: &models.Dataset{ID: "123-456"}}, nil
+			},
 			CheckDatasetExistsFunc: func(_ context.Context, _, state string) error {
 				datasetSearchState = state
 				return nil

--- a/mocks/generate_downloads_mocks.go
+++ b/mocks/generate_downloads_mocks.go
@@ -10,7 +10,7 @@ import (
 
 // Ensure, that KafkaProducerMock does implement download.KafkaProducer.
 // If this is not the case, regenerate this file with moq.
-// var _ download.KafkaProducer = &KafkaProducerMock{}
+//var _ download.KafkaProducer = &KafkaProducerMock{}
 
 // KafkaProducerMock is a mock implementation of download.KafkaProducer.
 //
@@ -69,7 +69,7 @@ func (mock *KafkaProducerMock) OutputCalls() []struct {
 
 // Ensure, that GenerateDownloadsEventMock does implement download.GenerateDownloadsEvent.
 // If this is not the case, regenerate this file with moq.
-// var _ download.GenerateDownloadsEvent = &GenerateDownloadsEventMock{}
+//var _ download.GenerateDownloadsEvent = &GenerateDownloadsEventMock{}
 
 // GenerateDownloadsEventMock is a mock implementation of download.GenerateDownloadsEvent.
 //

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -10,7 +10,7 @@ import (
 
 // Ensure, that DownloadsGeneratorMock does implement api.DownloadsGenerator.
 // If this is not the case, regenerate this file with moq.
-// var _ api.DownloadsGenerator = &DownloadsGeneratorMock{}
+//var _ api.DownloadsGenerator = &DownloadsGeneratorMock{}
 
 // DownloadsGeneratorMock is a mock implementation of api.DownloadsGenerator.
 //

--- a/mongo/version_store.go
+++ b/mongo/version_store.go
@@ -116,6 +116,22 @@ func (m *Mongo) GetVersionsWithDatasetID(ctx context.Context, datasetID string, 
 	return results, totalCount, nil
 }
 
+// GetVersion retrieves a version document for a dataset edition
+func (m *Mongo) GetVersionStatic(ctx context.Context, id, editionID string, versionID int, state string) (*models.Version, error) {
+	selector := buildVersionQuery(id, editionID, state, versionID)
+
+	var version models.Version
+	err := m.Connection.Collection(m.ActualCollectionName(config.VersionsCollection)).FindOne(ctx, selector, &version)
+	if err != nil {
+		if errors.Is(err, mongodriver.ErrNoDocumentFound) {
+			return nil, errs.ErrVersionNotFound
+		}
+		return nil, err
+	}
+
+	return &version, nil
+}
+
 func buildVersionWithDatasetIDQuery(id string) bson.M {
 	selector := bson.M{
 		"links.dataset.id": id,

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -40,6 +40,7 @@ type dataMongoDB interface {
 	GetNextVersion(ctx context.Context, datasetID, editionID string) (int, error)
 	GetNextVersionStatic(ctx context.Context, datasetID, editionID string) (int, error)
 	GetVersion(ctx context.Context, datasetID, editionID string, version int, state string) (*models.Version, error)
+	GetVersionStatic(ctx context.Context, datasetID, editionID string, version int, state string) (*models.Version, error)
 	GetUniqueDimensionAndOptions(ctx context.Context, ID, dimension string) ([]*string, int, error)
 	GetVersions(ctx context.Context, datasetID, editionID, state string, offset, limit int) ([]models.Version, int, error)
 	GetVersionsWithDatasetID(ctx context.Context, datasetID string, offset, limit int) ([]models.Version, int, error)

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -96,6 +96,9 @@ var _ store.Storer = &StorerMock{}
 //			GetVersionFunc: func(ctx context.Context, datasetID string, editionID string, version int, state string) (*models.Version, error) {
 //				panic("mock out the GetVersion method")
 //			},
+//			GetVersionStaticFunc: func(ctx context.Context, datasetID string, editionID string, version int, state string) (*models.Version, error) {
+//				panic("mock out the GetVersionStatic method")
+//			},
 //			GetVersionsFunc: func(ctx context.Context, datasetID string, editionID string, state string, offset int, limit int) ([]models.Version, int, error) {
 //				panic("mock out the GetVersions method")
 //			},
@@ -243,6 +246,9 @@ type StorerMock struct {
 
 	// GetVersionFunc mocks the GetVersion method.
 	GetVersionFunc func(ctx context.Context, datasetID string, editionID string, version int, state string) (*models.Version, error)
+
+	// GetVersionStaticFunc mocks the GetVersionStatic method.
+	GetVersionStaticFunc func(ctx context.Context, datasetID string, editionID string, version int, state string) (*models.Version, error)
 
 	// GetVersionsFunc mocks the GetVersions method.
 	GetVersionsFunc func(ctx context.Context, datasetID string, editionID string, state string, offset int, limit int) ([]models.Version, int, error)
@@ -563,6 +569,19 @@ type StorerMock struct {
 			// State is the state argument value.
 			State string
 		}
+		// GetVersionStatic holds details about calls to the GetVersionStatic method.
+		GetVersionStatic []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// DatasetID is the datasetID argument value.
+			DatasetID string
+			// EditionID is the editionID argument value.
+			EditionID string
+			// Version is the version argument value.
+			Version int
+			// State is the state argument value.
+			State string
+		}
 		// GetVersions holds details about calls to the GetVersions method.
 		GetVersions []struct {
 			// Ctx is the ctx argument value.
@@ -817,6 +836,7 @@ type StorerMock struct {
 	lockGetNextVersionStatic                sync.RWMutex
 	lockGetUniqueDimensionAndOptions        sync.RWMutex
 	lockGetVersion                          sync.RWMutex
+	lockGetVersionStatic                    sync.RWMutex
 	lockGetVersions                         sync.RWMutex
 	lockGetVersionsWithDatasetID            sync.RWMutex
 	lockRemoveDatasetVersionAndEditionLinks sync.RWMutex
@@ -1890,6 +1910,54 @@ func (mock *StorerMock) GetVersionCalls() []struct {
 	mock.lockGetVersion.RLock()
 	calls = mock.calls.GetVersion
 	mock.lockGetVersion.RUnlock()
+	return calls
+}
+
+// GetVersionStatic calls GetVersionStaticFunc.
+func (mock *StorerMock) GetVersionStatic(ctx context.Context, datasetID string, editionID string, version int, state string) (*models.Version, error) {
+	if mock.GetVersionStaticFunc == nil {
+		panic("StorerMock.GetVersionStaticFunc: method is nil but Storer.GetVersionStatic was just called")
+	}
+	callInfo := struct {
+		Ctx       context.Context
+		DatasetID string
+		EditionID string
+		Version   int
+		State     string
+	}{
+		Ctx:       ctx,
+		DatasetID: datasetID,
+		EditionID: editionID,
+		Version:   version,
+		State:     state,
+	}
+	mock.lockGetVersionStatic.Lock()
+	mock.calls.GetVersionStatic = append(mock.calls.GetVersionStatic, callInfo)
+	mock.lockGetVersionStatic.Unlock()
+	return mock.GetVersionStaticFunc(ctx, datasetID, editionID, version, state)
+}
+
+// GetVersionStaticCalls gets all the calls that were made to GetVersionStatic.
+// Check the length with:
+//
+//	len(mockedStorer.GetVersionStaticCalls())
+func (mock *StorerMock) GetVersionStaticCalls() []struct {
+	Ctx       context.Context
+	DatasetID string
+	EditionID string
+	Version   int
+	State     string
+} {
+	var calls []struct {
+		Ctx       context.Context
+		DatasetID string
+		EditionID string
+		Version   int
+		State     string
+	}
+	mock.lockGetVersionStatic.RLock()
+	calls = mock.calls.GetVersionStatic
+	mock.lockGetVersionStatic.RUnlock()
 	return calls
 }
 

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -100,6 +100,9 @@ var _ store.MongoDB = &MongoDBMock{}
 //			GetVersionFunc: func(ctx context.Context, datasetID string, editionID string, version int, state string) (*models.Version, error) {
 //				panic("mock out the GetVersion method")
 //			},
+//			GetVersionStaticFunc: func(ctx context.Context, datasetID string, editionID string, version int, state string) (*models.Version, error) {
+//				panic("mock out the GetVersionStatic method")
+//			},
 //			GetVersionsFunc: func(ctx context.Context, datasetID string, editionID string, state string, offset int, limit int) ([]models.Version, int, error) {
 //				panic("mock out the GetVersions method")
 //			},
@@ -247,6 +250,9 @@ type MongoDBMock struct {
 
 	// GetVersionFunc mocks the GetVersion method.
 	GetVersionFunc func(ctx context.Context, datasetID string, editionID string, version int, state string) (*models.Version, error)
+
+	// GetVersionStaticFunc mocks the GetVersionStatic method.
+	GetVersionStaticFunc func(ctx context.Context, datasetID string, editionID string, version int, state string) (*models.Version, error)
 
 	// GetVersionsFunc mocks the GetVersions method.
 	GetVersionsFunc func(ctx context.Context, datasetID string, editionID string, state string, offset int, limit int) ([]models.Version, int, error)
@@ -563,6 +569,19 @@ type MongoDBMock struct {
 			// State is the state argument value.
 			State string
 		}
+		// GetVersionStatic holds details about calls to the GetVersionStatic method.
+		GetVersionStatic []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// DatasetID is the datasetID argument value.
+			DatasetID string
+			// EditionID is the editionID argument value.
+			EditionID string
+			// Version is the version argument value.
+			Version int
+			// State is the state argument value.
+			State string
+		}
 		// GetVersions holds details about calls to the GetVersions method.
 		GetVersions []struct {
 			// Ctx is the ctx argument value.
@@ -811,6 +830,7 @@ type MongoDBMock struct {
 	lockGetNextVersionStatic                sync.RWMutex
 	lockGetUniqueDimensionAndOptions        sync.RWMutex
 	lockGetVersion                          sync.RWMutex
+	lockGetVersionStatic                    sync.RWMutex
 	lockGetVersions                         sync.RWMutex
 	lockGetVersionsWithDatasetID            sync.RWMutex
 	lockRemoveDatasetVersionAndEditionLinks sync.RWMutex
@@ -1903,6 +1923,54 @@ func (mock *MongoDBMock) GetVersionCalls() []struct {
 	mock.lockGetVersion.RLock()
 	calls = mock.calls.GetVersion
 	mock.lockGetVersion.RUnlock()
+	return calls
+}
+
+// GetVersionStatic calls GetVersionStaticFunc.
+func (mock *MongoDBMock) GetVersionStatic(ctx context.Context, datasetID string, editionID string, version int, state string) (*models.Version, error) {
+	if mock.GetVersionStaticFunc == nil {
+		panic("MongoDBMock.GetVersionStaticFunc: method is nil but MongoDB.GetVersionStatic was just called")
+	}
+	callInfo := struct {
+		Ctx       context.Context
+		DatasetID string
+		EditionID string
+		Version   int
+		State     string
+	}{
+		Ctx:       ctx,
+		DatasetID: datasetID,
+		EditionID: editionID,
+		Version:   version,
+		State:     state,
+	}
+	mock.lockGetVersionStatic.Lock()
+	mock.calls.GetVersionStatic = append(mock.calls.GetVersionStatic, callInfo)
+	mock.lockGetVersionStatic.Unlock()
+	return mock.GetVersionStaticFunc(ctx, datasetID, editionID, version, state)
+}
+
+// GetVersionStaticCalls gets all the calls that were made to GetVersionStatic.
+// Check the length with:
+//
+//	len(mockedMongoDB.GetVersionStaticCalls())
+func (mock *MongoDBMock) GetVersionStaticCalls() []struct {
+	Ctx       context.Context
+	DatasetID string
+	EditionID string
+	Version   int
+	State     string
+} {
+	var calls []struct {
+		Ctx       context.Context
+		DatasetID string
+		EditionID string
+		Version   int
+		State     string
+	}
+	mock.lockGetVersionStatic.RLock()
+	calls = mock.calls.GetVersionStatic
+	mock.lockGetVersionStatic.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
What

- updated getVersion and getVersions methods to retrieve the versions from the versions collection instead instances collection
- unit tests updated

How to review

- Check if the build checks are passed
- check if you can call to [http://localhost:22000/datasets/{dataset-id}/editions/{edition}/versions](http://localhost:22000/datasets/%7Bdataset-id%7D/editions/%7Bedition%7D/versions) and see the expected response as the requirement [DIS-2543](https://jira.ons.gov.uk/browse/DIS-2543)

Who can review

anyone