### PR TITLE
Update swagger for POST and PUT versions endpoints

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -478,7 +478,7 @@ paths:
         201:
           description: "A json object containing a version"
           schema:
-            $ref: "#/definitions/NewVersionResponse"
+            $ref: "#/definitions/Version"
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -510,7 +510,7 @@ paths:
         201:
           description: "A json object containing a version"
           schema:
-            $ref: "#/definitions/NewVersionResponse"
+            $ref: "#/definitions/Version"
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -2065,18 +2065,6 @@ definitions:
                 type: string
       state:
         $ref: "#/definitions/State"
-  NewVersionResponse:
-    description: "A model for the response body when creating a new version for an edition of a dataset"
-    allOf:
-      - type: object
-        properties:
-          collection_id:
-            $ref: "#/definitions/CollectionID"
-          id:
-            type: string
-            description: "An unique id for a dataset"
-            example: "DE3BC0B6-D6C4-4E20-917E-95D7EA8C91CD"
-      - $ref: "#/definitions/Version"
   Publisher:
     description: "The publisher of the dataset"
     type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2301,6 +2301,7 @@ definitions:
 
           A selection of download objects containing information of downloadable files.
         type: object
+        readOnly: true
         properties:
           csv:
             $ref: "#/definitions/DownloadObject"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2209,6 +2209,12 @@ definitions:
           $ref: "#/definitions/Alert"
       collection_id:
         $ref: "#/definitions/CollectionID"
+      distributions:
+        description: A list of representations of the dataset available and how to access them.
+        type: array
+        minItems: 1
+        items:
+          $ref: "#/definitions/Distribution"
       downloads:
         description: "A selection of download objects containing information of downloadable files. These can only be updated via an authorised caller."
         type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2289,6 +2289,7 @@ definitions:
       dataset_id:
         description: "The identifier for the dataset."
         type: string
+        readOnly: true
         example: my-dataset
       dimensions:
         description: "A list of codelists for each dimension of this version"
@@ -2358,7 +2359,9 @@ definitions:
       temporal:
         $ref: "#/definitions/Temporal"
       type:
-        $ref: "#/definitions/DatasetType"
+        readOnly: true
+        allOf:
+          - $ref: "#/definitions/DatasetType"
       usage_notes:
         description: "A list of usage notes relating to the dataset"
         type: array


### PR DESCRIPTION
### What

Review the version write endpoints (POST and PUT) to ensure that they align to the metadata model and API standards.

The changes are to ensure that:

1. `distributions` is writable by the PUT version endpoint
2. The deprecated `downloads` map is read only for the new POST versions endpoint to prevent use of this field
3. Fields that form part of the URL (e.g. dataset ID, edition and version) are read only
4. Dataset (series) level fields should be read only as they can not be edited at the version level (e.g. dataset type)

### How to review

Ensure the changes are valid and that the reasoning is sound.

### Who can review

!me