### PR TITLE
Feature/dis 2969 create sdk client

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -1,0 +1,46 @@
+package sdk
+
+import (
+	"context"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/health"
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+)
+
+const (
+	service = "dp-dataset-api"
+)
+
+type Client struct {
+	hcCli *health.Client
+}
+
+// New creates a new instance of Client for the service
+func New(datasetAPIUrl string) *Client {
+	return &Client{
+		hcCli: health.NewClient(service, datasetAPIUrl),
+	}
+}
+
+// NewWithHealthClient creates a new instance of service API Client, reusing the URL and Clienter
+// from the provided healthcheck client
+func NewWithHealthClient(hcCli *health.Client) *Client {
+	return &Client{
+		hcCli: health.NewClientWithClienter(service, hcCli.URL, hcCli.Client),
+	}
+}
+
+// URL returns the URL used by this client
+func (cli *Client) URL() string {
+	return cli.hcCli.URL
+}
+
+// Health returns the underlying Healthcheck Client for this API client
+func (cli *Client) Health() *health.Client {
+	return cli.hcCli
+}
+
+// Checker calls topic api health endpoint and returns a check object to the caller
+func (cli *Client) Checker(ctx context.Context, check *healthcheck.CheckState) error {
+	return cli.hcCli.Checker(ctx, check)
+}

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -1,24 +1,62 @@
 package sdk
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
 	"testing"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/health"
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+	dphttp "github.com/ONSdigital/dp-net/v2/http"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 const (
-	datasetAPIURL = "http://wwww.test.com"
+	datasetAPIURL = "http://localhost:25700"
 )
+
+type MockedHTTPResponse struct {
+	StatusCode int
+	Body       interface{}
+	Headers    map[string]string
+}
 
 func newDatasetAPIClient(_ *testing.T) *Client {
 	return New(datasetAPIURL)
 }
 
-// func newDatasetAPIHealthcheckClient(_ *testing.T, httpClient *dphttp.ClienterMock) *Client {
-// 	healthClient := health.NewClientWithClienter(service, testHost, httpClient)
-// 	return NewWithHealthClient(healthClient)
-// }
+func createHTTPClientMock(mockedHTTPResponse ...MockedHTTPResponse) *dphttp.ClienterMock {
+	numCall := 0
+	return &dphttp.ClienterMock{
+		DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+			body, _ := json.Marshal(mockedHTTPResponse[numCall].Body)
+			resp := &http.Response{
+				StatusCode: mockedHTTPResponse[numCall].StatusCode,
+				Body:       io.NopCloser(bytes.NewReader(body)),
+				Header:     http.Header{},
+			}
+			for hKey, hVal := range mockedHTTPResponse[numCall].Headers {
+				resp.Header.Set(hKey, hVal)
+			}
+			numCall++
+			return resp, nil
+		},
+		SetPathsWithNoRetriesFunc: func(paths []string) {},
+		GetPathsWithNoRetriesFunc: func() []string {
+			return []string{"/healthcheck"}
+		},
+	}
+}
 
+func newDatasetAPIHealthcheckClient(_ *testing.T, httpClient *dphttp.ClienterMock) *Client {
+	healthClient := health.NewClientWithClienter(service, datasetAPIURL, httpClient)
+	return NewWithHealthClient(healthClient)
+}
+
+// Tests for the `New()` sdk client method
 func TestClient(t *testing.T) {
 	client := newDatasetAPIClient(t)
 
@@ -33,6 +71,30 @@ func TestClient(t *testing.T) {
 	})
 }
 
-// func TestHealthCheckerClient(t *testing.T) {
+// Tests for the `NewWithHealthClient()` sdk client method
+func TestHealthCheckerClient(t *testing.T) {
+	ctx := context.Background()
+	initialStateCheck := health.CreateCheckState(service)
 
-// }
+	Convey("If http client returns 200 OK response", t, func() {
+		mockHTTPClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, "", nil})
+		client := newDatasetAPIHealthcheckClient(t, mockHTTPClient)
+
+		Convey("Test client URL() method returns correct url", func() {
+			So(client.URL(), ShouldEqual, datasetAPIURL)
+		})
+
+		Convey("Test client Health() method returns correct health client", func() {
+			So(client.Health(), ShouldNotBeNil)
+			So(client.hcCli.Name, ShouldEqual, service)
+			So(client.hcCli.URL, ShouldEqual, datasetAPIURL)
+		})
+
+		Convey("Test client Checker() method returns expected check", func() {
+			err := client.Checker(ctx, &initialStateCheck)
+			So(err, ShouldBeNil)
+			So(initialStateCheck.Name(), ShouldEqual, service)
+			So(initialStateCheck.Status(), ShouldEqual, healthcheck.StatusOK)
+		})
+	})
+}

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -1,0 +1,38 @@
+package sdk
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	datasetAPIURL = "http://wwww.test.com"
+)
+
+func newDatasetAPIClient(_ *testing.T) *Client {
+	return New(datasetAPIURL)
+}
+
+// func newDatasetAPIHealthcheckClient(_ *testing.T, httpClient *dphttp.ClienterMock) *Client {
+// 	healthClient := health.NewClientWithClienter(service, testHost, httpClient)
+// 	return NewWithHealthClient(healthClient)
+// }
+
+func TestClient(t *testing.T) {
+	client := newDatasetAPIClient(t)
+
+	Convey("Test client URL() method returns correct url", t, func() {
+		So(client.URL(), ShouldEqual, datasetAPIURL)
+	})
+
+	Convey("Test client Health() method returns correct health client", t, func() {
+		So(client.Health(), ShouldNotBeNil)
+		So(client.hcCli.Name, ShouldEqual, service)
+		So(client.hcCli.URL, ShouldEqual, datasetAPIURL)
+	})
+}
+
+// func TestHealthCheckerClient(t *testing.T) {
+
+// }


### PR DESCRIPTION
### What

[DIS-2968](https://jira.ons.gov.uk/browse/DIS-2968) Create dp-dataset-api sdk

Creating a new sdk so that we can provide a dataset client for other apps within `dp-dataset-api`. This will eventually replace the existing client within `dp-api-clients-go`.

- Added new `sdk/client.go` which contains the implementation of the new client. This is mostly a copy of the existing client implementation in https://github.com/ONSdigital/dp-topic-api/blob/develop/sdk/client.go. The client methods we need will be added to this file as we migrate them from `dp-api-clients-go`.
- Added new `sdk/client_test.go` to add some basic tests just to confirm that we are configuring the clients correctly 

### How to review

Checkout and run the tests contained within `sdk/client_test.go` locally
