### PR TITLE
updated getEditions method to retrieve the editions from versions collection

### DIFF
--- a/api/editions.go
+++ b/api/editions.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
@@ -56,8 +55,8 @@ func (api *DatasetAPI) getEditions(w http.ResponseWriter, r *http.Request, limit
 
 		versionResults, totalCount, err = api.dataStore.Backend.GetAllStaticVersions(ctx, datasetID, state, offset, limit)
 		if err != nil {
-			log.Error(ctx, "getEditions endpoint: unable to find editions for dataset", err, logData)
-			if err == errs.ErrEditionNotFound {
+			log.Error(ctx, "getEditions endpoint: unable to find versions for dataset", err, logData)
+			if err == errs.ErrVersionNotFound {
 				http.Error(w, err.Error(), http.StatusNotFound)
 			} else {
 				http.Error(w, errs.ErrInternalServer.Error(), http.StatusInternalServerError)
@@ -71,7 +70,6 @@ func (api *DatasetAPI) getEditions(w http.ResponseWriter, r *http.Request, limit
 		}
 
 		for editionID := range editionMap {
-			fmt.Println("editionID", editionID)
 			publishedVersion, err := api.dataStore.Backend.GetLatestVersionStatic(ctx, datasetID, editionID, models.PublishedState)
 			if err != nil && err != errs.ErrVersionNotFound {
 				log.Error(ctx, "getEdition endpoint: unable to find latest published static version", err, logData)

--- a/api/editions.go
+++ b/api/editions.go
@@ -57,7 +57,7 @@ func (api *DatasetAPI) getEditions(w http.ResponseWriter, r *http.Request, limit
 		if err != nil {
 			log.Error(ctx, "getEditions endpoint: unable to find versions for dataset", err, logData)
 			if err == errs.ErrVersionNotFound {
-				http.Error(w, errs.ErrVersionNotFound.Error(), http.StatusNotFound)
+				http.Error(w, errs.ErrEditionsNotFound.Error(), http.StatusNotFound)
 			} else {
 				http.Error(w, errs.ErrInternalServer.Error(), http.StatusInternalServerError)
 			}

--- a/api/editions.go
+++ b/api/editions.go
@@ -57,7 +57,7 @@ func (api *DatasetAPI) getEditions(w http.ResponseWriter, r *http.Request, limit
 		if err != nil {
 			log.Error(ctx, "getEditions endpoint: unable to find versions for dataset", err, logData)
 			if err == errs.ErrVersionNotFound {
-				http.Error(w, err.Error(), http.StatusNotFound)
+				http.Error(w, errs.ErrVersionNotFound.Error(), http.StatusNotFound)
 			} else {
 				http.Error(w, errs.ErrInternalServer.Error(), http.StatusInternalServerError)
 			}

--- a/api/editions_test.go
+++ b/api/editions_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/mocks"
 	"github.com/ONSdigital/dp-dataset-api/models"
 	storetest "github.com/ONSdigital/dp-dataset-api/store/datastoretest"
+	"github.com/ONSdigital/dp-dataset-api/utils"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -68,6 +69,416 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 1)
 		So(list, ShouldResemble, []*models.Edition{publicResult})
+		So(totalCount, ShouldEqual, 2)
+		So(err, ShouldEqual, nil)
+	})
+
+	Convey("get published editions when the dataset type is static", t, func() {
+		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions", http.NoBody)
+		w := httptest.NewRecorder()
+
+		editionsList := []*models.EditionUpdate{
+			{
+				Current: &models.Edition{
+					Edition:     "2023",
+					ID:          "",
+					DatasetID:   "123",
+					Version:     2,
+					LastUpdated: time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
+					ReleaseDate: "2023-10-01",
+					Links: &models.EditionUpdateLinks{
+						Dataset:       &models.LinkObject{HRef: "http://localhost:22000/datasets/123", ID: "123"},
+						LatestVersion: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023/versions/2", ID: "2"},
+						Self:          &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023", ID: "2023"},
+						Versions:      &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023/versions", ID: ""},
+					},
+					Alerts: &[]models.Alert{
+						{
+							Date:        "",
+							Description: "Test alert",
+							Type:        models.AlertType(""),
+						},
+					},
+					UsageNotes: &[]models.UsageNote{
+						{
+							Note:  "Test usage note",
+							Title: "",
+						},
+					},
+					Distributions: &[]models.Distribution{
+						{
+							Title:       "Test distribution",
+							Format:      models.DistributionFormat(""),
+							MediaType:   models.DistributionMediaType(""),
+							DownloadURL: "",
+							ByteSize:    0,
+						},
+					},
+					QualityDesignation: models.QualityDesignation("Test quality designation"),
+				},
+				Next: &models.Edition{
+					Edition:     "2023",
+					ID:          "",
+					DatasetID:   "123",
+					Version:     2,
+					LastUpdated: time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
+					ReleaseDate: "2023-10-01",
+					Links: &models.EditionUpdateLinks{
+						Dataset:       &models.LinkObject{HRef: "http://localhost:22000/datasets/123", ID: "123"},
+						LatestVersion: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023/versions/2", ID: "2"},
+						Self:          &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023", ID: "2023"},
+						Versions:      &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023/versions", ID: ""},
+					},
+					Alerts: &[]models.Alert{
+						{
+							Date:        "",
+							Description: "Test alert",
+							Type:        models.AlertType(""),
+						},
+					},
+					UsageNotes: &[]models.UsageNote{
+						{
+							Note:  "Test usage note",
+							Title: "",
+						},
+					},
+					Distributions: &[]models.Distribution{
+						{
+							Title:       "Test distribution",
+							Format:      models.DistributionFormat(""),
+							MediaType:   models.DistributionMediaType(""),
+							DownloadURL: "",
+							ByteSize:    0,
+						},
+					},
+					QualityDesignation: models.QualityDesignation("Test quality designation"),
+				},
+			},
+		}
+
+		versions := []*models.Version{
+			{
+				DatasetID:   "123",
+				Edition:     "2023",
+				ReleaseDate: "2023-10-01",
+				Links: &models.VersionLinks{
+					Dataset: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123",
+						ID:   "123",
+					},
+					Version: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123/editions/2023/versions/1",
+						ID:   "1",
+					},
+					Edition: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123/editions/2023",
+						ID:   "2023",
+					},
+				},
+				Version:            1,
+				LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
+				Alerts:             &[]models.Alert{{Description: "Test alert"}},
+				UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
+				Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
+				QualityDesignation: "Test quality designation",
+				State:              "published",
+			},
+			{
+				DatasetID:   "123",
+				Edition:     "2023",
+				ReleaseDate: "2023-10-01",
+				Links: &models.VersionLinks{
+					Dataset: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123",
+						ID:   "123",
+					},
+					Version: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123/editions/2023/versions/2",
+						ID:   "2",
+					},
+					Edition: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123/editions/2023",
+						ID:   "2023",
+					},
+				},
+				Version:            2,
+				LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
+				Alerts:             &[]models.Alert{{Description: "Test alert"}},
+				UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
+				Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
+				QualityDesignation: "Test quality designation",
+				State:              "published",
+			},
+		}
+		publishedLatestVersion := &models.Version{
+			DatasetID:   "123",
+			Edition:     "2023",
+			ReleaseDate: "2023-10-01",
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123",
+					ID:   "123",
+				},
+				Version: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123/editions/2023/versions/2",
+					ID:   "2",
+				},
+				Edition: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123/editions/2023",
+					ID:   "2023",
+				},
+			},
+			Version:            2,
+			LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
+			Alerts:             &[]models.Alert{{Description: "Test alert"}},
+			UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
+			Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
+			QualityDesignation: "Test quality designation",
+			State:              "published",
+		}
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			GetDatasetTypeFunc: func(_ context.Context, _ string, authorised bool) (string, error) {
+				return models.Static.String(), nil
+			},
+			GetAllStaticVersionsFunc: func(ctx context.Context, ID, state string, offset, limit int) ([]*models.Version, int, error) {
+				return versions, 2, nil
+			},
+			GetLatestVersionStaticFunc: func(ctx context.Context, datasetID, editionID, state string) (*models.Version, error) {
+				return publishedLatestVersion, nil
+			},
+		}
+
+		permissions := getAuthorisationHandlerMock()
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, permissions, permissions)
+		_, totalCount, _ := api.getEditions(w, r, 20, 0)
+
+		editions, err := utils.MapVersionsToEditionUpdate(publishedLatestVersion, nil)
+		So(w.Code, ShouldEqual, http.StatusOK)
+		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.GetAllStaticVersionsCalls()), ShouldEqual, 1)
+		So([]*models.EditionUpdate{editions}, ShouldEqual, editionsList)
+		So(totalCount, ShouldEqual, 2)
+		So(err, ShouldEqual, nil)
+	})
+
+	Convey("get all editions when the dataset type is static", t, func() {
+		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions", http.NoBody)
+		w := httptest.NewRecorder()
+
+		editionsList := []*models.EditionUpdate{
+			{
+				Current: &models.Edition{
+					Edition:     "2023",
+					ID:          "",
+					DatasetID:   "123",
+					Version:     1,
+					LastUpdated: time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
+					ReleaseDate: "2023-10-01",
+					Links: &models.EditionUpdateLinks{
+						Dataset:       &models.LinkObject{HRef: "http://localhost:22000/datasets/123", ID: "123"},
+						LatestVersion: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023/versions/1", ID: "1"},
+						Self:          &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023", ID: "2023"},
+						Versions:      &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023/versions", ID: ""},
+					},
+					Alerts: &[]models.Alert{
+						{
+							Date:        "",
+							Description: "Test alert",
+							Type:        models.AlertType(""),
+						},
+					},
+					UsageNotes: &[]models.UsageNote{
+						{
+							Note:  "Test usage note",
+							Title: "",
+						},
+					},
+					Distributions: &[]models.Distribution{
+						{
+							Title:       "Test distribution",
+							Format:      models.DistributionFormat(""),
+							MediaType:   models.DistributionMediaType(""),
+							DownloadURL: "",
+							ByteSize:    0,
+						},
+					},
+					QualityDesignation: models.QualityDesignation("Test quality designation"),
+				},
+				Next: &models.Edition{
+					Edition:     "2023",
+					ID:          "",
+					DatasetID:   "123",
+					Version:     2,
+					LastUpdated: time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
+					ReleaseDate: "2023-10-01",
+					Links: &models.EditionUpdateLinks{
+						Dataset:       &models.LinkObject{HRef: "http://localhost:22000/datasets/123", ID: "123"},
+						LatestVersion: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023/versions/2", ID: "2"},
+						Self:          &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023", ID: "2023"},
+						Versions:      &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023/versions", ID: ""},
+					},
+					Alerts: &[]models.Alert{
+						{
+							Date:        "",
+							Description: "Test alert",
+							Type:        models.AlertType(""),
+						},
+					},
+					UsageNotes: &[]models.UsageNote{
+						{
+							Note:  "Test usage note",
+							Title: "",
+						},
+					},
+					Distributions: &[]models.Distribution{
+						{
+							Title:       "Test distribution",
+							Format:      models.DistributionFormat(""),
+							MediaType:   models.DistributionMediaType(""),
+							DownloadURL: "",
+							ByteSize:    0,
+						},
+					},
+					QualityDesignation: models.QualityDesignation("Test quality designation"),
+				},
+			},
+		}
+
+		versions := []*models.Version{
+			{
+				DatasetID:   "123",
+				Edition:     "2023",
+				ReleaseDate: "2023-10-01",
+				Links: &models.VersionLinks{
+					Dataset: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123",
+						ID:   "123",
+					},
+					Version: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123/editions/2023/versions/1",
+						ID:   "1",
+					},
+					Edition: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123/editions/2023",
+						ID:   "2023",
+					},
+				},
+				Version:            1,
+				LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
+				Alerts:             &[]models.Alert{{Description: "Test alert"}},
+				UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
+				Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
+				QualityDesignation: "Test quality designation",
+				State:              "published",
+			},
+			{
+				DatasetID:   "123",
+				Edition:     "2023",
+				ReleaseDate: "2023-10-01",
+				Links: &models.VersionLinks{
+					Dataset: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123",
+						ID:   "123",
+					},
+					Version: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123/editions/2023/versions/2",
+						ID:   "2",
+					},
+					Edition: &models.LinkObject{
+						HRef: "http://localhost:22000/datasets/123/editions/2023",
+						ID:   "2023",
+					},
+				},
+				Version:            2,
+				LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
+				Alerts:             &[]models.Alert{{Description: "Test alert"}},
+				UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
+				Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
+				QualityDesignation: "Test quality designation",
+				State:              "associated",
+			},
+		}
+		publishedLatestVersion := &models.Version{
+			DatasetID:   "123",
+			Edition:     "2023",
+			ReleaseDate: "2023-10-01",
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123",
+					ID:   "123",
+				},
+				Version: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123/editions/2023/versions/1",
+					ID:   "1",
+				},
+				Edition: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123/editions/2023",
+					ID:   "2023",
+				},
+			},
+			Version:            1,
+			LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
+			Alerts:             &[]models.Alert{{Description: "Test alert"}},
+			UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
+			Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
+			QualityDesignation: "Test quality designation",
+			State:              "published",
+		}
+		unpublishedLatestVersion := &models.Version{
+			DatasetID:   "123",
+			Edition:     "2023",
+			ReleaseDate: "2023-10-01",
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123",
+					ID:   "123",
+				},
+				Version: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123/editions/2023/versions/2",
+					ID:   "2",
+				},
+				Edition: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123/editions/2023",
+					ID:   "2023",
+				},
+			},
+			Version:            2,
+			LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
+			Alerts:             &[]models.Alert{{Description: "Test alert"}},
+			UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
+			Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
+			QualityDesignation: "Test quality designation",
+			State:              "assosiated",
+		}
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			GetDatasetTypeFunc: func(_ context.Context, _ string, authorised bool) (string, error) {
+				return models.Static.String(), nil
+			},
+			GetAllStaticVersionsFunc: func(ctx context.Context, ID, state string, offset, limit int) ([]*models.Version, int, error) {
+				return versions, 2, nil
+			},
+			GetLatestVersionStaticFunc: func(ctx context.Context, datasetID, editionID, state string) (*models.Version, error) {
+				return publishedLatestVersion, nil
+			},
+		}
+
+		permissions := getAuthorisationHandlerMock()
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, permissions, permissions)
+		_, totalCount, _ := api.getEditions(w, r, 20, 0)
+
+		editions, err := utils.MapVersionsToEditionUpdate(publishedLatestVersion, unpublishedLatestVersion)
+		So(w.Code, ShouldEqual, http.StatusOK)
+		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.GetAllStaticVersionsCalls()), ShouldEqual, 1)
+		So([]*models.EditionUpdate{editions}, ShouldEqual, editionsList)
 		So(totalCount, ShouldEqual, 2)
 		So(err, ShouldEqual, nil)
 	})

--- a/api/editions_test.go
+++ b/api/editions_test.go
@@ -617,7 +617,7 @@ func TestGetEditionsReturnsError(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(datasetPermissions.Required.Calls, ShouldEqual, 1)
 		So(permissions.Required.Calls, ShouldEqual, 0)
-		So(w.Body.String(), ShouldContainSubstring, errs.ErrVersionNotFound.Error())
+		So(w.Body.String(), ShouldContainSubstring, errs.ErrEditionsNotFound.Error())
 		So(len(mockedDataStore.CheckDatasetExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.GetAllStaticVersionsCalls()), ShouldEqual, 1)
 	})

--- a/api/editions_test.go
+++ b/api/editions_test.go
@@ -47,7 +47,11 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 		w := httptest.NewRecorder()
 		publicResult := &models.Edition{ID: "20"}
 		results := []*models.EditionUpdate{{Current: publicResult}}
+
 		mockedDataStore := &storetest.StorerMock{
+			GetDatasetTypeFunc: func(_ context.Context, _ string, authorised bool) (string, error) {
+				return models.CantabularFlexibleTable.String(), nil
+			},
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
 			},
@@ -78,6 +82,9 @@ func TestGetEditionsReturnsError(t *testing.T) {
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return errs.ErrInternalServer
 			},
+			GetDatasetTypeFunc: func(_ context.Context, _ string, authorised bool) (string, error) {
+				return "", nil
+			},
 		}
 
 		datasetPermissions := getAuthorisationHandlerMock()
@@ -100,6 +107,9 @@ func TestGetEditionsReturnsError(t *testing.T) {
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return errs.ErrDatasetNotFound
+			},
+			GetDatasetTypeFunc: func(_ context.Context, _ string, authorised bool) (string, error) {
+				return "", nil
 			},
 		}
 
@@ -127,6 +137,9 @@ func TestGetEditionsReturnsError(t *testing.T) {
 			GetEditionsFunc: func(context.Context, string, string, int, int, bool) ([]*models.EditionUpdate, int, error) {
 				return nil, 0, errs.ErrEditionNotFound
 			},
+			GetDatasetTypeFunc: func(_ context.Context, _ string, authorised bool) (string, error) {
+				return "", nil
+			},
 		}
 
 		datasetPermissions := getAuthorisationHandlerMock()
@@ -151,6 +164,9 @@ func TestGetEditionsReturnsError(t *testing.T) {
 			},
 			GetEditionsFunc: func(context.Context, string, string, int, int, bool) ([]*models.EditionUpdate, int, error) {
 				return nil, 0, errs.ErrEditionNotFound
+			},
+			GetDatasetTypeFunc: func(_ context.Context, _ string, authorised bool) (string, error) {
+				return "", nil
 			},
 		}
 

--- a/api/webendpoints_test.go
+++ b/api/webendpoints_test.go
@@ -106,6 +106,14 @@ func TestWebSubnetEditionsEndpoint(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
+			GetDatasetTypeFunc: func(_ context.Context, _ string, authorised bool) (string, error) {
+				if authorised {
+					datasetSearchState = models.SubmittedState
+				} else {
+					datasetSearchState = models.PublishedState
+				}
+				return models.CantabularFlexibleTable.String(), nil
+			},
 			CheckDatasetExistsFunc: func(_ context.Context, _, state string) error {
 				datasetSearchState = state
 				return nil

--- a/mocks/generate_downloads_mocks.go
+++ b/mocks/generate_downloads_mocks.go
@@ -10,7 +10,7 @@ import (
 
 // Ensure, that KafkaProducerMock does implement download.KafkaProducer.
 // If this is not the case, regenerate this file with moq.
-// var _ download.KafkaProducer = &KafkaProducerMock{}
+//var _ download.KafkaProducer = &KafkaProducerMock{}
 
 // KafkaProducerMock is a mock implementation of download.KafkaProducer.
 //
@@ -69,7 +69,7 @@ func (mock *KafkaProducerMock) OutputCalls() []struct {
 
 // Ensure, that GenerateDownloadsEventMock does implement download.GenerateDownloadsEvent.
 // If this is not the case, regenerate this file with moq.
-// var _ download.GenerateDownloadsEvent = &GenerateDownloadsEventMock{}
+//var _ download.GenerateDownloadsEvent = &GenerateDownloadsEventMock{}
 
 // GenerateDownloadsEventMock is a mock implementation of download.GenerateDownloadsEvent.
 //

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -10,7 +10,7 @@ import (
 
 // Ensure, that DownloadsGeneratorMock does implement api.DownloadsGenerator.
 // If this is not the case, regenerate this file with moq.
-// var _ api.DownloadsGenerator = &DownloadsGeneratorMock{}
+//var _ api.DownloadsGenerator = &DownloadsGeneratorMock{}
 
 // DownloadsGeneratorMock is a mock implementation of api.DownloadsGenerator.
 //

--- a/mongo/version_store.go
+++ b/mongo/version_store.go
@@ -189,7 +189,10 @@ func (m *Mongo) GetDatasetType(ctx context.Context, datasetID string, authorised
 }
 
 func (m *Mongo) GetAllStaticVersions(ctx context.Context, datasetID, state string, offset, limit int) ([]*models.Version, int, error) {
-	selector := buildAllEditionsQuery(datasetID, state)
+	selector := bson.M{"links.dataset.id": datasetID}
+	if state != "" {
+		selector["state"] = state
+	}
 	// get total count and paginated values according to provided offset and limit
 	results := []*models.Version{}
 	totalCount, err := m.Connection.Collection(m.ActualCollectionName(config.VersionsCollection)).Find(ctx, selector, &results,
@@ -204,30 +207,5 @@ func (m *Mongo) GetAllStaticVersions(ctx context.Context, datasetID, state strin
 		return nil, 0, errs.ErrVersionNotFound
 	}
 
-	for i := 0; i < len(results); i++ {
-		results[i].Links.Self.HRef = results[i].Links.Version.HRef
-		results[i].DatasetID = datasetID
-	}
 	return results, totalCount, nil
-}
-
-func buildAllEditionsQuery(datasetID, state string) bson.M {
-	var selector bson.M
-	if state == "" {
-		selector = bson.M{
-			"links.dataset.id": datasetID,
-			"$or": []interface{}{
-				bson.M{"state": models.EditionConfirmedState},
-				bson.M{"state": models.AssociatedState},
-				bson.M{"state": models.PublishedState},
-			},
-		}
-	} else {
-		selector = bson.M{
-			"links.dataset.id": datasetID,
-			"state":            state,
-		}
-	}
-
-	return selector
 }

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -36,6 +36,7 @@ type dataMongoDB interface {
 	GetDimensionOptionsFromIDs(ctx context.Context, version *models.Version, dimension string, ids []string) ([]*models.PublicDimensionOption, int, error)
 	GetEdition(ctx context.Context, ID, editionID, state string) (*models.EditionUpdate, error)
 	GetEditions(ctx context.Context, ID, state string, offset, limit int, authorised bool) ([]*models.EditionUpdate, int, error)
+	GetAllStaticVersions(ctx context.Context, ID, state string, offset, limit int) ([]*models.Version, int, error)
 	GetInstances(ctx context.Context, states []string, datasets []string, offset, limit int) ([]*models.Instance, int, error)
 	GetInstance(ctx context.Context, ID, eTagSelector string) (*models.Instance, error)
 	GetNextVersion(ctx context.Context, datasetID, editionID string) (int, error)

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -51,6 +51,9 @@ var _ store.Storer = &StorerMock{}
 //			DeleteEditionFunc: func(ctx context.Context, ID string) error {
 //				panic("mock out the DeleteEdition method")
 //			},
+//			GetAllStaticVersionsFunc: func(ctx context.Context, ID string, state string, offset int, limit int) ([]*models.Version, int, error) {
+//				panic("mock out the GetAllStaticVersions method")
+//			},
 //			GetDatasetFunc: func(ctx context.Context, ID string) (*models.DatasetUpdate, error) {
 //				panic("mock out the GetDataset method")
 //			},
@@ -207,6 +210,9 @@ type StorerMock struct {
 
 	// DeleteEditionFunc mocks the DeleteEdition method.
 	DeleteEditionFunc func(ctx context.Context, ID string) error
+
+	// GetAllStaticVersionsFunc mocks the GetAllStaticVersions method.
+	GetAllStaticVersionsFunc func(ctx context.Context, ID string, state string, offset int, limit int) ([]*models.Version, int, error)
 
 	// GetDatasetFunc mocks the GetDataset method.
 	GetDatasetFunc func(ctx context.Context, ID string) (*models.DatasetUpdate, error)
@@ -419,6 +425,19 @@ type StorerMock struct {
 			Ctx context.Context
 			// ID is the ID argument value.
 			ID string
+		}
+		// GetAllStaticVersions holds details about calls to the GetAllStaticVersions method.
+		GetAllStaticVersions []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the ID argument value.
+			ID string
+			// State is the state argument value.
+			State string
+			// Offset is the offset argument value.
+			Offset int
+			// Limit is the limit argument value.
+			Limit int
 		}
 		// GetDataset holds details about calls to the GetDataset method.
 		GetDataset []struct {
@@ -857,6 +876,7 @@ type StorerMock struct {
 	lockCheckEditionExistsStatic            sync.RWMutex
 	lockDeleteDataset                       sync.RWMutex
 	lockDeleteEdition                       sync.RWMutex
+	lockGetAllStaticVersions                sync.RWMutex
 	lockGetDataset                          sync.RWMutex
 	lockGetDatasetType                      sync.RWMutex
 	lockGetDatasets                         sync.RWMutex
@@ -1296,6 +1316,54 @@ func (mock *StorerMock) DeleteEditionCalls() []struct {
 	mock.lockDeleteEdition.RLock()
 	calls = mock.calls.DeleteEdition
 	mock.lockDeleteEdition.RUnlock()
+	return calls
+}
+
+// GetAllStaticVersions calls GetAllStaticVersionsFunc.
+func (mock *StorerMock) GetAllStaticVersions(ctx context.Context, ID string, state string, offset int, limit int) ([]*models.Version, int, error) {
+	if mock.GetAllStaticVersionsFunc == nil {
+		panic("StorerMock.GetAllStaticVersionsFunc: method is nil but Storer.GetAllStaticVersions was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		ID     string
+		State  string
+		Offset int
+		Limit  int
+	}{
+		Ctx:    ctx,
+		ID:     ID,
+		State:  state,
+		Offset: offset,
+		Limit:  limit,
+	}
+	mock.lockGetAllStaticVersions.Lock()
+	mock.calls.GetAllStaticVersions = append(mock.calls.GetAllStaticVersions, callInfo)
+	mock.lockGetAllStaticVersions.Unlock()
+	return mock.GetAllStaticVersionsFunc(ctx, ID, state, offset, limit)
+}
+
+// GetAllStaticVersionsCalls gets all the calls that were made to GetAllStaticVersions.
+// Check the length with:
+//
+//	len(mockedStorer.GetAllStaticVersionsCalls())
+func (mock *StorerMock) GetAllStaticVersionsCalls() []struct {
+	Ctx    context.Context
+	ID     string
+	State  string
+	Offset int
+	Limit  int
+} {
+	var calls []struct {
+		Ctx    context.Context
+		ID     string
+		State  string
+		Offset int
+		Limit  int
+	}
+	mock.lockGetAllStaticVersions.RLock()
+	calls = mock.calls.GetAllStaticVersions
+	mock.lockGetAllStaticVersions.RUnlock()
 	return calls
 }
 

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -55,6 +55,9 @@ var _ store.MongoDB = &MongoDBMock{}
 //			DeleteEditionFunc: func(ctx context.Context, ID string) error {
 //				panic("mock out the DeleteEdition method")
 //			},
+//			GetAllStaticVersionsFunc: func(ctx context.Context, ID string, state string, offset int, limit int) ([]*models.Version, int, error) {
+//				panic("mock out the GetAllStaticVersions method")
+//			},
 //			GetDatasetFunc: func(ctx context.Context, ID string) (*models.DatasetUpdate, error) {
 //				panic("mock out the GetDataset method")
 //			},
@@ -211,6 +214,9 @@ type MongoDBMock struct {
 
 	// DeleteEditionFunc mocks the DeleteEdition method.
 	DeleteEditionFunc func(ctx context.Context, ID string) error
+
+	// GetAllStaticVersionsFunc mocks the GetAllStaticVersions method.
+	GetAllStaticVersionsFunc func(ctx context.Context, ID string, state string, offset int, limit int) ([]*models.Version, int, error)
 
 	// GetDatasetFunc mocks the GetDataset method.
 	GetDatasetFunc func(ctx context.Context, ID string) (*models.DatasetUpdate, error)
@@ -419,6 +425,19 @@ type MongoDBMock struct {
 			Ctx context.Context
 			// ID is the ID argument value.
 			ID string
+		}
+		// GetAllStaticVersions holds details about calls to the GetAllStaticVersions method.
+		GetAllStaticVersions []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the ID argument value.
+			ID string
+			// State is the state argument value.
+			State string
+			// Offset is the offset argument value.
+			Offset int
+			// Limit is the limit argument value.
+			Limit int
 		}
 		// GetDataset holds details about calls to the GetDataset method.
 		GetDataset []struct {
@@ -851,6 +870,7 @@ type MongoDBMock struct {
 	lockClose                               sync.RWMutex
 	lockDeleteDataset                       sync.RWMutex
 	lockDeleteEdition                       sync.RWMutex
+	lockGetAllStaticVersions                sync.RWMutex
 	lockGetDataset                          sync.RWMutex
 	lockGetDatasetType                      sync.RWMutex
 	lockGetDatasets                         sync.RWMutex
@@ -1309,6 +1329,54 @@ func (mock *MongoDBMock) DeleteEditionCalls() []struct {
 	mock.lockDeleteEdition.RLock()
 	calls = mock.calls.DeleteEdition
 	mock.lockDeleteEdition.RUnlock()
+	return calls
+}
+
+// GetAllStaticVersions calls GetAllStaticVersionsFunc.
+func (mock *MongoDBMock) GetAllStaticVersions(ctx context.Context, ID string, state string, offset int, limit int) ([]*models.Version, int, error) {
+	if mock.GetAllStaticVersionsFunc == nil {
+		panic("MongoDBMock.GetAllStaticVersionsFunc: method is nil but MongoDB.GetAllStaticVersions was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		ID     string
+		State  string
+		Offset int
+		Limit  int
+	}{
+		Ctx:    ctx,
+		ID:     ID,
+		State:  state,
+		Offset: offset,
+		Limit:  limit,
+	}
+	mock.lockGetAllStaticVersions.Lock()
+	mock.calls.GetAllStaticVersions = append(mock.calls.GetAllStaticVersions, callInfo)
+	mock.lockGetAllStaticVersions.Unlock()
+	return mock.GetAllStaticVersionsFunc(ctx, ID, state, offset, limit)
+}
+
+// GetAllStaticVersionsCalls gets all the calls that were made to GetAllStaticVersions.
+// Check the length with:
+//
+//	len(mockedMongoDB.GetAllStaticVersionsCalls())
+func (mock *MongoDBMock) GetAllStaticVersionsCalls() []struct {
+	Ctx    context.Context
+	ID     string
+	State  string
+	Offset int
+	Limit  int
+} {
+	var calls []struct {
+		Ctx    context.Context
+		ID     string
+		State  string
+		Offset int
+		Limit  int
+	}
+	mock.lockGetAllStaticVersions.RLock()
+	calls = mock.calls.GetAllStaticVersions
+	mock.lockGetAllStaticVersions.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
### What

- updated getEditions method to retrieve the editions from versions collection
- updated unit tests

### How to review

- check if the editions are correctly returned with the json response (wrapped published editions with 'current' obj, unpublished editions with 'next' obj)
- check if all the builds are passed

### Who can review

Anyone