### PR TITLE
Feature/dis 2970 create client get version method

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -2,12 +2,12 @@ package sdk
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/health"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dpNetRequest "github.com/ONSdigital/dp-net/v2/request"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 const (
@@ -58,14 +58,10 @@ func addCollectionIDHeader(r *http.Request, collectionID string) {
 
 // closeResponseBody closes the response body and logs an error if unsuccessful
 // TODO: Add to dp-net?
-func closeResponseBody(resp *http.Response) (statusError *StatusError) {
-	statusError = &StatusError{}
-
+func closeResponseBody(ctx context.Context, resp *http.Response) (err error) {
 	if resp.Body != nil {
 		if err := resp.Body.Close(); err != nil {
-			statusError.Err = fmt.Errorf("error closing http response body from call to %s, error is: %v", service, err)
-			statusError.Code = http.StatusInternalServerError
-			return
+			log.Error(ctx, "error closing http response body", err)
 		}
 	}
 

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -1,0 +1,47 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ONSdigital/dp-dataset-api/models"
+	dpNetRequest "github.com/ONSdigital/dp-net/v2/request"
+)
+
+// GetVersion gets a specific version for an edition from the dataset api
+func (c *Client) GetVersion(ctx context.Context, userAccessToken, serviceToken,
+	downloadServiceToken, collectionID, datasetID, editionID, versionID string) (v models.Version, err error) {
+	v = models.Version{}
+
+	uri := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s", c.hcCli.URL, datasetID, editionID, versionID)
+
+	req, err := http.NewRequest(http.MethodGet, uri, http.NoBody)
+	if err != nil {
+		return
+	}
+
+	// Add auth headers
+	addCollectionIDHeader(req, collectionID)
+	dpNetRequest.AddFlorenceHeader(req, userAccessToken)
+	dpNetRequest.AddServiceTokenHeader(req, serviceToken)
+	dpNetRequest.AddDownloadServiceTokenHeader(req, downloadServiceToken)
+
+	resp, err := c.hcCli.Client.Do(ctx, req)
+	if err != nil {
+		return
+	}
+
+	defer closeResponseBody(ctx, resp)
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(b, &v)
+
+	return
+}

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -35,6 +36,16 @@ func (c *Client) GetVersion(ctx context.Context, userAccessToken, serviceToken,
 	}
 
 	defer closeResponseBody(ctx, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		var errString string
+		errResponseReadErr := json.NewDecoder(resp.Body).Decode(&errString)
+		if errResponseReadErr != nil {
+			errString = "Client failed to read DatasetAPI body"
+		}
+		err = errors.New(errString)
+		return
+	}
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -1,0 +1,55 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/ONSdigital/dp-dataset-api/models"
+	dpNetRequest "github.com/ONSdigital/dp-net/v2/request"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+// Tests for the `GetVersion` client method
+func TestGetVersion(t *testing.T) {
+	datasetID := "1234"
+	downloadServiceToken := "mydownloadservicetoken"
+	collectionID := "collection"
+	ctx := context.Background()
+	editionID := "my-edition"
+	serviceToken := "myservicetoken"
+	userAccessToken := "myuseraccesstoken"
+
+	versionID := 1
+
+	requestedVersion := models.Version{
+		CollectionID: collectionID,
+		DatasetID:    datasetID,
+		Edition:      editionID,
+		Version:      versionID,
+	}
+
+	Convey("If requested version is valid", t, func() {
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, requestedVersion, map[string]string{}})
+		datasetApiClient := newDatasetAPIHealthcheckClient(t, httpClient)
+		returnedVersion, err := datasetApiClient.GetVersion(ctx, userAccessToken, serviceToken,
+			downloadServiceToken, collectionID, datasetID, editionID, strconv.Itoa(versionID))
+		Convey("Test that the request URI is constructed correctly and the correct method is used", func() {
+			expectedURI := fmt.Sprintf("/datasets/%s/editions/%s/versions/%s", datasetID, editionID, strconv.Itoa(versionID))
+			So(httpClient.DoCalls()[0].Req.Method, ShouldEqual, http.MethodGet)
+			So(httpClient.DoCalls()[0].Req.URL.RequestURI(), ShouldResemble, expectedURI)
+		})
+		Convey("Test that the correct auth headers are added to the request", func() {
+			So(httpClient.DoCalls()[0].Req.Header.Get(dpNetRequest.CollectionIDHeaderKey), ShouldEqual, collectionID)
+			So(httpClient.DoCalls()[0].Req.Header.Get(dpNetRequest.FlorenceHeaderKey), ShouldEqual, userAccessToken)
+			So(httpClient.DoCalls()[0].Req.Header.Get(dpNetRequest.AuthHeaderKey), ShouldContainSubstring, serviceToken)
+			So(httpClient.DoCalls()[0].Req.Header.Get(dpNetRequest.DownloadServiceHeaderKey), ShouldEqual, downloadServiceToken)
+		})
+		Convey("Test that the requested version is returned without error", func() {
+			So(err, ShouldBeNil)
+			So(returnedVersion, ShouldResemble, requestedVersion)
+		})
+	})
+}


### PR DESCRIPTION
### What

[DIS-2970](https://jira.ons.gov.uk/browse/DIS-2970) Create client GetVersion method
Created new dataset client `GetVersion`. Mostly copied from code in `dp-api-clients-go` see https://github.com/ONSdigital/dp-api-clients-go/blob/main/dataset/dataset.go#L590.

- Updated `sdk/client.go` to add some functions that will be used across client methods
- Updated `sdk/client_test.go` to include tests for new functions
- Added `sdk/version.go` and `sdk/version_test.go` to include new `GetVersion` dataset client method and associated tests

### How to review

Check out locally and run the unit tests.
