### PR TITLE
add validation for exisiting version

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -873,6 +873,8 @@ func handleVersionAPIErr(ctx context.Context, err error, w http.ResponseWriter, 
 }
 
 // condensed api call to add new version
+//
+//nolint:gocyclo,gocognit // high cyclomactic & cognitive complexity not in scope for maintenance
 func (api *DatasetAPI) addDatasetVersionCondensed(w http.ResponseWriter, r *http.Request) {
 	defer dphttp.DrainBody(r)
 

--- a/api/versions.go
+++ b/api/versions.go
@@ -897,6 +897,37 @@ func (api *DatasetAPI) addDatasetVersionCondensed(w http.ResponseWriter, r *http
 		editionExists = false
 	}
 
+	if editionExists {
+		latestVersion, err := api.dataStore.Backend.GetLatestVersionStatic(ctx, datasetID, edition, "")
+		if err == nil && latestVersion != nil && latestVersion.State != models.PublishedState {
+			log.Error(ctx, "unpublished version already exists", errors.New("cannot create new version when unpublished version exists"),
+				log.Data{"state": latestVersion.State, "version": latestVersion.Version})
+
+			errorResponse := map[string]interface{}{
+				"error":               "cannot create new version when an unpublished version already exists",
+				"unpublished_version": latestVersion.Version,
+			}
+
+			responseBody, err := json.Marshal(errorResponse)
+			if err != nil {
+				log.Error(ctx, "failed to marshal error response", err, logData)
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+				return
+			}
+
+			setJSONContentType(w)
+			w.WriteHeader(http.StatusBadRequest)
+			if _, err := w.Write(responseBody); err != nil {
+				log.Error(ctx, "failed to write response", err, logData)
+			}
+			return
+		} else if err != nil && !errors.Is(err, errs.ErrVersionNotFound) {
+			log.Error(ctx, "failed to check latest version", err, logData)
+			handleDatasetAPIErr(ctx, errs.ErrInternalServer, w, nil)
+			return
+		}
+	}
+
 	versionRequest := &models.Version{}
 	if err := json.NewDecoder(r.Body).Decode(versionRequest); err != nil {
 		log.Error(ctx, "failed to unmarshal version", err, logData)

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -3038,6 +3038,11 @@ func TestAddDatasetVersionCondensed(t *testing.T) {
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
 				return &models.DatasetUpdate{Next: &models.Dataset{State: "associated"}}, nil
 			},
+			GetLatestVersionStaticFunc: func(context.Context, string, string, string) (*models.Version, error) {
+				return &models.Version{
+					State: models.PublishedState,
+				}, nil
+			},
 			GetNextVersionStaticFunc: func(context.Context, string, string) (int, error) {
 				return 2, nil
 			},
@@ -3263,6 +3268,11 @@ func TestAddDatasetVersionCondensed(t *testing.T) {
 			UpsertDatasetFunc: func(context.Context, string, *models.DatasetUpdate) error {
 				return nil
 			},
+			GetLatestVersionStaticFunc: func(context.Context, string, string, string) (*models.Version, error) {
+				return &models.Version{
+					State: models.AssociatedState,
+				}, nil
+			},
 			AddVersionStaticFunc: func(context.Context, *models.Version) (*models.Version, error) {
 				return nil, nil
 			},
@@ -3322,6 +3332,11 @@ func TestAddDatasetVersionCondensed(t *testing.T) {
 			},
 			UpsertDatasetFunc: func(context.Context, string, *models.DatasetUpdate) error {
 				return nil
+			},
+			GetLatestVersionStaticFunc: func(context.Context, string, string, string) (*models.Version, error) {
+				return &models.Version{
+					State: models.PublishedState,
+				}, nil
 			},
 			AddVersionStaticFunc: func(context.Context, *models.Version) (*models.Version, error) {
 				return &models.Version{Version: 2}, nil

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -485,6 +485,7 @@ paths:
               * invalid request body
               * dataset id was incorrect
               * edition was incorrect
+              * an unpublished version of the dataset already exists
         401:
           description: "Unauthorised to update version of dataset"
         404:


### PR DESCRIPTION
### What

Added validation to check for an unpublished version of the dataset series before creating a new version, and return a error if there is an unpublished version

### How to review

To test locally - 
1. Make a POST request to `localhost:22000/datasets` to create a dataset
2. Make a POST request to `localhost:22000/datasets/{dataset-id}/editions/time-series/versions` using the dataset-id from the previous step
3. Repeat step 2 and confirm that you receive a 400 error with `"error": "cannot create new version when an unpublished version already exists"` in the response
4. In the local mongo database, edit the version you have created to set the state to `published`
5. Repeat step 2 and confirm that the new version is created

Confirm changes make sense, tests pass

### Who can review

Anyone
