### PR TITLE
switch case to decide how to map versions to edition

### DIFF
--- a/api/editions.go
+++ b/api/editions.go
@@ -191,8 +191,10 @@ func (api *DatasetAPI) getEdition(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	if err != nil {
-		if err == errs.ErrDatasetNotFound || err == errs.ErrEditionNotFound || err == errs.ErrVersionNotFound {
+		if err == errs.ErrDatasetNotFound || err == errs.ErrEditionNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
+		} else if err == errs.ErrVersionNotFound {
+			http.Error(w, errs.ErrEditionNotFound.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, errs.ErrInternalServer.Error(), http.StatusInternalServerError)
 		}

--- a/api/editions.go
+++ b/api/editions.go
@@ -109,14 +109,28 @@ func (api *DatasetAPI) getEdition(w http.ResponseWriter, r *http.Request) {
 		}
 
 		var edition *models.EditionUpdate
+		var unpublishedVersion *models.Version
 
 		if datasetType == models.Static.String() {
-			version, err := api.dataStore.Backend.GetLatestVersionStatic(ctx, datasetID, editionID, state)
-			if err != nil {
-				log.Error(ctx, "getEdition endpoint: unable to find latest static version", err, logData)
+			publishedVersion, err := api.dataStore.Backend.GetLatestVersionStatic(ctx, datasetID, editionID, models.PublishedState)
+			if err != nil && err != errs.ErrVersionNotFound {
+				log.Error(ctx, "getEdition endpoint: unable to find latest published static version", err, logData)
 				return nil, err
 			}
-			edition = utils.MapVersionToEdition(version, authorised)
+
+			if authorised {
+				unpublishedVersion, err = api.dataStore.Backend.GetLatestVersionStatic(ctx, datasetID, editionID, "")
+				if err != nil && err != errs.ErrVersionNotFound {
+					log.Error(ctx, "getEdition endpoint: unable to find latest unpublished static version", err, logData)
+					return nil, err
+				}
+			}
+
+			edition, err = utils.MapVersionsToEditionUpdate(publishedVersion, unpublishedVersion)
+			if err != nil {
+				log.Error(ctx, "getEdition endpoint: failed to map version to edition", err, logData)
+				return nil, err
+			}
 		} else {
 			edition, err = api.dataStore.Backend.GetEdition(ctx, datasetID, editionID, state)
 			if err != nil {

--- a/api/editions_test.go
+++ b/api/editions_test.go
@@ -343,7 +343,7 @@ func TestGetEditionReturnsError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(datasetPermissions.Required.Calls, ShouldEqual, 1)
 		So(permissions.Required.Calls, ShouldEqual, 0)
-		So(w.Body.String(), ShouldContainSubstring, errs.ErrVersionNotFound.Error())
+		So(w.Body.String(), ShouldContainSubstring, errs.ErrEditionNotFound.Error())
 		So(len(mockedDataStore.GetDatasetTypeCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.GetLatestVersionStaticCalls()), ShouldEqual, 1)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -48,53 +48,205 @@ func TestMapVersionToEdition(t *testing.T) {
 			QualityDesignation: "Test quality designation",
 		}
 
-		Convey("When the user is authorised", func() {
-			editionUpdate := MapVersionToEdition(version, true)
+		Convey("When the version is mapped to an edition", func() {
+			edition := MapVersionToEdition(version)
 
-			Convey("Then the 'Next' field should be populated", func() {
-				So(editionUpdate.Next, ShouldNotBeNil)
-				So(editionUpdate.Current, ShouldBeNil)
-				So(editionUpdate.Next.DatasetID, ShouldEqual, version.DatasetID)
-				So(editionUpdate.Next.Edition, ShouldEqual, version.Edition)
-				So(editionUpdate.Next.ReleaseDate, ShouldEqual, version.ReleaseDate)
-				So(editionUpdate.Next.Links.Dataset.HRef, ShouldEqual, version.Links.Dataset.HRef)
-				So(editionUpdate.Next.Links.Dataset.ID, ShouldEqual, version.Links.Dataset.ID)
-				So(editionUpdate.Next.Links.LatestVersion.HRef, ShouldEqual, version.Links.Version.HRef)
-				So(editionUpdate.Next.Links.LatestVersion.ID, ShouldEqual, version.Links.Version.ID)
-				So(editionUpdate.Next.Links.Self.HRef, ShouldEqual, version.Links.Edition.HRef)
-				So(editionUpdate.Next.Links.Self.ID, ShouldEqual, version.Links.Edition.ID)
-				So(editionUpdate.Next.Links.Versions.HRef, ShouldEqual, version.Links.Edition.HRef+"/versions")
-				So(editionUpdate.Next.Version, ShouldEqual, version.Version)
-				So(editionUpdate.Next.LastUpdated, ShouldEqual, version.LastUpdated)
-				So(editionUpdate.Next.Alerts, ShouldResemble, version.Alerts)
-				So(editionUpdate.Next.UsageNotes, ShouldResemble, version.UsageNotes)
-				So(editionUpdate.Next.Distributions, ShouldResemble, version.Distributions)
-				So(editionUpdate.Next.QualityDesignation, ShouldEqual, version.QualityDesignation)
+			Convey("Then the edition should be mapped correctly", func() {
+				So(edition.DatasetID, ShouldEqual, version.DatasetID)
+				So(edition.Edition, ShouldEqual, version.Edition)
+				So(edition.ReleaseDate, ShouldEqual, version.ReleaseDate)
+				So(edition.Links.Dataset.HRef, ShouldEqual, version.Links.Dataset.HRef)
+				So(edition.Links.Dataset.ID, ShouldEqual, version.Links.Dataset.ID)
+				So(edition.Links.LatestVersion.HRef, ShouldEqual, version.Links.Version.HRef)
+				So(edition.Links.LatestVersion.ID, ShouldEqual, version.Links.Version.ID)
+				So(edition.Links.Self.HRef, ShouldEqual, version.Links.Edition.HRef)
+				So(edition.Links.Self.ID, ShouldEqual, version.Links.Edition.ID)
+				So(edition.Links.Versions.HRef, ShouldEqual, version.Links.Edition.HRef+"/versions")
+				So(edition.Version, ShouldEqual, version.Version)
+				So(edition.LastUpdated, ShouldEqual, version.LastUpdated)
+				So(edition.Alerts, ShouldResemble, version.Alerts)
+				So(edition.UsageNotes, ShouldResemble, version.UsageNotes)
+				So(edition.Distributions, ShouldResemble, version.Distributions)
+				So(edition.QualityDesignation, ShouldEqual, version.QualityDesignation)
+			})
+		})
+	})
+}
+
+func TestMapVersionsToEditions(t *testing.T) {
+	Convey("Given a published and unpublished version", t, func() {
+		publishedVersion := &models.Version{
+			DatasetID:   "123",
+			Edition:     "2023",
+			ReleaseDate: "2023-10-01",
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123",
+					ID:   "123",
+				},
+				Version: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123/editions/2023/versions/1",
+					ID:   "1",
+				},
+				Edition: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123/editions/2023",
+					ID:   "2023",
+				},
+			},
+			Version:            1,
+			LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
+			Alerts:             &[]models.Alert{{Description: "Test alert"}},
+			UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
+			Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
+			QualityDesignation: "Test quality designation",
+			State:              models.PublishedState,
+		}
+
+		unpublishedVersion := &models.Version{
+			DatasetID:   "123",
+			Edition:     "2023",
+			ReleaseDate: "2023-10-01",
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123",
+					ID:   "123",
+				},
+				Version: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123/editions/2023/versions/2",
+					ID:   "2",
+				},
+				Edition: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123/editions/2023",
+					ID:   "2023",
+				},
+			},
+			Version:            2,
+			LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
+			Alerts:             &[]models.Alert{{Description: "Test alert"}},
+			UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
+			Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
+			QualityDesignation: "Test quality designation",
+			State:              models.AssociatedState,
+		}
+
+		Convey("When both versions are available", func() {
+			edition, err := MapVersionsToEditionUpdate(publishedVersion, unpublishedVersion)
+
+			Convey("Then the published version should be mapped to the 'Current' field", func() {
+				So(err, ShouldBeNil)
+				So(edition.Current.DatasetID, ShouldEqual, publishedVersion.DatasetID)
+				So(edition.Current.Edition, ShouldEqual, publishedVersion.Edition)
+				So(edition.Current.ReleaseDate, ShouldEqual, publishedVersion.ReleaseDate)
+				So(edition.Current.Links.Dataset.HRef, ShouldEqual, publishedVersion.Links.Dataset.HRef)
+				So(edition.Current.Links.Dataset.ID, ShouldEqual, publishedVersion.Links.Dataset.ID)
+				So(edition.Current.Links.LatestVersion.HRef, ShouldEqual, publishedVersion.Links.Version.HRef)
+				So(edition.Current.Links.LatestVersion.ID, ShouldEqual, publishedVersion.Links.Version.ID)
+				So(edition.Current.Links.Self.HRef, ShouldEqual, publishedVersion.Links.Edition.HRef)
+				So(edition.Current.Links.Self.ID, ShouldEqual, publishedVersion.Links.Edition.ID)
+				So(edition.Current.Links.Versions.HRef, ShouldEqual, publishedVersion.Links.Edition.HRef+"/versions")
+				So(edition.Current.Version, ShouldEqual, publishedVersion.Version)
+				So(edition.Current.LastUpdated, ShouldEqual, publishedVersion.LastUpdated)
+				So(edition.Current.Alerts, ShouldResemble, publishedVersion.Alerts)
+				So(edition.Current.UsageNotes, ShouldResemble, publishedVersion.UsageNotes)
+				So(edition.Current.Distributions, ShouldResemble, publishedVersion.Distributions)
+				So(edition.Current.QualityDesignation, ShouldEqual, publishedVersion.QualityDesignation)
+			})
+
+			Convey("And the unpublished version should be mapped to the 'Next' field", func() {
+				So(edition.Next.DatasetID, ShouldEqual, unpublishedVersion.DatasetID)
+				So(edition.Next.Edition, ShouldEqual, unpublishedVersion.Edition)
+				So(edition.Next.ReleaseDate, ShouldEqual, unpublishedVersion.ReleaseDate)
+				So(edition.Next.Links.Dataset.HRef, ShouldEqual, unpublishedVersion.Links.Dataset.HRef)
+				So(edition.Next.Links.Dataset.ID, ShouldEqual, unpublishedVersion.Links.Dataset.ID)
+				So(edition.Next.Links.LatestVersion.HRef, ShouldEqual, unpublishedVersion.Links.Version.HRef)
+				So(edition.Next.Links.LatestVersion.ID, ShouldEqual, unpublishedVersion.Links.Version.ID)
+				So(edition.Next.Links.Self.HRef, ShouldEqual, unpublishedVersion.Links.Edition.HRef)
+				So(edition.Next.Links.Self.ID, ShouldEqual, unpublishedVersion.Links.Edition.ID)
+				So(edition.Next.Links.Versions.HRef, ShouldEqual, unpublishedVersion.Links.Edition.HRef+"/versions")
+				So(edition.Next.Version, ShouldEqual, unpublishedVersion.Version)
+				So(edition.Next.LastUpdated, ShouldEqual, unpublishedVersion.LastUpdated)
+				So(edition.Next.Alerts, ShouldResemble, unpublishedVersion.Alerts)
+				So(edition.Next.UsageNotes, ShouldResemble, unpublishedVersion.UsageNotes)
+				So(edition.Next.Distributions, ShouldResemble, unpublishedVersion.Distributions)
+				So(edition.Next.QualityDesignation, ShouldEqual, unpublishedVersion.QualityDesignation)
 			})
 		})
 
-		Convey("When the user is not authorised", func() {
-			editionUpdate := MapVersionToEdition(version, false)
+		Convey("When only the published version is available", func() {
+			edition, err := MapVersionsToEditionUpdate(publishedVersion, nil)
 
-			Convey("Then the 'Current' field should be populated", func() {
-				So(editionUpdate.Current, ShouldNotBeNil)
-				So(editionUpdate.Next, ShouldBeNil)
-				So(editionUpdate.Current.DatasetID, ShouldEqual, version.DatasetID)
-				So(editionUpdate.Current.Edition, ShouldEqual, version.Edition)
-				So(editionUpdate.Current.ReleaseDate, ShouldEqual, version.ReleaseDate)
-				So(editionUpdate.Current.Links.Dataset.HRef, ShouldEqual, version.Links.Dataset.HRef)
-				So(editionUpdate.Current.Links.Dataset.ID, ShouldEqual, version.Links.Dataset.ID)
-				So(editionUpdate.Current.Links.LatestVersion.HRef, ShouldEqual, version.Links.Version.HRef)
-				So(editionUpdate.Current.Links.LatestVersion.ID, ShouldEqual, version.Links.Version.ID)
-				So(editionUpdate.Current.Links.Self.HRef, ShouldEqual, version.Links.Edition.HRef)
-				So(editionUpdate.Current.Links.Self.ID, ShouldEqual, version.Links.Edition.ID)
-				So(editionUpdate.Current.Links.Versions.HRef, ShouldEqual, version.Links.Edition.HRef+"/versions")
-				So(editionUpdate.Current.Version, ShouldEqual, version.Version)
-				So(editionUpdate.Current.LastUpdated, ShouldEqual, version.LastUpdated)
-				So(editionUpdate.Current.Alerts, ShouldResemble, version.Alerts)
-				So(editionUpdate.Current.UsageNotes, ShouldResemble, version.UsageNotes)
-				So(editionUpdate.Current.Distributions, ShouldResemble, version.Distributions)
-				So(editionUpdate.Current.QualityDesignation, ShouldEqual, version.QualityDesignation)
+			Convey("Then the published version should be mapped to both 'Current' and 'Next' fields", func() {
+				So(err, ShouldBeNil)
+				So(edition.Current.DatasetID, ShouldEqual, publishedVersion.DatasetID)
+				So(edition.Current.Edition, ShouldEqual, publishedVersion.Edition)
+				So(edition.Current.ReleaseDate, ShouldEqual, publishedVersion.ReleaseDate)
+				So(edition.Current.Links.Dataset.HRef, ShouldEqual, publishedVersion.Links.Dataset.HRef)
+				So(edition.Current.Links.Dataset.ID, ShouldEqual, publishedVersion.Links.Dataset.ID)
+				So(edition.Current.Links.LatestVersion.HRef, ShouldEqual, publishedVersion.Links.Version.HRef)
+				So(edition.Current.Links.LatestVersion.ID, ShouldEqual, publishedVersion.Links.Version.ID)
+				So(edition.Current.Links.Self.HRef, ShouldEqual, publishedVersion.Links.Edition.HRef)
+				So(edition.Current.Links.Self.ID, ShouldEqual, publishedVersion.Links.Edition.ID)
+				So(edition.Current.Links.Versions.HRef, ShouldEqual, publishedVersion.Links.Edition.HRef+"/versions")
+				So(edition.Current.Version, ShouldEqual, publishedVersion.Version)
+				So(edition.Current.LastUpdated, ShouldEqual, publishedVersion.LastUpdated)
+				So(edition.Current.Alerts, ShouldResemble, publishedVersion.Alerts)
+				So(edition.Current.UsageNotes, ShouldResemble, publishedVersion.UsageNotes)
+				So(edition.Current.Distributions, ShouldResemble, publishedVersion.Distributions)
+				So(edition.Current.QualityDesignation, ShouldEqual, publishedVersion.QualityDesignation)
+
+				So(edition.Next.DatasetID, ShouldEqual, publishedVersion.DatasetID)
+				So(edition.Next.Edition, ShouldEqual, publishedVersion.Edition)
+				So(edition.Next.ReleaseDate, ShouldEqual, publishedVersion.ReleaseDate)
+				So(edition.Next.Links.Dataset.HRef, ShouldEqual, publishedVersion.Links.Dataset.HRef)
+				So(edition.Next.Links.Dataset.ID, ShouldEqual, publishedVersion.Links.Dataset.ID)
+				So(edition.Next.Links.LatestVersion.HRef, ShouldEqual, publishedVersion.Links.Version.HRef)
+				So(edition.Next.Links.LatestVersion.ID, ShouldEqual, publishedVersion.Links.Version.ID)
+				So(edition.Next.Links.Self.HRef, ShouldEqual, publishedVersion.Links.Edition.HRef)
+				So(edition.Next.Links.Self.ID, ShouldEqual, publishedVersion.Links.Edition.ID)
+				So(edition.Next.Links.Versions.HRef, ShouldEqual, publishedVersion.Links.Edition.HRef+"/versions")
+				So(edition.Next.Version, ShouldEqual, publishedVersion.Version)
+				So(edition.Next.LastUpdated, ShouldEqual, publishedVersion.LastUpdated)
+				So(edition.Next.Alerts, ShouldResemble, publishedVersion.Alerts)
+				So(edition.Next.UsageNotes, ShouldResemble, publishedVersion.UsageNotes)
+				So(edition.Next.Distributions, ShouldResemble, publishedVersion.Distributions)
+				So(edition.Next.QualityDesignation, ShouldEqual, publishedVersion.QualityDesignation)
+			})
+		})
+
+		Convey("When only the unpublished version is available", func() {
+			edition, err := MapVersionsToEditionUpdate(nil, unpublishedVersion)
+
+			Convey("Then the unpublished version should be mapped to the 'Next' field", func() {
+				So(err, ShouldBeNil)
+				So(edition.Current, ShouldBeNil)
+				So(edition.Next.DatasetID, ShouldEqual, unpublishedVersion.DatasetID)
+				So(edition.Next.Edition, ShouldEqual, unpublishedVersion.Edition)
+				So(edition.Next.ReleaseDate, ShouldEqual, unpublishedVersion.ReleaseDate)
+				So(edition.Next.Links.Dataset.HRef, ShouldEqual, unpublishedVersion.Links.Dataset.HRef)
+				So(edition.Next.Links.Dataset.ID, ShouldEqual, unpublishedVersion.Links.Dataset.ID)
+				So(edition.Next.Links.LatestVersion.HRef, ShouldEqual, unpublishedVersion.Links.Version.HRef)
+				So(edition.Next.Links.LatestVersion.ID, ShouldEqual, unpublishedVersion.Links.Version.ID)
+				So(edition.Next.Links.Self.HRef, ShouldEqual, unpublishedVersion.Links.Edition.HRef)
+				So(edition.Next.Links.Self.ID, ShouldEqual, unpublishedVersion.Links.Edition.ID)
+				So(edition.Next.Links.Versions.HRef, ShouldEqual, unpublishedVersion.Links.Edition.HRef+"/versions")
+				So(edition.Next.Version, ShouldEqual, unpublishedVersion.Version)
+				So(edition.Next.LastUpdated, ShouldEqual, unpublishedVersion.LastUpdated)
+				So(edition.Next.Alerts, ShouldResemble, unpublishedVersion.Alerts)
+				So(edition.Next.UsageNotes, ShouldResemble, unpublishedVersion.UsageNotes)
+				So(edition.Next.Distributions, ShouldResemble, unpublishedVersion.Distributions)
+				So(edition.Next.QualityDesignation, ShouldEqual, unpublishedVersion.QualityDesignation)
+			})
+		})
+
+		Convey("When neither version is available", func() {
+			edition, err := MapVersionsToEditionUpdate(nil, nil)
+
+			Convey("Then the edition should be nil", func() {
+				So(edition, ShouldBeNil)
+			})
+
+			Convey("And a version not found error should be returned", func() {
+				So(err, ShouldEqual, errs.ErrVersionNotFound)
 			})
 		})
 	})


### PR DESCRIPTION
### What

Added a `switch` statement to decide how the versions should be mapped to the edition update based on the latest published/unpublished versions existing

### How to review

Check changes make sense
Run the `dataset-catalogue` stack and test all 4 cases are working as expected. (published version nil or not nil, unpublished version nil or not nil)

### Who can review

Anyone
