### PR TITLE
removed dimensions Linkobject from static versions

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -1097,10 +1097,6 @@ func (api *DatasetAPI) generateVersionLinks(datasetID, edition string, version i
 			HRef: fmt.Sprintf("%s/datasets/%s", api.host, datasetID),
 			ID:   datasetID,
 		},
-		Dimensions: &models.LinkObject{
-			HRef: fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d/dimensions", api.host, datasetID, edition, version),
-			ID:   datasetID,
-		},
 		Self: &models.LinkObject{
 			HRef: fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d", api.host, datasetID, edition, version),
 		},


### PR DESCRIPTION
### What

Removed the `dimensions` link field as this is not relevant for static datasets

### How to review

Check changes are ok

- Follow steps to publish static dataset: https://confluence.ons.gov.uk/display/DIS/Discoverable+Datasets+-+Basic+API+Calls+-+Publish
- Ensure both `datasets/{id}/editions/{edition}/versions/{version}` and `datasets/{id}/editions/{edition}/versions` do not return the dimensions field for static datasets but do return them for CMD and cantabular

### Who can review

Anyone
