### PR TITLE
added type search param to /datasets endpoint with unit tests

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -46,7 +46,7 @@ var (
 )
 
 const IsBasedOn = "is_based_on"
-const DataseyType = "type"
+const DatasetType = "type"
 
 // getDatasets returns a list of datasets, the total count of datasets and an error
 func (api *DatasetAPI) getDatasets(w http.ResponseWriter, r *http.Request, limit, offset int) (mappedDatasets interface{}, totalCount int, err error) {
@@ -57,8 +57,8 @@ func (api *DatasetAPI) getDatasets(w http.ResponseWriter, r *http.Request, limit
 	isBasedOnExists := r.URL.Query().Has(IsBasedOn)
 	isBasedOn := r.URL.Query().Get(IsBasedOn)
 
-	isDatasetTypeExists := r.URL.Query().Has(DataseyType)
-	datasetType := r.URL.Query().Get(DataseyType)
+	isDatasetTypeExists := r.URL.Query().Has(DatasetType)
+	datasetType := r.URL.Query().Get(DatasetType)
 
 	if isBasedOnExists && isBasedOn == "" {
 		err := errs.ErrInvalidQueryParameter

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -46,6 +46,7 @@ var (
 )
 
 const IsBasedOn = "is_based_on"
+const DataseyType = "type"
 
 // getDatasets returns a list of datasets, the total count of datasets and an error
 func (api *DatasetAPI) getDatasets(w http.ResponseWriter, r *http.Request, limit, offset int) (mappedDatasets interface{}, totalCount int, err error) {
@@ -56,6 +57,9 @@ func (api *DatasetAPI) getDatasets(w http.ResponseWriter, r *http.Request, limit
 	isBasedOnExists := r.URL.Query().Has(IsBasedOn)
 	isBasedOn := r.URL.Query().Get(IsBasedOn)
 
+	isDatasetTypeExists := r.URL.Query().Has(DataseyType)
+	datasetType := r.URL.Query().Get(DataseyType)
+
 	if isBasedOnExists && isBasedOn == "" {
 		err := errs.ErrInvalidQueryParameter
 		log.Error(ctx, "malformed is_based_on parameter", err)
@@ -63,10 +67,17 @@ func (api *DatasetAPI) getDatasets(w http.ResponseWriter, r *http.Request, limit
 		return nil, 0, err
 	}
 
+	if isDatasetTypeExists && datasetType == "" {
+		err := errs.ErrInvalidQueryParameter
+		log.Error(ctx, "malformed type parameter", err)
+		handleDatasetAPIErr(ctx, err, w, logData)
+		return nil, 0, err
+	}
+
 	var datasets []*models.DatasetUpdate
 
-	if isBasedOnExists {
-		datasets, totalCount, err = api.dataStore.Backend.GetDatasetsByBasedOn(ctx, isBasedOn, offset, limit, authorised)
+	if isBasedOnExists || isDatasetTypeExists {
+		datasets, totalCount, err = api.dataStore.Backend.GetDatasetsByQueryParams(ctx, isBasedOn, datasetType, offset, limit, authorised)
 	} else {
 		datasets, totalCount, err = api.dataStore.Backend.GetDatasets(
 			ctx,

--- a/mocks/generate_downloads_mocks.go
+++ b/mocks/generate_downloads_mocks.go
@@ -4,6 +4,7 @@
 package mocks
 
 import (
+	//"github.com/ONSdigital/dp-dataset-api/download"
 	kafka "github.com/ONSdigital/dp-kafka/v4"
 	"sync"
 )

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -28,7 +28,7 @@ type dataMongoDB interface {
 	CheckEditionExistsStatic(ctx context.Context, id, editionID, state string) error
 	GetDataset(ctx context.Context, ID string) (*models.DatasetUpdate, error)
 	GetDatasets(ctx context.Context, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
-	GetDatasetsByBasedOn(ctx context.Context, ID string, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
+	GetDatasetsByQueryParams(ctx context.Context, ID, datasetType string, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
 	GetDatasetType(ctx context.Context, datasetID string, authorised bool) (string, error)
 	GetDimensionsFromInstance(ctx context.Context, ID string, offset, limit int) ([]*models.DimensionOption, int, error)
 	GetDimensions(ctx context.Context, versionID string) ([]bson.M, error)

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/bson"
 	"sync"
 )
 
@@ -70,8 +70,8 @@ var _ store.MongoDB = &MongoDBMock{}
 //			GetDatasetsFunc: func(ctx context.Context, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
 //				panic("mock out the GetDatasets method")
 //			},
-//			GetDatasetsByBasedOnFunc: func(ctx context.Context, ID string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
-//				panic("mock out the GetDatasetsByBasedOn method")
+//			GetDatasetsByQueryParamsFunc: func(ctx context.Context, ID string, datasetType string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
+//				panic("mock out the GetDatasetsByQueryParams method")
 //			},
 //			GetDimensionOptionsFunc: func(ctx context.Context, version *models.Version, dimension string, offset int, limit int) ([]*models.PublicDimensionOption, int, error) {
 //				panic("mock out the GetDimensionOptions method")
@@ -79,7 +79,7 @@ var _ store.MongoDB = &MongoDBMock{}
 //			GetDimensionOptionsFromIDsFunc: func(ctx context.Context, version *models.Version, dimension string, ids []string) ([]*models.PublicDimensionOption, int, error) {
 //				panic("mock out the GetDimensionOptionsFromIDs method")
 //			},
-//			GetDimensionsFunc: func(ctx context.Context, versionID string) ([]primitive.M, error) {
+//			GetDimensionsFunc: func(ctx context.Context, versionID string) ([]bson.M, error) {
 //				panic("mock out the GetDimensions method")
 //			},
 //			GetDimensionsFromInstanceFunc: func(ctx context.Context, ID string, offset int, limit int) ([]*models.DimensionOption, int, error) {
@@ -239,8 +239,8 @@ type MongoDBMock struct {
 	// GetDatasetsFunc mocks the GetDatasets method.
 	GetDatasetsFunc func(ctx context.Context, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
 
-	// GetDatasetsByBasedOnFunc mocks the GetDatasetsByBasedOn method.
-	GetDatasetsByBasedOnFunc func(ctx context.Context, ID string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
+	// GetDatasetsByQueryParamsFunc mocks the GetDatasetsByQueryParams method.
+	GetDatasetsByQueryParamsFunc func(ctx context.Context, ID string, datasetType string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
 
 	// GetDimensionOptionsFunc mocks the GetDimensionOptions method.
 	GetDimensionOptionsFunc func(ctx context.Context, version *models.Version, dimension string, offset int, limit int) ([]*models.PublicDimensionOption, int, error)
@@ -249,7 +249,7 @@ type MongoDBMock struct {
 	GetDimensionOptionsFromIDsFunc func(ctx context.Context, version *models.Version, dimension string, ids []string) ([]*models.PublicDimensionOption, int, error)
 
 	// GetDimensionsFunc mocks the GetDimensions method.
-	GetDimensionsFunc func(ctx context.Context, versionID string) ([]primitive.M, error)
+	GetDimensionsFunc func(ctx context.Context, versionID string) ([]bson.M, error)
 
 	// GetDimensionsFromInstanceFunc mocks the GetDimensionsFromInstance method.
 	GetDimensionsFromInstanceFunc func(ctx context.Context, ID string, offset int, limit int) ([]*models.DimensionOption, int, error)
@@ -491,12 +491,14 @@ type MongoDBMock struct {
 			// Authorised is the authorised argument value.
 			Authorised bool
 		}
-		// GetDatasetsByBasedOn holds details about calls to the GetDatasetsByBasedOn method.
-		GetDatasetsByBasedOn []struct {
+		// GetDatasetsByQueryParams holds details about calls to the GetDatasetsByQueryParams method.
+		GetDatasetsByQueryParams []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// ID is the ID argument value.
 			ID string
+			// DatasetType is the datasetType argument value.
+			DatasetType string
 			// Offset is the offset argument value.
 			Offset int
 			// Limit is the limit argument value.
@@ -918,7 +920,7 @@ type MongoDBMock struct {
 	lockGetDataset                          sync.RWMutex
 	lockGetDatasetType                      sync.RWMutex
 	lockGetDatasets                         sync.RWMutex
-	lockGetDatasetsByBasedOn                sync.RWMutex
+	lockGetDatasetsByQueryParams            sync.RWMutex
 	lockGetDimensionOptions                 sync.RWMutex
 	lockGetDimensionOptionsFromIDs          sync.RWMutex
 	lockGetDimensions                       sync.RWMutex
@@ -1582,51 +1584,55 @@ func (mock *MongoDBMock) GetDatasetsCalls() []struct {
 	return calls
 }
 
-// GetDatasetsByBasedOn calls GetDatasetsByBasedOnFunc.
-func (mock *MongoDBMock) GetDatasetsByBasedOn(ctx context.Context, ID string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
-	if mock.GetDatasetsByBasedOnFunc == nil {
-		panic("MongoDBMock.GetDatasetsByBasedOnFunc: method is nil but MongoDB.GetDatasetsByBasedOn was just called")
+// GetDatasetsByQueryParams calls GetDatasetsByQueryParamsFunc.
+func (mock *MongoDBMock) GetDatasetsByQueryParams(ctx context.Context, ID string, datasetType string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
+	if mock.GetDatasetsByQueryParamsFunc == nil {
+		panic("MongoDBMock.GetDatasetsByQueryParamsFunc: method is nil but MongoDB.GetDatasetsByQueryParams was just called")
 	}
 	callInfo := struct {
-		Ctx        context.Context
-		ID         string
-		Offset     int
-		Limit      int
-		Authorised bool
+		Ctx         context.Context
+		ID          string
+		DatasetType string
+		Offset      int
+		Limit       int
+		Authorised  bool
 	}{
-		Ctx:        ctx,
-		ID:         ID,
-		Offset:     offset,
-		Limit:      limit,
-		Authorised: authorised,
+		Ctx:         ctx,
+		ID:          ID,
+		DatasetType: datasetType,
+		Offset:      offset,
+		Limit:       limit,
+		Authorised:  authorised,
 	}
-	mock.lockGetDatasetsByBasedOn.Lock()
-	mock.calls.GetDatasetsByBasedOn = append(mock.calls.GetDatasetsByBasedOn, callInfo)
-	mock.lockGetDatasetsByBasedOn.Unlock()
-	return mock.GetDatasetsByBasedOnFunc(ctx, ID, offset, limit, authorised)
+	mock.lockGetDatasetsByQueryParams.Lock()
+	mock.calls.GetDatasetsByQueryParams = append(mock.calls.GetDatasetsByQueryParams, callInfo)
+	mock.lockGetDatasetsByQueryParams.Unlock()
+	return mock.GetDatasetsByQueryParamsFunc(ctx, ID, datasetType, offset, limit, authorised)
 }
 
-// GetDatasetsByBasedOnCalls gets all the calls that were made to GetDatasetsByBasedOn.
+// GetDatasetsByQueryParamsCalls gets all the calls that were made to GetDatasetsByQueryParams.
 // Check the length with:
 //
-//	len(mockedMongoDB.GetDatasetsByBasedOnCalls())
-func (mock *MongoDBMock) GetDatasetsByBasedOnCalls() []struct {
-	Ctx        context.Context
-	ID         string
-	Offset     int
-	Limit      int
-	Authorised bool
+//	len(mockedMongoDB.GetDatasetsByQueryParamsCalls())
+func (mock *MongoDBMock) GetDatasetsByQueryParamsCalls() []struct {
+	Ctx         context.Context
+	ID          string
+	DatasetType string
+	Offset      int
+	Limit       int
+	Authorised  bool
 } {
 	var calls []struct {
-		Ctx        context.Context
-		ID         string
-		Offset     int
-		Limit      int
-		Authorised bool
+		Ctx         context.Context
+		ID          string
+		DatasetType string
+		Offset      int
+		Limit       int
+		Authorised  bool
 	}
-	mock.lockGetDatasetsByBasedOn.RLock()
-	calls = mock.calls.GetDatasetsByBasedOn
-	mock.lockGetDatasetsByBasedOn.RUnlock()
+	mock.lockGetDatasetsByQueryParams.RLock()
+	calls = mock.calls.GetDatasetsByQueryParams
+	mock.lockGetDatasetsByQueryParams.RUnlock()
 	return calls
 }
 
@@ -1723,7 +1729,7 @@ func (mock *MongoDBMock) GetDimensionOptionsFromIDsCalls() []struct {
 }
 
 // GetDimensions calls GetDimensionsFunc.
-func (mock *MongoDBMock) GetDimensions(ctx context.Context, versionID string) ([]primitive.M, error) {
+func (mock *MongoDBMock) GetDimensions(ctx context.Context, versionID string) ([]bson.M, error) {
 	if mock.GetDimensionsFunc == nil {
 		panic("MongoDBMock.GetDimensionsFunc: method is nil but MongoDB.GetDimensions was just called")
 	}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -248,7 +248,7 @@ paths:
               description: The RFC9111 Cache-Control header field for the response which instructs how to handle caching the resource.
               type: string
         400:
-          description: "Parameter is_based_on was sent but no value was provided"
+          description: "Parameter is_based_on or type was sent but no value was provided"
         404:
           description: "No dataset was found with the population-type provided"
         500:
@@ -485,13 +485,14 @@ paths:
         201:
           description: "A json object containing a version"
           schema:
-            $ref: "#/definitions/NewVersionResponse"
+            $ref: "#/definitions/Version"
         400:
           description: |
             Invalid request, reasons can be one of the following:
               * invalid request body
               * dataset id was incorrect
               * edition was incorrect
+              * an unpublished version of the dataset already exists
         401:
           description: "Unauthorised to update version of dataset"
         404:
@@ -517,7 +518,7 @@ paths:
         201:
           description: "A json object containing a version"
           schema:
-            $ref: "#/definitions/NewVersionResponse"
+            $ref: "#/definitions/Version"
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -1886,23 +1887,42 @@ definitions:
       contacts:
         description: "A list containing contact details of statisticians for a dataset"
         type: array
+        minItems: 1
         items:
           $ref: "#/definitions/Contact"
+      dataset_id:
+        description: "The identifier for the dataset."
+        type: string
+        readOnly: true
+        example: my-dataset
       description:
         description: "A description for a dataset"
         type: string
+        example: "This dataset contains some very interesting data about the UK."
       dimensions:
         description: "A list of codelists for each dimension of this version"
         type: array
         items:
           $ref: "#/definitions/Dimension"
       distribution:
-        description: "A list of media types that the version data of an edition of a dataset can be accessed"
+        description: |
+          **Deprecated:** This field is being deprecated. Use `distributions` for list of formats in which the dataset can be accessed.
+
+          A list of media types that the version data of an edition of a dataset can be accessed
         type: array
         items:
           type: string
+      distributions:
+        description: A list of representations of the dataset available and how to access them.
+        type: array
+        minItems: 1
+        items:
+          $ref: "#/definitions/Distribution"
       downloads:
-        description: A selection of download objects containing information of downloadable files."
+        description: |
+          **Deprecated:** These fields have been deprecated and replaced by the `distributions` list.
+
+          A selection of download objects containing information of downloadable files.
         type: object
         properties:
           csv:
@@ -1913,6 +1933,11 @@ definitions:
             $ref: "#/definitions/DownloadObject"
           xls:
             $ref: "#/definitions/DownloadObject"
+      edition:
+        description: "The dataset edition for this version"
+        readOnly: true
+        type: string
+        example: 2017
       headers:
         description: "A list of headers for a census dataset"
         type: array
@@ -1923,6 +1948,9 @@ definitions:
         type: array
         items:
           type: "string"
+          example: "Inflation"
+      last_updated:
+        $ref: "#/definitions/LastUpdated"
       latest_changes:
         description: "A list of changes between version of an edition for a dataset and the previous version of the same dataset edition"
         type: array
@@ -1932,7 +1960,7 @@ definitions:
         description: "The license the dataset is released under."
         type: string
         default: "Open Government Licence v3.0"
-      dataset_links:
+      links:
         $ref: "#/definitions/MetadataLinks"
       methodologies:
         description: "A list of methodologies for the dataset."
@@ -1940,7 +1968,10 @@ definitions:
         items:
           $ref: "#/definitions/RelatedLink"
       national_statistic:
-        description: "The flag indicating the resource is a national statistic. These are certified as compliant with the Code of Practice for Official Statistics"
+        description: |
+          **Deprecated:** This field has been deprecated and replaced with the `quality_designation` field under at the edition level in order to correctly represent the three potential quality designations under the updated Code of Practice for Statistics.
+
+          The flag indicating the latest version of the dataset has `accredited` designation as granted under the Code of Practice for Statistics.
         type: boolean
       next_release:
         $ref: "#/definitions/NextRelease"
@@ -1956,6 +1987,19 @@ definitions:
           $ref: "#/definitions/Publisher"
       qmi:
         $ref: "#/definitions/QMILink"
+      quality_designation:
+        description: |
+          The official statistics quality designation level of this dataset version.
+
+          Possible quality designations:
+            * `accredited-official`
+            * `official`
+            * `official-in-development`
+        type: string
+        enum:
+          - accredited-official
+          - official
+          - official-in-development
       related_datasets:
         description: "A list of other datasets related to this dataset."
         type: array
@@ -1964,9 +2008,11 @@ definitions:
       release_date:
         description: "The release date of this version of the dataset"
         type: string
+        format: date-time
       release_frequency:
         description: "The release frequency of a dataset"
         type: string
+        example: "Monthly"
       subtopics:
         description: |
           **Deprecated:** This field is being deprecated and replaced by the `topics` field.
@@ -1980,18 +2026,31 @@ definitions:
         $ref: "#/definitions/Temporal"
       title:
         description: "The title of the dataset"
-        example: "CPI"
+        example: "Consumer Prices Index"
         type: string
+      topics:
+        description: "A list of topic IDs that the dataset relates to within the topic taxonomy. This field consolidates the previously separate `canonical_topic` and `subtopics` fields."
+        type: array
+        minItems: 1
+        items:
+          type: "string"
+        example: ["7779", "7755"]
+      type:
+        $ref: "#/definitions/DatasetType"
       unit_of_measure:
         description: "The unit of measure for the dataset observations"
         type: string
+        example: "Number of people"
       usage_notes:
-        $ref: "#/definitions/UsageNote"
-      topics:
-        description: "A list of topics and subtopics that the dataset relates to within the topic taxonomy. This field consolidates the previously separate `canonical_topic` and `subtopics` fields."
+        description: "A list of usage notes relating to the dataset"
         type: array
         items:
-          type: "string"
+          $ref: "#/definitions/UsageNote"
+      version:
+        description: "A number identifying the version for an edition from a dataset"
+        example: 1
+        readOnly: true
+        type: integer
   NewDatasetResponse:
     description: "A model for the response body when creating a new dataset"
     type: object
@@ -2072,18 +2131,6 @@ definitions:
                 type: string
       state:
         $ref: "#/definitions/State"
-  NewVersionResponse:
-    description: "A model for the response body when creating a new version for an edition of a dataset"
-    allOf:
-      - type: object
-        properties:
-          collection_id:
-            $ref: "#/definitions/CollectionID"
-          id:
-            type: string
-            description: "An unique id for a dataset"
-            example: "DE3BC0B6-D6C4-4E20-917E-95D7EA8C91CD"
-      - $ref: "#/definitions/Version"
   Publisher:
     description: "The publisher of the dataset"
     type: object
@@ -2216,6 +2263,12 @@ definitions:
           $ref: "#/definitions/Alert"
       collection_id:
         $ref: "#/definitions/CollectionID"
+      distributions:
+        description: A list of representations of the dataset available and how to access them.
+        type: array
+        minItems: 1
+        items:
+          $ref: "#/definitions/Distribution"
       downloads:
         description: "A selection of download objects containing information of downloadable files. These can only be updated via an authorised caller."
         type: object
@@ -2290,6 +2343,7 @@ definitions:
       dataset_id:
         description: "The identifier for the dataset."
         type: string
+        readOnly: true
         example: my-dataset
       dimensions:
         description: "A list of codelists for each dimension of this version"
@@ -2308,6 +2362,7 @@ definitions:
 
           A selection of download objects containing information of downloadable files.
         type: object
+        readOnly: true
         properties:
           csv:
             $ref: "#/definitions/DownloadObject"
@@ -2358,7 +2413,9 @@ definitions:
       temporal:
         $ref: "#/definitions/Temporal"
       type:
-        $ref: "#/definitions/DatasetType"
+        readOnly: true
+        allOf:
+          - $ref: "#/definitions/DatasetType"
       usage_notes:
         description: "A list of usage notes relating to the dataset"
         type: array
@@ -2390,6 +2447,7 @@ definitions:
         type: integer
         minimum: 0
         example: 4300000
+        readOnly: true
       format:
         description: |
           The format for the download file referenced by `download_url`.
@@ -2421,6 +2479,7 @@ definitions:
             * `text/plain`: Plain text (used for CSDB output structured text files)
             * `application/ld+json`: JSON-LD metadata file. Commonly used to annotate tabular data in an associated CSV file as outlined in the CSVW standard.
         type: string
+        readOnly: true
         enum:
           - text/csv
           - application/vnd.sdmx.structurespecificdata+xml

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -195,6 +195,12 @@ parameters:
     description: "A population type to search on to return datasets that are associated with that population type e.g. Usual-Residents.  This is applicable to Census 2021 datasets only."
     in: query
     type: string
+  type:
+    name: type
+    required: false
+    description: "A filter to search the datasets by dataset type e.g. type=static"
+    in: query
+    type: string
   metadata_update:
     name: metadata_update
     in: body
@@ -221,6 +227,7 @@ paths:
       description: "Returns a list of all datasets available via the ONS APIs."
       parameters:
         - $ref: "#/parameters/is_based_on"
+        - $ref: "#/parameters/type"
         - $ref: "#/parameters/limit"
         - $ref: "#/parameters/offset"
       security:
@@ -478,14 +485,13 @@ paths:
         201:
           description: "A json object containing a version"
           schema:
-            $ref: "#/definitions/Version"
+            $ref: "#/definitions/NewVersionResponse"
         400:
           description: |
             Invalid request, reasons can be one of the following:
               * invalid request body
               * dataset id was incorrect
               * edition was incorrect
-              * an unpublished version of the dataset already exists
         401:
           description: "Unauthorised to update version of dataset"
         404:
@@ -511,7 +517,7 @@ paths:
         201:
           description: "A json object containing a version"
           schema:
-            $ref: "#/definitions/Version"
+            $ref: "#/definitions/NewVersionResponse"
         400:
           description: |
             Invalid request, reasons can be one of the following:
@@ -1880,42 +1886,23 @@ definitions:
       contacts:
         description: "A list containing contact details of statisticians for a dataset"
         type: array
-        minItems: 1
         items:
           $ref: "#/definitions/Contact"
-      dataset_id:
-        description: "The identifier for the dataset."
-        type: string
-        readOnly: true
-        example: my-dataset
       description:
         description: "A description for a dataset"
         type: string
-        example: "This dataset contains some very interesting data about the UK."
       dimensions:
         description: "A list of codelists for each dimension of this version"
         type: array
         items:
           $ref: "#/definitions/Dimension"
       distribution:
-        description: |
-          **Deprecated:** This field is being deprecated. Use `distributions` for list of formats in which the dataset can be accessed.
-
-          A list of media types that the version data of an edition of a dataset can be accessed
+        description: "A list of media types that the version data of an edition of a dataset can be accessed"
         type: array
         items:
           type: string
-      distributions:
-        description: A list of representations of the dataset available and how to access them.
-        type: array
-        minItems: 1
-        items:
-          $ref: "#/definitions/Distribution"
       downloads:
-        description: |
-          **Deprecated:** These fields have been deprecated and replaced by the `distributions` list.
-
-          A selection of download objects containing information of downloadable files.
+        description: A selection of download objects containing information of downloadable files."
         type: object
         properties:
           csv:
@@ -1926,11 +1913,6 @@ definitions:
             $ref: "#/definitions/DownloadObject"
           xls:
             $ref: "#/definitions/DownloadObject"
-      edition:
-        description: "The dataset edition for this version"
-        readOnly: true
-        type: string
-        example: 2017
       headers:
         description: "A list of headers for a census dataset"
         type: array
@@ -1941,9 +1923,6 @@ definitions:
         type: array
         items:
           type: "string"
-          example: "Inflation"
-      last_updated:
-        $ref: "#/definitions/LastUpdated"
       latest_changes:
         description: "A list of changes between version of an edition for a dataset and the previous version of the same dataset edition"
         type: array
@@ -1953,7 +1932,7 @@ definitions:
         description: "The license the dataset is released under."
         type: string
         default: "Open Government Licence v3.0"
-      links:
+      dataset_links:
         $ref: "#/definitions/MetadataLinks"
       methodologies:
         description: "A list of methodologies for the dataset."
@@ -1961,10 +1940,7 @@ definitions:
         items:
           $ref: "#/definitions/RelatedLink"
       national_statistic:
-        description: |
-          **Deprecated:** This field has been deprecated and replaced with the `quality_designation` field under at the edition level in order to correctly represent the three potential quality designations under the updated Code of Practice for Statistics.
-
-          The flag indicating the latest version of the dataset has `accredited` designation as granted under the Code of Practice for Statistics.
+        description: "The flag indicating the resource is a national statistic. These are certified as compliant with the Code of Practice for Official Statistics"
         type: boolean
       next_release:
         $ref: "#/definitions/NextRelease"
@@ -1980,19 +1956,6 @@ definitions:
           $ref: "#/definitions/Publisher"
       qmi:
         $ref: "#/definitions/QMILink"
-      quality_designation:
-        description: |
-          The official statistics quality designation level of this dataset version.
-
-          Possible quality designations:
-            * `accredited-official`
-            * `official`
-            * `official-in-development`
-        type: string
-        enum:
-          - accredited-official
-          - official
-          - official-in-development
       related_datasets:
         description: "A list of other datasets related to this dataset."
         type: array
@@ -2001,11 +1964,9 @@ definitions:
       release_date:
         description: "The release date of this version of the dataset"
         type: string
-        format: date-time
       release_frequency:
         description: "The release frequency of a dataset"
         type: string
-        example: "Monthly"
       subtopics:
         description: |
           **Deprecated:** This field is being deprecated and replaced by the `topics` field.
@@ -2019,31 +1980,18 @@ definitions:
         $ref: "#/definitions/Temporal"
       title:
         description: "The title of the dataset"
-        example: "Consumer Prices Index"
+        example: "CPI"
         type: string
-      topics:
-        description: "A list of topic IDs that the dataset relates to within the topic taxonomy. This field consolidates the previously separate `canonical_topic` and `subtopics` fields."
-        type: array
-        minItems: 1
-        items:
-          type: "string"
-        example: ["7779", "7755"]
-      type:
-        $ref: "#/definitions/DatasetType"
       unit_of_measure:
         description: "The unit of measure for the dataset observations"
         type: string
-        example: "Number of people"
       usage_notes:
-        description: "A list of usage notes relating to the dataset"
+        $ref: "#/definitions/UsageNote"
+      topics:
+        description: "A list of topics and subtopics that the dataset relates to within the topic taxonomy. This field consolidates the previously separate `canonical_topic` and `subtopics` fields."
         type: array
         items:
-          $ref: "#/definitions/UsageNote"
-      version:
-        description: "A number identifying the version for an edition from a dataset"
-        example: 1
-        readOnly: true
-        type: integer
+          type: "string"
   NewDatasetResponse:
     description: "A model for the response body when creating a new dataset"
     type: object
@@ -2124,6 +2072,18 @@ definitions:
                 type: string
       state:
         $ref: "#/definitions/State"
+  NewVersionResponse:
+    description: "A model for the response body when creating a new version for an edition of a dataset"
+    allOf:
+      - type: object
+        properties:
+          collection_id:
+            $ref: "#/definitions/CollectionID"
+          id:
+            type: string
+            description: "An unique id for a dataset"
+            example: "DE3BC0B6-D6C4-4E20-917E-95D7EA8C91CD"
+      - $ref: "#/definitions/Version"
   Publisher:
     description: "The publisher of the dataset"
     type: object
@@ -2256,12 +2216,6 @@ definitions:
           $ref: "#/definitions/Alert"
       collection_id:
         $ref: "#/definitions/CollectionID"
-      distributions:
-        description: A list of representations of the dataset available and how to access them.
-        type: array
-        minItems: 1
-        items:
-          $ref: "#/definitions/Distribution"
       downloads:
         description: "A selection of download objects containing information of downloadable files. These can only be updated via an authorised caller."
         type: object
@@ -2336,7 +2290,6 @@ definitions:
       dataset_id:
         description: "The identifier for the dataset."
         type: string
-        readOnly: true
         example: my-dataset
       dimensions:
         description: "A list of codelists for each dimension of this version"
@@ -2355,7 +2308,6 @@ definitions:
 
           A selection of download objects containing information of downloadable files.
         type: object
-        readOnly: true
         properties:
           csv:
             $ref: "#/definitions/DownloadObject"
@@ -2406,9 +2358,7 @@ definitions:
       temporal:
         $ref: "#/definitions/Temporal"
       type:
-        readOnly: true
-        allOf:
-          - $ref: "#/definitions/DatasetType"
+        $ref: "#/definitions/DatasetType"
       usage_notes:
         description: "A list of usage notes relating to the dataset"
         type: array
@@ -2440,7 +2390,6 @@ definitions:
         type: integer
         minimum: 0
         example: 4300000
-        readOnly: true
       format:
         description: |
           The format for the download file referenced by `download_url`.
@@ -2472,7 +2421,6 @@ definitions:
             * `text/plain`: Plain text (used for CSDB output structured text files)
             * `application/ld+json`: JSON-LD metadata file. Commonly used to annotate tabular data in an associated CSV file as outlined in the CSVW standard.
         type: string
-        readOnly: true
         enum:
           - text/csv
           - application/vnd.sdmx.structurespecificdata+xml


### PR DESCRIPTION
### What

- added type search param to /datasets endpoint with unit tests
- refactored previous `GetDatasetsByBasedOn` function to work with both `is_based_on` and 'type` queries
- unit tests added

### How to review

- Check if the dataset can be filtered using `type` & `is_based_on` parameters
- Check if the build checks are passed

### Who can review

Anyone