### PR TITLE
remove distribution if static dataset

### DIFF
--- a/models/metadata.go
+++ b/models/metadata.go
@@ -143,7 +143,9 @@ func CreateMetaDataDoc(datasetDoc *Dataset, versionDoc *Version, urlBuilder *url
 		}
 	}
 
-	metaDataDoc.Distribution = getDistribution(versionDoc.Downloads)
+	if datasetDoc.Type != "static" {
+		metaDataDoc.Distribution = getDistribution(versionDoc.Downloads)
+	}
 
 	if versionDoc.Downloads != nil {
 		metaDataDoc.Downloads = &DownloadList{}


### PR DESCRIPTION
### What

We are not returning `Distribution` as part of the metadata model for static datasets, as per the v1 diagram - https://confluence.ons.gov.uk/pages/viewpage.action?spaceKey=DIS&title=v1+API+Minimal+Dataset+Metadata&preview=/221253054/256645183/image-2025-3-13_11-6-16.png

This will only be returned in non-static datasets (as it had been previously)

### How to review

Confirm changes make sense, tests pass

### Who can review

Anyone
