### PR TITLE
Feature/dis 2985 create client get version metadata method

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -78,7 +78,7 @@ func closeResponseBody(ctx context.Context, resp *http.Response) {
 	}
 }
 
-// Takes the input http response and unmarshalls the body to the input target
+// Takes the input http response and unmarshals the body to the input target
 func unmarshalResponseBody(response *http.Response, target interface{}) (err error) {
 	if response.StatusCode != http.StatusOK {
 		var errString string

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -251,7 +251,7 @@ func TestUnmarshalResponseBody(t *testing.T) {
 			Body:       io.NopCloser(bytes.NewBuffer(responseJSON)),
 		}
 		target := mockTarget{}
-		Convey("Test response body is unmarshalled to target", func() {
+		Convey("Test response body is unmarshaled to target", func() {
 			err := unmarshalResponseBody(mockResponse, &target)
 			So(err, ShouldBeNil)
 			So(target, ShouldResemble, requestedData)

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -2,10 +2,8 @@ package sdk
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -60,22 +58,8 @@ func (c *Client) GetVersion(ctx context.Context, headers Headers, datasetID, edi
 
 	defer closeResponseBody(ctx, resp)
 
-	if resp.StatusCode != http.StatusOK {
-		var errString string
-		errResponseReadErr := json.NewDecoder(resp.Body).Decode(&errString)
-		if errResponseReadErr != nil {
-			errString = "Client failed to read DatasetAPI body"
-		}
-		err = errors.New(errString)
-		return version, err
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return version, err
-	}
-
-	err = json.Unmarshal(b, &version)
+	// Unmarshall the response body to target
+	err = unmarshalResponseBody(resp, &version)
 
 	return version, err
 }
@@ -110,22 +94,8 @@ func (c *Client) GetVersionDimensions(ctx context.Context, headers Headers, data
 
 	defer closeResponseBody(ctx, resp)
 
-	if resp.StatusCode != http.StatusOK {
-		var errString string
-		errResponseReadErr := json.NewDecoder(resp.Body).Decode(&errString)
-		if errResponseReadErr != nil {
-			errString = "Client failed to read DatasetAPI body"
-		}
-		err = errors.New(errString)
-		return versionDimensionsList, err
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return versionDimensionsList, err
-	}
-
-	err = json.Unmarshal(b, &versionDimensionsList)
+	// Unmarshall the response body to target
+	err = unmarshalResponseBody(resp, &versionDimensionsList)
 
 	return versionDimensionsList, err
 }
@@ -153,22 +123,8 @@ func (c *Client) GetVersionMetadata(ctx context.Context, headers Headers, datase
 
 	defer closeResponseBody(ctx, resp)
 
-	if resp.StatusCode != http.StatusOK {
-		var errString string
-		errResponseReadErr := json.NewDecoder(resp.Body).Decode(&errString)
-		if errResponseReadErr != nil {
-			errString = "Client failed to read DatasetAPI body"
-		}
-		err = errors.New(errString)
-		return metadata, err
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return metadata, err
-	}
-
-	err = json.Unmarshal(b, &metadata)
+	// Unmarshall the response body to target
+	err = unmarshalResponseBody(resp, &metadata)
 
 	return metadata, err
 }
@@ -217,22 +173,8 @@ func (c *Client) GetVersions(ctx context.Context, headers Headers, datasetID, ed
 
 	defer closeResponseBody(ctx, resp)
 
-	if resp.StatusCode != http.StatusOK {
-		var errString string
-		errResponseReadErr := json.NewDecoder(resp.Body).Decode(&errString)
-		if errResponseReadErr != nil {
-			errString = "Client failed to read DatasetAPI body"
-		}
-		err = errors.New(errString)
-		return versionsList, err
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return versionsList, err
-	}
-
-	err = json.Unmarshal(b, &versionsList)
+	// Unmarshall the response body to target
+	err = unmarshalResponseBody(resp, &versionsList)
 
 	return versionsList, err
 }

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -58,7 +58,7 @@ func (c *Client) GetVersion(ctx context.Context, headers Headers, datasetID, edi
 
 	defer closeResponseBody(ctx, resp)
 
-	// Unmarshall the response body to target
+	// Unmarshal the response body to target
 	err = unmarshalResponseBody(resp, &version)
 
 	return version, err
@@ -94,7 +94,7 @@ func (c *Client) GetVersionDimensions(ctx context.Context, headers Headers, data
 
 	defer closeResponseBody(ctx, resp)
 
-	// Unmarshall the response body to target
+	// Unmarshal the response body to target
 	err = unmarshalResponseBody(resp, &versionDimensionsList)
 
 	return versionDimensionsList, err
@@ -123,7 +123,7 @@ func (c *Client) GetVersionMetadata(ctx context.Context, headers Headers, datase
 
 	defer closeResponseBody(ctx, resp)
 
-	// Unmarshall the response body to target
+	// Unmarshal the response body to target
 	err = unmarshalResponseBody(resp, &metadata)
 
 	return metadata, err
@@ -173,7 +173,7 @@ func (c *Client) GetVersions(ctx context.Context, headers Headers, datasetID, ed
 
 	defer closeResponseBody(ctx, resp)
 
-	// Unmarshall the response body to target
+	// Unmarshal the response body to target
 	err = unmarshalResponseBody(resp, &versionsList)
 
 	return versionsList, err

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -163,6 +163,49 @@ func TestGetVersionDimensions(t *testing.T) {
 			So(returnedVersionDimensions, ShouldResemble, expectedVersionDimensionsList)
 		})
 	})
+	Convey("If requested version is not valid and get request returns 404", t, func() {
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusNotFound, apierrors.ErrVersionNotFound.Error(), map[string]string{}})
+		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+		_, err := datasetAPIClient.GetVersionDimensions(ctx, headers, datasetID, editionID, strconv.Itoa(versionID))
+		Convey("Test that an error is raised and should contain status code", func() {
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, apierrors.ErrVersionNotFound.Error())
+		})
+	})
+}
+
+// Tests for the `GetVersionMetadata` client method
+func TestGetVersionMetadata(t *testing.T) {
+	versionID := 1
+	versionMetadata := models.Metadata{
+		Edition: editionID,
+		Version: versionID,
+	}
+	mockGetResponse := versionMetadata
+
+	Convey("If requested version is valid and get request returns 200", t, func() {
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, mockGetResponse, map[string]string{}})
+		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+		returnedVersionDimensions, err := datasetAPIClient.GetVersionMetadata(ctx, headers, datasetID, editionID, strconv.Itoa(versionID))
+		Convey("Test that the request URI is constructed correctly and the correct method is used", func() {
+			expectedURI := fmt.Sprintf("/datasets/%s/editions/%s/versions/%d/metadata", datasetID, editionID, versionID)
+			So(httpClient.DoCalls()[0].Req.Method, ShouldEqual, http.MethodGet)
+			So(httpClient.DoCalls()[0].Req.URL.RequestURI(), ShouldResemble, expectedURI)
+		})
+		Convey("Test that the requested version is returned without error", func() {
+			So(err, ShouldBeNil)
+			So(returnedVersionDimensions, ShouldResemble, versionMetadata)
+		})
+	})
+	Convey("If requested version is not valid and get request returns 404", t, func() {
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusNotFound, apierrors.ErrVersionNotFound.Error(), map[string]string{}})
+		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+		_, err := datasetAPIClient.GetVersionMetadata(ctx, headers, datasetID, editionID, strconv.Itoa(versionID))
+		Convey("Test that an error is raised and should contain status code", func() {
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, apierrors.ErrVersionNotFound.Error())
+		})
+	})
 }
 
 // Tests for the `GetVersions` client method


### PR DESCRIPTION
### What

[DIS-2985](https://jira.ons.gov.uk/browse/DIS-2985) Create client GetVersionMetadata method

- Updated `sdk/client.go` to create new `unmarshalResponseBody` function to cut down duplicate code across the client methods
- Updated `sdk/client_test.go` to add tests for new `unmarshalResponseBody` function
- Updated `sdk/version.go` to add new `GetVersionMetadata` client method and use new `unmarshalResponseBody` function to cut down duplicate code across the client methods

### How to review

Check out locally and ensure unit tests pass
