### PR TITLE
Prevent duplication of dataset series title

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -22,6 +22,7 @@ var (
 	datasetsForbidden = map[error]bool{
 		errs.ErrDeletePublishedDatasetForbidden: true,
 		errs.ErrAddDatasetAlreadyExists:         true,
+		errs.ErrAddDatasetTitleAlreadyExists:    true,
 	}
 
 	// errors that should return a 204 status
@@ -342,6 +343,19 @@ func (api *DatasetAPI) addDatasetNew(w http.ResponseWriter, r *http.Request) {
 	if err != errs.ErrDatasetNotFound {
 		log.Error(ctx, "addDatasetNew endpoint: error checking if dataset exists", err, logData)
 		handleDatasetAPIErr(ctx, err, w, logData)
+		return
+	}
+
+	datasetTitleExist, err := api.dataStore.Backend.CheckDatasetTitleExist(ctx, dataset.Title)
+	if err != nil {
+		log.Error(ctx, "addDatasetNew endpoint: error checking if dataset title exists", err, logData)
+		handleDatasetAPIErr(ctx, err, w, logData)
+		return
+	}
+
+	if datasetTitleExist {
+		log.Error(ctx, "addDatasetNew endpoint: unable to create a dataset with title that already exists", errs.ErrAddDatasetTitleAlreadyExists, logData)
+		handleDatasetAPIErr(ctx, errs.ErrAddDatasetTitleAlreadyExists, w, logData)
 		return
 	}
 

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -16,6 +16,7 @@ func (e ErrInvalidPatch) Error() string {
 // A list of error messages for Dataset API
 var (
 	ErrAddDatasetAlreadyExists           = errors.New("forbidden - dataset already exists")
+	ErrAddDatasetTitleAlreadyExists      = errors.New("forbidden - dataset title already exists")
 	ErrDatasetTypeInvalid                = errors.New("invalid dataset type")
 	ErrTypeMismatch                      = errors.New("type mismatch")
 	ErrAddUpdateDatasetBadRequest        = errors.New("failed to parse json body")

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -122,6 +122,24 @@ func (m *Mongo) GetDataset(ctx context.Context, id string) (*models.DatasetUpdat
 	return &dataset, nil
 }
 
+func (m *Mongo) CheckDatasetTitleExist(ctx context.Context, title string) (bool, error) {
+	titleFilter := bson.M{
+		"$or": bson.A{
+			bson.M{"current.title": title},
+			bson.M{"next.title": title},
+		},
+	}
+	count, err := m.Connection.Collection(m.ActualCollectionName(config.DatasetsCollection)).Count(ctx, titleFilter)
+	if err != nil {
+		return false, err
+	}
+	if count > 0 {
+		return true, nil
+	} else {
+		return false, nil
+	}
+}
+
 // GetEditions retrieves all edition documents for a dataset
 func (m *Mongo) GetEditions(ctx context.Context, id, state string, offset, limit int, authorised bool) ([]*models.EditionUpdate, int, error) {
 	selector := buildEditionsQuery(id, state, authorised)

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -24,6 +24,7 @@ type dataMongoDB interface {
 	AddInstance(ctx context.Context, instance *models.Instance) (*models.Instance, error)
 	AddVersionStatic(ctx context.Context, version *models.Version) (inst *models.Version, err error)
 	CheckDatasetExists(ctx context.Context, ID, state string) error
+	CheckDatasetTitleExist(ctx context.Context, title string) (bool, error)
 	CheckEditionExists(ctx context.Context, ID, editionID, state string) error
 	CheckEditionExistsStatic(ctx context.Context, id, editionID, state string) error
 	GetDataset(ctx context.Context, ID string) (*models.DatasetUpdate, error)

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store"
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"sync"
 )
 
@@ -42,6 +42,9 @@ var _ store.Storer = &StorerMock{}
 //			CheckDatasetExistsFunc: func(ctx context.Context, ID string, state string) error {
 //				panic("mock out the CheckDatasetExists method")
 //			},
+//			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
+//				panic("mock out the CheckDatasetTitleExist method")
+//			},
 //			CheckEditionExistsFunc: func(ctx context.Context, ID string, editionID string, state string) error {
 //				panic("mock out the CheckEditionExists method")
 //			},
@@ -75,7 +78,7 @@ var _ store.Storer = &StorerMock{}
 //			GetDimensionOptionsFromIDsFunc: func(ctx context.Context, version *models.Version, dimension string, ids []string) ([]*models.PublicDimensionOption, int, error) {
 //				panic("mock out the GetDimensionOptionsFromIDs method")
 //			},
-//			GetDimensionsFunc: func(ctx context.Context, versionID string) ([]bson.M, error) {
+//			GetDimensionsFunc: func(ctx context.Context, versionID string) ([]primitive.M, error) {
 //				panic("mock out the GetDimensions method")
 //			},
 //			GetDimensionsFromInstanceFunc: func(ctx context.Context, ID string, offset int, limit int) ([]*models.DimensionOption, int, error) {
@@ -211,6 +214,9 @@ type StorerMock struct {
 	// CheckDatasetExistsFunc mocks the CheckDatasetExists method.
 	CheckDatasetExistsFunc func(ctx context.Context, ID string, state string) error
 
+	// CheckDatasetTitleExistFunc mocks the CheckDatasetTitleExist method.
+	CheckDatasetTitleExistFunc func(ctx context.Context, title string) (bool, error)
+
 	// CheckEditionExistsFunc mocks the CheckEditionExists method.
 	CheckEditionExistsFunc func(ctx context.Context, ID string, editionID string, state string) error
 
@@ -245,7 +251,7 @@ type StorerMock struct {
 	GetDimensionOptionsFromIDsFunc func(ctx context.Context, version *models.Version, dimension string, ids []string) ([]*models.PublicDimensionOption, int, error)
 
 	// GetDimensionsFunc mocks the GetDimensions method.
-	GetDimensionsFunc func(ctx context.Context, versionID string) ([]bson.M, error)
+	GetDimensionsFunc func(ctx context.Context, versionID string) ([]primitive.M, error)
 
 	// GetDimensionsFromInstanceFunc mocks the GetDimensionsFromInstance method.
 	GetDimensionsFromInstanceFunc func(ctx context.Context, ID string, offset int, limit int) ([]*models.DimensionOption, int, error)
@@ -414,6 +420,13 @@ type StorerMock struct {
 			ID string
 			// State is the state argument value.
 			State string
+		}
+		// CheckDatasetTitleExist holds details about calls to the CheckDatasetTitleExist method.
+		CheckDatasetTitleExist []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Title is the title argument value.
+			Title string
 		}
 		// CheckEditionExists holds details about calls to the CheckEditionExists method.
 		CheckEditionExists []struct {
@@ -918,6 +931,7 @@ type StorerMock struct {
 	lockAddVersionDetailsToInstance         sync.RWMutex
 	lockAddVersionStatic                    sync.RWMutex
 	lockCheckDatasetExists                  sync.RWMutex
+	lockCheckDatasetTitleExist              sync.RWMutex
 	lockCheckEditionExists                  sync.RWMutex
 	lockCheckEditionExistsStatic            sync.RWMutex
 	lockDeleteDataset                       sync.RWMutex
@@ -1240,6 +1254,42 @@ func (mock *StorerMock) CheckDatasetExistsCalls() []struct {
 	mock.lockCheckDatasetExists.RLock()
 	calls = mock.calls.CheckDatasetExists
 	mock.lockCheckDatasetExists.RUnlock()
+	return calls
+}
+
+// CheckDatasetTitleExist calls CheckDatasetTitleExistFunc.
+func (mock *StorerMock) CheckDatasetTitleExist(ctx context.Context, title string) (bool, error) {
+	if mock.CheckDatasetTitleExistFunc == nil {
+		panic("StorerMock.CheckDatasetTitleExistFunc: method is nil but Storer.CheckDatasetTitleExist was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Title string
+	}{
+		Ctx:   ctx,
+		Title: title,
+	}
+	mock.lockCheckDatasetTitleExist.Lock()
+	mock.calls.CheckDatasetTitleExist = append(mock.calls.CheckDatasetTitleExist, callInfo)
+	mock.lockCheckDatasetTitleExist.Unlock()
+	return mock.CheckDatasetTitleExistFunc(ctx, title)
+}
+
+// CheckDatasetTitleExistCalls gets all the calls that were made to CheckDatasetTitleExist.
+// Check the length with:
+//
+//	len(mockedStorer.CheckDatasetTitleExistCalls())
+func (mock *StorerMock) CheckDatasetTitleExistCalls() []struct {
+	Ctx   context.Context
+	Title string
+} {
+	var calls []struct {
+		Ctx   context.Context
+		Title string
+	}
+	mock.lockCheckDatasetTitleExist.RLock()
+	calls = mock.calls.CheckDatasetTitleExist
+	mock.lockCheckDatasetTitleExist.RUnlock()
 	return calls
 }
 
@@ -1716,7 +1766,7 @@ func (mock *StorerMock) GetDimensionOptionsFromIDsCalls() []struct {
 }
 
 // GetDimensions calls GetDimensionsFunc.
-func (mock *StorerMock) GetDimensions(ctx context.Context, versionID string) ([]bson.M, error) {
+func (mock *StorerMock) GetDimensions(ctx context.Context, versionID string) ([]primitive.M, error) {
 	if mock.GetDimensionsFunc == nil {
 		panic("StorerMock.GetDimensionsFunc: method is nil but Storer.GetDimensions was just called")
 	}

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"sync"
 )
 
@@ -39,6 +39,9 @@ var _ store.MongoDB = &MongoDBMock{}
 //			},
 //			CheckDatasetExistsFunc: func(ctx context.Context, ID string, state string) error {
 //				panic("mock out the CheckDatasetExists method")
+//			},
+//			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
+//				panic("mock out the CheckDatasetTitleExist method")
 //			},
 //			CheckEditionExistsFunc: func(ctx context.Context, ID string, editionID string, state string) error {
 //				panic("mock out the CheckEditionExists method")
@@ -79,7 +82,7 @@ var _ store.MongoDB = &MongoDBMock{}
 //			GetDimensionOptionsFromIDsFunc: func(ctx context.Context, version *models.Version, dimension string, ids []string) ([]*models.PublicDimensionOption, int, error) {
 //				panic("mock out the GetDimensionOptionsFromIDs method")
 //			},
-//			GetDimensionsFunc: func(ctx context.Context, versionID string) ([]bson.M, error) {
+//			GetDimensionsFunc: func(ctx context.Context, versionID string) ([]primitive.M, error) {
 //				panic("mock out the GetDimensions method")
 //			},
 //			GetDimensionsFromInstanceFunc: func(ctx context.Context, ID string, offset int, limit int) ([]*models.DimensionOption, int, error) {
@@ -209,6 +212,9 @@ type MongoDBMock struct {
 	// CheckDatasetExistsFunc mocks the CheckDatasetExists method.
 	CheckDatasetExistsFunc func(ctx context.Context, ID string, state string) error
 
+	// CheckDatasetTitleExistFunc mocks the CheckDatasetTitleExist method.
+	CheckDatasetTitleExistFunc func(ctx context.Context, title string) (bool, error)
+
 	// CheckEditionExistsFunc mocks the CheckEditionExists method.
 	CheckEditionExistsFunc func(ctx context.Context, ID string, editionID string, state string) error
 
@@ -249,7 +255,7 @@ type MongoDBMock struct {
 	GetDimensionOptionsFromIDsFunc func(ctx context.Context, version *models.Version, dimension string, ids []string) ([]*models.PublicDimensionOption, int, error)
 
 	// GetDimensionsFunc mocks the GetDimensions method.
-	GetDimensionsFunc func(ctx context.Context, versionID string) ([]bson.M, error)
+	GetDimensionsFunc func(ctx context.Context, versionID string) ([]primitive.M, error)
 
 	// GetDimensionsFromInstanceFunc mocks the GetDimensionsFromInstance method.
 	GetDimensionsFromInstanceFunc func(ctx context.Context, ID string, offset int, limit int) ([]*models.DimensionOption, int, error)
@@ -402,6 +408,13 @@ type MongoDBMock struct {
 			ID string
 			// State is the state argument value.
 			State string
+		}
+		// CheckDatasetTitleExist holds details about calls to the CheckDatasetTitleExist method.
+		CheckDatasetTitleExist []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Title is the title argument value.
+			Title string
 		}
 		// CheckEditionExists holds details about calls to the CheckEditionExists method.
 		CheckEditionExists []struct {
@@ -910,6 +923,7 @@ type MongoDBMock struct {
 	lockAddInstance                         sync.RWMutex
 	lockAddVersionStatic                    sync.RWMutex
 	lockCheckDatasetExists                  sync.RWMutex
+	lockCheckDatasetTitleExist              sync.RWMutex
 	lockCheckEditionExists                  sync.RWMutex
 	lockCheckEditionExistsStatic            sync.RWMutex
 	lockChecker                             sync.RWMutex
@@ -1185,6 +1199,42 @@ func (mock *MongoDBMock) CheckDatasetExistsCalls() []struct {
 	mock.lockCheckDatasetExists.RLock()
 	calls = mock.calls.CheckDatasetExists
 	mock.lockCheckDatasetExists.RUnlock()
+	return calls
+}
+
+// CheckDatasetTitleExist calls CheckDatasetTitleExistFunc.
+func (mock *MongoDBMock) CheckDatasetTitleExist(ctx context.Context, title string) (bool, error) {
+	if mock.CheckDatasetTitleExistFunc == nil {
+		panic("MongoDBMock.CheckDatasetTitleExistFunc: method is nil but MongoDB.CheckDatasetTitleExist was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Title string
+	}{
+		Ctx:   ctx,
+		Title: title,
+	}
+	mock.lockCheckDatasetTitleExist.Lock()
+	mock.calls.CheckDatasetTitleExist = append(mock.calls.CheckDatasetTitleExist, callInfo)
+	mock.lockCheckDatasetTitleExist.Unlock()
+	return mock.CheckDatasetTitleExistFunc(ctx, title)
+}
+
+// CheckDatasetTitleExistCalls gets all the calls that were made to CheckDatasetTitleExist.
+// Check the length with:
+//
+//	len(mockedMongoDB.CheckDatasetTitleExistCalls())
+func (mock *MongoDBMock) CheckDatasetTitleExistCalls() []struct {
+	Ctx   context.Context
+	Title string
+} {
+	var calls []struct {
+		Ctx   context.Context
+		Title string
+	}
+	mock.lockCheckDatasetTitleExist.RLock()
+	calls = mock.calls.CheckDatasetTitleExist
+	mock.lockCheckDatasetTitleExist.RUnlock()
 	return calls
 }
 
@@ -1729,7 +1779,7 @@ func (mock *MongoDBMock) GetDimensionOptionsFromIDsCalls() []struct {
 }
 
 // GetDimensions calls GetDimensionsFunc.
-func (mock *MongoDBMock) GetDimensions(ctx context.Context, versionID string) ([]bson.M, error) {
+func (mock *MongoDBMock) GetDimensions(ctx context.Context, versionID string) ([]primitive.M, error) {
 	if mock.GetDimensionsFunc == nil {
 		panic("MongoDBMock.GetDimensionsFunc: method is nil but MongoDB.GetDimensions was just called")
 	}


### PR DESCRIPTION
### What

Prevent duplication of dataset series title

### How to review

Check code looks ok, tests pass.

- Run the dataset-catalogue stack in dp-compose
- Make a POST request to localhost:22000/datasets to create a dataset
- Make a POST request to localhost:22000/datasets to create a second dataset with the same title and different id
- Confirm that dataset series cannot be created if there is a dataset with the same title. Should get back 403 and "forbidden dataset title already exists"

### Who can review

Anyone
