### PR TITLE
Feature/dis 3005 create client get edition method

### DIFF
--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -17,9 +17,25 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+// Used throughout the sdk tests
 const (
-	datasetAPIURL = "http://localhost:25700"
+	datasetAPIURL        = "http://localhost:25700"
+	datasetID            = "1234"
+	downloadServiceToken = "mydownloadservicetoken"
+	collectionID         = "collection"
+	editionID            = "my-edition"
+	serviceToken         = "myservicetoken"
+	userAccessToken      = "myuseraccesstoken"
 )
+
+var ctx = context.Background()
+
+var headers = Headers{
+	CollectionID:         collectionID,
+	DownloadServiceToken: downloadServiceToken,
+	ServiceToken:         serviceToken,
+	UserAccessToken:      userAccessToken,
+}
 
 type MockedHTTPResponse struct {
 	StatusCode int
@@ -76,7 +92,6 @@ func TestClient(t *testing.T) {
 
 // Tests for the `NewWithHealthClient()` sdk client method
 func TestHealthCheckerClient(t *testing.T) {
-	ctx := context.Background()
 	initialStateCheck := health.CreateCheckState(service)
 
 	Convey("If http client returns 200 OK response", t, func() {
@@ -213,7 +228,6 @@ func (m *mockReadCloser) Close() error {
 
 // Tests for `closeResponseBody` function
 func TestCloseResponseBody(t *testing.T) {
-	ctx := context.Background()
 	// Create a buffer to capture log output for tests
 	var buf bytes.Buffer
 	var fbBuf bytes.Buffer

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -19,7 +19,7 @@ import (
 
 // Used throughout the sdk tests
 const (
-	datasetAPIURL        = "http://localhost:25700"
+	datasetAPIURL        = "http://localhost:22000"
 	datasetID            = "1234"
 	downloadServiceToken = "mydownloadservicetoken"
 	collectionID         = "collection"

--- a/sdk/edition.go
+++ b/sdk/edition.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"net/url"
+	"strconv"
 
 	"github.com/ONSdigital/dp-dataset-api/models"
 )
@@ -29,4 +30,50 @@ func (c *Client) GetEdition(ctx context.Context, headers Headers, datasetID, edi
 	err = unmarshalResponseBody(resp, &edition)
 
 	return edition, err
+}
+
+// EditionList represents an object containing a list of paginated versions. This struct is based
+// on the `pagination.page` struct which is returned when we call the `api.getEditions` endpoint
+type EditionList struct {
+	Items      []models.Edition `json:"items"`
+	Count      int              `json:"count"`
+	Offset     int              `json:"offset"`
+	Limit      int              `json:"limit"`
+	TotalCount int              `json:"total_count"`
+}
+
+// GetEditions returns all editions for a dataset
+func (c *Client) GetEditions(ctx context.Context, headers Headers, datasetID string, queryParams *QueryParams) (editionList EditionList, err error) {
+	editionList = EditionList{}
+	// Build uri
+	uri := &url.URL{}
+	uri.Path, err = url.JoinPath(c.hcCli.URL, "datasets", datasetID, "editions")
+	if err != nil {
+		return editionList, err
+	}
+
+	// Add query params to request if valid
+	if queryParams != nil {
+		if err := queryParams.Validate(); err != nil {
+			return editionList, err
+		}
+		// Add query parameters
+		query := uri.Query()
+		query.Set("limit", strconv.Itoa(queryParams.Limit))
+		query.Set("offset", strconv.Itoa(queryParams.Offset))
+		uri.RawQuery = query.Encode()
+	}
+
+	// Make request
+	resp, err := c.DoAuthenticatedGetRequest(ctx, headers, uri)
+	if err != nil {
+		return editionList, err
+	}
+
+	defer closeResponseBody(ctx, resp)
+
+	// Unmarshal the response body to target
+	err = unmarshalResponseBody(resp, &editionList)
+
+	return editionList, err
 }

--- a/sdk/edition.go
+++ b/sdk/edition.go
@@ -34,7 +34,7 @@ func (c *Client) GetEdition(ctx context.Context, headers Headers, datasetID, edi
 
 // EditionList represents an object containing a list of paginated versions. This struct is based
 // on the `pagination.page` struct which is returned when we call the `api.getEditions` endpoint
-type EditionList struct {
+type EditionsList struct {
 	Items      []models.Edition `json:"items"`
 	Count      int              `json:"count"`
 	Offset     int              `json:"offset"`
@@ -43,8 +43,8 @@ type EditionList struct {
 }
 
 // GetEditions returns all editions for a dataset
-func (c *Client) GetEditions(ctx context.Context, headers Headers, datasetID string, queryParams *QueryParams) (editionList EditionList, err error) {
-	editionList = EditionList{}
+func (c *Client) GetEditions(ctx context.Context, headers Headers, datasetID string, queryParams *QueryParams) (editionList EditionsList, err error) {
+	editionList = EditionsList{}
 	// Build uri
 	uri := &url.URL{}
 	uri.Path, err = url.JoinPath(c.hcCli.URL, "datasets", datasetID, "editions")

--- a/sdk/edition.go
+++ b/sdk/edition.go
@@ -1,0 +1,32 @@
+package sdk
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/ONSdigital/dp-dataset-api/models"
+)
+
+// GetEdition retrieves a single edition document from a given datasetID and edition label
+func (c *Client) GetEdition(ctx context.Context, headers Headers, datasetID, editionID string) (edition models.Edition, err error) {
+	edition = models.Edition{}
+	// Build uri
+	uri := &url.URL{}
+	uri.Path, err = url.JoinPath(c.hcCli.URL, "datasets", datasetID, "editions", editionID)
+	if err != nil {
+		return edition, err
+	}
+
+	// Make request
+	resp, err := c.DoAuthenticatedGetRequest(ctx, headers, uri)
+	if err != nil {
+		return edition, err
+	}
+
+	defer closeResponseBody(ctx, resp)
+
+	// Unmarshal the response body to target
+	err = unmarshalResponseBody(resp, &edition)
+
+	return edition, err
+}

--- a/sdk/edition_test.go
+++ b/sdk/edition_test.go
@@ -1,0 +1,44 @@
+package sdk
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/ONSdigital/dp-dataset-api/apierrors"
+	"github.com/ONSdigital/dp-dataset-api/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+// Tests for the `GetEdition` client method
+func TestGetEdition(t *testing.T) {
+	mockGetResponse := models.Edition{
+		DatasetID: datasetID,
+		Edition:   editionID,
+	}
+
+	Convey("If requested version is valid and get request returns 200", t, func() {
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, mockGetResponse, map[string]string{}})
+		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+		returnedVersion, err := datasetAPIClient.GetEdition(ctx, headers, datasetID, editionID)
+		Convey("Test that the request URI is constructed correctly and the correct method is used", func() {
+			expectedURI := fmt.Sprintf("/datasets/%s/editions/%s", datasetID, editionID)
+			So(httpClient.DoCalls()[0].Req.Method, ShouldEqual, http.MethodGet)
+			So(httpClient.DoCalls()[0].Req.URL.RequestURI(), ShouldResemble, expectedURI)
+		})
+		Convey("Test that the requested version is returned without error", func() {
+			So(err, ShouldBeNil)
+			So(returnedVersion, ShouldResemble, mockGetResponse)
+		})
+	})
+
+	Convey("If requested version is not valid and get request returns 404", t, func() {
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusNotFound, apierrors.ErrVersionNotFound.Error(), map[string]string{}})
+		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+		_, err := datasetAPIClient.GetEdition(ctx, headers, datasetID, editionID)
+		Convey("Test that an error is raised and should contain status code", func() {
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, apierrors.ErrVersionNotFound.Error())
+		})
+	})
+}

--- a/sdk/edition_test.go
+++ b/sdk/edition_test.go
@@ -17,28 +17,126 @@ func TestGetEdition(t *testing.T) {
 		Edition:   editionID,
 	}
 
-	Convey("If requested version is valid and get request returns 200", t, func() {
+	Convey("If requested edition is valid and get request returns 200", t, func() {
 		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, mockGetResponse, map[string]string{}})
 		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
-		returnedVersion, err := datasetAPIClient.GetEdition(ctx, headers, datasetID, editionID)
+		returnedEdition, err := datasetAPIClient.GetEdition(ctx, headers, datasetID, editionID)
 		Convey("Test that the request URI is constructed correctly and the correct method is used", func() {
 			expectedURI := fmt.Sprintf("/datasets/%s/editions/%s", datasetID, editionID)
 			So(httpClient.DoCalls()[0].Req.Method, ShouldEqual, http.MethodGet)
 			So(httpClient.DoCalls()[0].Req.URL.RequestURI(), ShouldResemble, expectedURI)
 		})
-		Convey("Test that the requested version is returned without error", func() {
+		Convey("Test that the requested edition is returned without error", func() {
 			So(err, ShouldBeNil)
-			So(returnedVersion, ShouldResemble, mockGetResponse)
+			So(returnedEdition, ShouldResemble, mockGetResponse)
 		})
 	})
 
-	Convey("If requested version is not valid and get request returns 404", t, func() {
-		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusNotFound, apierrors.ErrVersionNotFound.Error(), map[string]string{}})
+	Convey("If requested edition is not valid and get request returns 404", t, func() {
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusNotFound, apierrors.ErrEditionNotFound.Error(), map[string]string{}})
 		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
 		_, err := datasetAPIClient.GetEdition(ctx, headers, datasetID, editionID)
 		Convey("Test that an error is raised and should contain status code", func() {
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, apierrors.ErrVersionNotFound.Error())
+			So(err.Error(), ShouldEqual, apierrors.ErrEditionNotFound.Error())
+		})
+	})
+}
+
+// Tests for the `GetEditions` client method
+func TestGetEditions(t *testing.T) {
+	editions := []models.Edition{
+		{
+			DatasetID: datasetID,
+			Edition:   editionID,
+		},
+		{
+			DatasetID: datasetID,
+			Edition:   editionID,
+		},
+	}
+	mockGetResponse := MockGetListRequestResponse{
+		Items: editions,
+	}
+
+	Convey("If input query params are nil", t, func() {
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, nil, map[string]string{}})
+		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+		datasetAPIClient.GetEditions(ctx, headers, datasetID, nil)
+		Convey("Test that the request URI is constructed correctly and the correct method is used", func() {
+			expectedURI := fmt.Sprintf("/datasets/%s/editions", datasetID)
+			So(httpClient.DoCalls()[0].Req.Method, ShouldEqual, http.MethodGet)
+			So(httpClient.DoCalls()[0].Req.URL.RequestURI(), ShouldResemble, expectedURI)
+		})
+	})
+	Convey("If input query params are empty", t, func() {
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, nil, map[string]string{}})
+		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+		queryParams := QueryParams{}
+		datasetAPIClient.GetEditions(ctx, headers, datasetID, &queryParams)
+		Convey("Test that the request URI is constructed correctly and the correct method is used", func() {
+			// URI should be built with default values
+			expectedURI := fmt.Sprintf("/datasets/%s/editions?limit=0&offset=0", datasetID)
+			So(httpClient.DoCalls()[0].Req.Method, ShouldEqual, http.MethodGet)
+			So(httpClient.DoCalls()[0].Req.URL.RequestURI(), ShouldResemble, expectedURI)
+		})
+	})
+	Convey("If input query params are not empty but invalid", t, func() {
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, nil, map[string]string{}})
+		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+		// Create some invalid query params
+		queryParams := QueryParams{
+			IDs:       []string{"1", "2", "3"},
+			IsBasedOn: "mytestdataset",
+			Limit:     -1,
+			Offset:    2,
+		}
+		_, err := datasetAPIClient.GetEditions(ctx, headers, datasetID, &queryParams)
+		Convey("Test that the client method raises an error", func() {
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "negative offsets or limits are not allowed")
+		})
+	})
+	Convey("If input query params are not empty and valid", t, func() {
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, nil, map[string]string{}})
+		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+		// Create some valid query params
+		limit := 1
+		offset := 2
+		queryParams := QueryParams{
+			IDs:       []string{"1", "2", "3"},
+			IsBasedOn: "mytestdataset",
+			Limit:     limit,
+			Offset:    offset,
+		}
+		datasetAPIClient.GetEditions(ctx, headers, datasetID, &queryParams)
+		Convey("Test that the request URI is constructed correctly and the correct method is used", func() {
+			expectedURI := fmt.Sprintf("/datasets/%s/editions?limit=%d&offset=%d", datasetID, limit, offset)
+			So(httpClient.DoCalls()[0].Req.Method, ShouldEqual, http.MethodGet)
+			So(httpClient.DoCalls()[0].Req.URL.RequestURI(), ShouldResemble, expectedURI)
+		})
+	})
+	Convey("If requested dataset and edition is valid", t, func() {
+		requestedEditionList := EditionsList{
+			Items: editions,
+		}
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, mockGetResponse, map[string]string{}})
+		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+		queryParams := QueryParams{}
+		returnedEditionsList, err := datasetAPIClient.GetEditions(ctx, headers, datasetID, &queryParams)
+		Convey("Test that the requested edition is returned without error", func() {
+			So(err, ShouldBeNil)
+			So(returnedEditionsList, ShouldResemble, requestedEditionList)
+		})
+	})
+	Convey("If requested dataset and edition is not valid and get request returns 404", t, func() {
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusNotFound, apierrors.ErrEditionNotFound.Error(), map[string]string{}})
+		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+		queryParams := QueryParams{}
+		_, err := datasetAPIClient.GetEditions(ctx, headers, datasetID, &queryParams)
+		Convey("Test that an error is raised and should contain status code", func() {
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, apierrors.ErrEditionNotFound.Error())
 		})
 	})
 }

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -1,7 +1,6 @@
 package sdk
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -11,24 +10,6 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/models"
 	. "github.com/smartystreets/goconvey/convey"
 )
-
-const (
-	datasetID            = "1234"
-	downloadServiceToken = "mydownloadservicetoken"
-	collectionID         = "collection"
-	editionID            = "my-edition"
-	serviceToken         = "myservicetoken"
-	userAccessToken      = "myuseraccesstoken"
-)
-
-var ctx = context.Background()
-
-var headers = Headers{
-	CollectionID:         collectionID,
-	DownloadServiceToken: downloadServiceToken,
-	ServiceToken:         serviceToken,
-	UserAccessToken:      userAccessToken,
-}
 
 // This is the shape of a paginated list get request response
 type MockGetListRequestResponse struct {


### PR DESCRIPTION
### What

[DIS-3005](https://jira.ons.gov.uk/browse/DIS-3005) Create client GetEdition method and [DIS-3006](https://jira.ons.gov.uk/browse/DIS-3006) Create client GetEditions method 

- Updated `sdk/client_test.go` and `sdk/version_test.go` to share constants and common code across all tests in the sdk package from a logical central place
- Added `sdk/edition.go` to include new `GetEdition` and `GetEditions` client methods
- Added `sdk/edition_test.go` to include tests for new `GetEdition` and `GetEditions` client methods

### How to review

Checkout locally and confirm unit tests pass.
