### PR TITLE
Feature/dis 3157 add metadata tostring method to sdk

### DIFF
--- a/models/metadata.go
+++ b/models/metadata.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"bytes"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -332,4 +334,33 @@ func (v *Version) UpdateMetadata(metadata EditableMetadata) {
 	v.Dimensions = metadata.Dimensions
 	v.UsageNotes = metadata.UsageNotes
 	v.LatestChanges = metadata.LatestChanges
+}
+
+// ToString builds a string of metadata information
+func (m Metadata) ToString() string {
+	var b bytes.Buffer
+
+	// Default values
+	nationalStatistic := false
+
+	b.WriteString(fmt.Sprintf("Title: %s\n", m.Title))
+	b.WriteString(fmt.Sprintf("Description: %s\n", m.Description))
+	b.WriteString(fmt.Sprintf("Issued: %s\n", m.ReleaseDate))
+	b.WriteString(fmt.Sprintf("Next Release: %s\n", m.NextRelease))
+	b.WriteString(fmt.Sprintf("Identifier: %s\n", m.Title))
+	b.WriteString(fmt.Sprintf("Language: %s\n", "English"))
+	b.WriteString(fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency))
+	b.WriteString(fmt.Sprintf("Distribution:\n"))
+	b.WriteString(fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure))
+	b.WriteString(fmt.Sprintf("License: %s\n", m.License))
+
+	if m.NationalStatistic != nil {
+		nationalStatistic = *m.NationalStatistic
+	}
+	b.WriteString(fmt.Sprintf("National Statistic: %t\n", nationalStatistic))
+	b.WriteString(fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic))
+	b.WriteString(fmt.Sprintf("Survey: %s\n", m.Survey))
+	b.WriteString(fmt.Sprintf("Lowest Geography: \n"))
+
+	return b.String()
 }

--- a/models/metadata.go
+++ b/models/metadata.go
@@ -356,19 +356,42 @@ func (m Metadata) ToString() string {
 		b.WriteString(fmt.Sprintf("Contact: %s, %s, %s\n", contact.Name, contact.Email, contact.Telephone))
 	}
 
+	if m.Temporal != nil {
+		// Write first temporal irrespective of number in list
+		temporalList := *m.Temporal
+		b.WriteString(fmt.Sprintf("Temporal: %s\n", temporalList[0].Frequency))
+	}
+
 	b.WriteString(fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency))
 
 	b.WriteString(fmt.Sprintf("Distribution:\n"))
 	b.WriteString(fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure))
 	b.WriteString(fmt.Sprintf("License: %s\n", m.License))
 
+	if len(m.Methodologies) > 0 {
+		b.WriteString(fmt.Sprintf("Methodologies: %s\n", m.Methodologies))
+	}
+
 	if m.NationalStatistic != nil {
 		nationalStatistic = *m.NationalStatistic
 	}
 	b.WriteString(fmt.Sprintf("National Statistic: %t\n", nationalStatistic))
+
+	if len(m.Publications) > 0 {
+		b.WriteString(fmt.Sprintf("Publications: %s\n", m.Publications))
+	}
+
 	b.WriteString(fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic))
+
+	if len(m.Subtopics) > 0 {
+		b.WriteString(fmt.Sprintf("Subtopics: %s\n", m.Subtopics))
+	}
+
 	b.WriteString(fmt.Sprintf("Survey: %s\n", m.Survey))
-	b.WriteString(fmt.Sprintf("Lowest Geography: \n"))
+
+	if len(m.RelatedContent) > 0 {
+		b.WriteString(fmt.Sprintf("Related content: %s\n", m.RelatedContent))
+	}
 
 	return b.String()
 }

--- a/models/metadata.go
+++ b/models/metadata.go
@@ -365,6 +365,20 @@ func (m Metadata) ToString() string {
 	b.WriteString(fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency))
 
 	b.WriteString(fmt.Sprintf("Distribution:\n"))
+	// Map `DownloadObject`s in `DownloadList` to extension strings, loop through and output if
+	// valid objects
+	if m.Downloads != nil {
+		downloadObjects := m.Downloads.ExtensionsMapping()
+
+		for downloadObject, extension := range downloadObjects {
+			if downloadObject != nil {
+				b.WriteString(fmt.Sprintf("\tExtension: %s\n", extension))
+				b.WriteString(fmt.Sprintf("\tSize: %s\n", downloadObject.Size))
+				b.WriteString(fmt.Sprintf("\tURL: %s\n\n", downloadObject.HRef))
+			}
+		}
+	}
+
 	b.WriteString(fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure))
 	b.WriteString(fmt.Sprintf("License: %s\n", m.License))
 

--- a/models/metadata.go
+++ b/models/metadata.go
@@ -349,7 +349,15 @@ func (m Metadata) ToString() string {
 	b.WriteString(fmt.Sprintf("Next Release: %s\n", m.NextRelease))
 	b.WriteString(fmt.Sprintf("Identifier: %s\n", m.Title))
 	b.WriteString(fmt.Sprintf("Language: %s\n", "English"))
+
+	if len(m.Contacts) > 0 {
+		// Write first contact irrespective of number in list
+		contact := m.Contacts[0]
+		b.WriteString(fmt.Sprintf("Contact: %s, %s, %s\n", contact.Name, contact.Email, contact.Telephone))
+	}
+
 	b.WriteString(fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency))
+
 	b.WriteString(fmt.Sprintf("Distribution:\n"))
 	b.WriteString(fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure))
 	b.WriteString(fmt.Sprintf("License: %s\n", m.License))

--- a/models/metadata.go
+++ b/models/metadata.go
@@ -364,7 +364,7 @@ func (m Metadata) ToString() string {
 
 	b.WriteString(fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency))
 
-	b.WriteString(fmt.Sprintf("Distribution:\n"))
+	b.WriteString("Distribution:\n")
 	// Map `DownloadObject`s in `DownloadList` to extension strings, loop through and output if
 	// valid objects
 	if m.Downloads != nil {

--- a/models/metadata_test.go
+++ b/models/metadata_test.go
@@ -10,6 +10,40 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+// Mock data used across tests
+var (
+	csvDownload = DownloadObject{
+		HRef:    "https://www.aws/123csv",
+		Private: "csv-private",
+		Public:  "csv-public",
+		Size:    "252",
+	}
+	csvwDownload = DownloadObject{
+		HRef:    "https://www.aws/123",
+		Private: "csvw-private",
+		Public:  "csvw-public",
+		Size:    "25",
+	}
+	xlsDownload = DownloadObject{
+		HRef:    "https://www.aws/1234",
+		Private: "xls-private",
+		Public:  "xls-public",
+		Size:    "45",
+	}
+	txtDownload = DownloadObject{
+		HRef:    "https://www.aws/txt",
+		Private: "txt-private",
+		Public:  "txt-public",
+		Size:    "11",
+	}
+	xlsxDownload = DownloadObject{
+		HRef:    "https://www.aws/xlsx",
+		Private: "xlsx-private",
+		Public:  "xlsx-public",
+		Size:    "119",
+	}
+)
+
 func TestCreateMetadata(t *testing.T) {
 	Convey("Given a dataset and a version objects", t, func() {
 		dataset := Dataset{
@@ -65,37 +99,6 @@ func TestCreateMetadata(t *testing.T) {
 					ID:   "taxonomy",
 				},
 			},
-		}
-
-		csvDownload := DownloadObject{
-			HRef:    "https://www.aws/123csv",
-			Private: "csv-private",
-			Public:  "csv-public",
-			Size:    "252",
-		}
-		csvwDownload := DownloadObject{
-			HRef:    "https://www.aws/123",
-			Private: "csvw-private",
-			Public:  "csvw-public",
-			Size:    "25",
-		}
-		xlsDownload := DownloadObject{
-			HRef:    "https://www.aws/1234",
-			Private: "xls-private",
-			Public:  "xls-public",
-			Size:    "45",
-		}
-		txtDownload := DownloadObject{
-			HRef:    "https://www.aws/txt",
-			Private: "txt-private",
-			Public:  "txt-public",
-			Size:    "11",
-		}
-		xlsxDownload := DownloadObject{
-			HRef:    "https://www.aws/xlsx",
-			Private: "xlsx-private",
-			Public:  "xlsx-public",
-			Size:    "119",
 		}
 
 		version := Version{
@@ -570,8 +573,7 @@ func TestMetadataToString(t *testing.T) {
 				"License: \n" +
 				"National Statistic: false\n" +
 				"Canonical Topic: \n" +
-				"Survey: \n" +
-				"Lowest Geography: \n"
+				"Survey: \n"
 
 			So(m.ToString(), ShouldEqual, expectedString)
 		})
@@ -604,18 +606,6 @@ func TestMetadataToString(t *testing.T) {
 				Title:             "metadata title",
 				UnitOfMeasure:     "miles",
 			},
-			Temporal: &[]TemporalFrequency{
-				{
-					EndDate:   "2025-06-06T16:06:00.000Z",
-					Frequency: "every day",
-					StartDate: "2025-05-06T16:06:00.000Z",
-				},
-				{
-					EndDate:   "2025-06-06T16:06:00.000Z",
-					Frequency: "every week",
-					StartDate: "2025-05-06T16:06:00.000Z",
-				},
-			},
 			Version: 1,
 		}
 		Convey("Test that the `ToString()` method returns the correct string", func() {
@@ -631,8 +621,7 @@ func TestMetadataToString(t *testing.T) {
 				fmt.Sprintf("License: %s\n", m.License) +
 				fmt.Sprintf("National Statistic: %v\n", nationalStatistic) +
 				fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic) +
-				fmt.Sprintf("Survey: %s\n", m.Survey) +
-				"Lowest Geography: \n"
+				fmt.Sprintf("Survey: %s\n", m.Survey)
 
 			So(m.ToString(), ShouldEqual, expectedString)
 		})
@@ -663,8 +652,171 @@ func TestMetadataToString(t *testing.T) {
 				fmt.Sprintf("License: %s\n", m.License) +
 				fmt.Sprintf("National Statistic: %v\n", nationalStatistic) +
 				fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic) +
+				fmt.Sprintf("Survey: %s\n", m.Survey)
+
+			So(m.ToString(), ShouldEqual, expectedString)
+		})
+		Convey("Test that the `ToString()` method contains temporal information", func() {
+			// Update the model to include temporal string
+			temporal1 := TemporalFrequency{
+				EndDate:   "2025-06-06T16:06:00.000Z",
+				Frequency: "every day",
+				StartDate: "2025-05-06T16:06:00.000Z",
+			}
+			temporal2 := TemporalFrequency{
+				EndDate:   "2025-06-06T16:06:00.000Z",
+				Frequency: "every week",
+				StartDate: "2025-05-06T16:06:00.000Z",
+			}
+			m.Temporal = &[]TemporalFrequency{
+				temporal1,
+				temporal2,
+			}
+			expectedString := fmt.Sprintf("Title: %s\n", m.Title) +
+				fmt.Sprintf("Description: %s\n", m.Description) +
+				fmt.Sprintf("Issued: %s\n", m.ReleaseDate) +
+				fmt.Sprintf("Next Release: %s\n", m.NextRelease) +
+				fmt.Sprintf("Identifier: %s\n", m.Title) +
+				"Language: English\n" +
+				fmt.Sprintf("Temporal: %s\n", temporal1.Frequency) +
+				fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency) +
+				"Distribution:\n" +
+				fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure) +
+				fmt.Sprintf("License: %s\n", m.License) +
+				fmt.Sprintf("National Statistic: %v\n", nationalStatistic) +
+				fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic) +
+				fmt.Sprintf("Survey: %s\n", m.Survey)
+
+			So(m.ToString(), ShouldEqual, expectedString)
+		})
+		// Convey("Test that the `ToString()` method contains downloads information", func() {
+		// 	// Update the model to include downloads
+		// 	m.Downloads = &DownloadList{
+		// 		CSV:  &csvDownload,
+		// 		CSVW: &csvwDownload,
+		// 		XLS:  &xlsDownload,
+		// 		TXT:  &txtDownload,
+		// 		XLSX: &xlsxDownload,
+		// 	}
+		// 	expectedDownloadsString := getDistribution(m.Downloads)
+
+		// 	expectedString := fmt.Sprintf("Title: %s\n", m.Title) +
+		// 		fmt.Sprintf("Description: %s\n", m.Description) +
+		// 		fmt.Sprintf("Issued: %s\n", m.ReleaseDate) +
+		// 		fmt.Sprintf("Next Release: %s\n", m.NextRelease) +
+		// 		fmt.Sprintf("Identifier: %s\n", m.Title) +
+		// 		"Language: English\n" +
+		// 		fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency) +
+		// 		"Distribution:\n" +
+		// 		fmt.Sprintf("\t%s", expectedDownloadsString) +
+		// 		fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure) +
+		// 		fmt.Sprintf("License: %s\n", m.License) +
+		// 		fmt.Sprintf("National Statistic: %v\n", nationalStatistic) +
+		// 		fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic) +
+		// 		fmt.Sprintf("Survey: %s\n", m.Survey)
+
+		// 	So(m.ToString(), ShouldEqual, expectedString)
+		// })
+		Convey("Test that the `ToString()` method contains methodology information", func() {
+			// Update the model to include methodology
+			m.EditableMetadata.Methodologies = []GeneralDetails{
+				{
+					Description: "some methodologies description",
+					HRef:        "http://localhost:22000/datasets/href",
+					Title:       "some publication title",
+				},
+				{
+					Description: "another methodologies description",
+					HRef:        "http://localhost:22000/datasets/hruf",
+					Title:       "another publication title",
+				},
+			}
+			expectedString := fmt.Sprintf("Title: %s\n", m.Title) +
+				fmt.Sprintf("Description: %s\n", m.Description) +
+				fmt.Sprintf("Issued: %s\n", m.ReleaseDate) +
+				fmt.Sprintf("Next Release: %s\n", m.NextRelease) +
+				fmt.Sprintf("Identifier: %s\n", m.Title) +
+				"Language: English\n" +
+				fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency) +
+				"Distribution:\n" +
+				fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure) +
+				fmt.Sprintf("License: %s\n", m.License) +
+				fmt.Sprintf("Methodologies: %s\n", m.Methodologies) +
+				fmt.Sprintf("National Statistic: %v\n", nationalStatistic) +
+				fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic) +
+				fmt.Sprintf("Survey: %s\n", m.Survey)
+
+			So(m.ToString(), ShouldEqual, expectedString)
+		})
+		Convey("Test that the `ToString()` method contains publication information", func() {
+			// Update the model to include publication
+			m.EditableMetadata.Publications = []GeneralDetails{
+				{
+					Description: "some publication description",
+					HRef:        "http://localhost:22000/datasets/href",
+					Title:       "some publication title",
+				},
+				{
+					Description: "another publication description",
+					HRef:        "http://localhost:22000/datasets/hruf",
+					Title:       "another publication title",
+				},
+			}
+			expectedString := fmt.Sprintf("Title: %s\n", m.Title) +
+				fmt.Sprintf("Description: %s\n", m.Description) +
+				fmt.Sprintf("Issued: %s\n", m.ReleaseDate) +
+				fmt.Sprintf("Next Release: %s\n", m.NextRelease) +
+				fmt.Sprintf("Identifier: %s\n", m.Title) +
+				"Language: English\n" +
+				fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency) +
+				"Distribution:\n" +
+				fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure) +
+				fmt.Sprintf("License: %s\n", m.License) +
+				fmt.Sprintf("National Statistic: %v\n", nationalStatistic) +
+				fmt.Sprintf("Publications: %s\n", m.Publications) +
+				fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic) +
+				fmt.Sprintf("Survey: %s\n", m.Survey)
+
+			So(m.ToString(), ShouldEqual, expectedString)
+		})
+		Convey("Test that the `ToString()` method contains subtopic information", func() {
+			// Update the model to include subtopics
+			m.EditableMetadata.Subtopics = []string{"1234", "5678"}
+			expectedString := fmt.Sprintf("Title: %s\n", m.Title) +
+				fmt.Sprintf("Description: %s\n", m.Description) +
+				fmt.Sprintf("Issued: %s\n", m.ReleaseDate) +
+				fmt.Sprintf("Next Release: %s\n", m.NextRelease) +
+				fmt.Sprintf("Identifier: %s\n", m.Title) +
+				"Language: English\n" +
+				fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency) +
+				"Distribution:\n" +
+				fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure) +
+				fmt.Sprintf("License: %s\n", m.License) +
+				fmt.Sprintf("National Statistic: %v\n", nationalStatistic) +
+				fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic) +
+				fmt.Sprintf("Subtopics: %s\n", m.Subtopics) +
+				fmt.Sprintf("Survey: %s\n", m.Survey)
+
+			So(m.ToString(), ShouldEqual, expectedString)
+		})
+		Convey("Test that the `ToString()` method contains related content information", func() {
+			// Update the model to include related content
+			m.EditableMetadata.RelatedContent = []GeneralDetails{relatedDatasets}
+			expectedString := fmt.Sprintf("Title: %s\n", m.Title) +
+				fmt.Sprintf("Description: %s\n", m.Description) +
+				fmt.Sprintf("Issued: %s\n", m.ReleaseDate) +
+				fmt.Sprintf("Next Release: %s\n", m.NextRelease) +
+				fmt.Sprintf("Identifier: %s\n", m.Title) +
+				"Language: English\n" +
+				fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency) +
+				"Distribution:\n" +
+				fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure) +
+				fmt.Sprintf("License: %s\n", m.License) +
+				fmt.Sprintf("National Statistic: %v\n", nationalStatistic) +
+				fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic) +
 				fmt.Sprintf("Survey: %s\n", m.Survey) +
-				"Lowest Geography: \n"
+				fmt.Sprintf("Related content: %s\n", m.RelatedContent)
+
 			So(m.ToString(), ShouldEqual, expectedString)
 		})
 	})

--- a/models/metadata_test.go
+++ b/models/metadata_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	neturl "net/url"
 	"testing"
 	"time"
@@ -553,55 +554,10 @@ func TestUpdateMetadata(t *testing.T) {
 	})
 }
 
-func expectedData(isEmpty bool) string {
-	if isEmpty {
-		return "Title: \n" +
-			"Description: \n" +
-			"Issued: \n" +
-			"Next Release: \n" +
-			"Identifier: \n" +
-			"Language: English\n" +
-			"Periodicity: \n" +
-			"Distribution:\n" +
-			"Unit of measure: \n" +
-			"License: \n" +
-			"National Statistic: false\n" +
-			"Canonical Topic: \n" +
-			"Survey: \n" +
-			"Lowest Geography: \n"
-	}
-
-	return "Title: title\n" +
-		"Description: description\n" +
-		"Publisher: {url name type}\n" +
-		"Issued: release date\n" +
-		"Next Release: next release\n" +
-		"Identifier: title\n" +
-		"Keywords: [keyword_1 keyword_2]\n" +
-		"Language: English\n" +
-		"Contact: Bob, bob@test.com, 01657923723\n" +
-		"Latest Changes: [{change description change name change type}]\n" +
-		"Periodicity: release frequency\n" +
-		"Distribution:\n" +
-		"\tExtension: xls\n" +
-		"\tSize: size\n" +
-		"\tURL: url\n\n" +
-		"Unit of measure: unit of measure\n" +
-		"License: license\n" +
-		"Methodologies: [{methodology description methodology url methodology title}]\n" +
-		"National Statistic: true\n" +
-		"Publications: [{publication description publication url publication title}]\n" +
-		"Related Links: [{related dataset url related dataset title}]\n" +
-		"Canonical Topic: canonicalTopicID\n" +
-		"Subtopics: [secondaryTopic1ID secondaryTopic2ID]\n" +
-		"Survey: census\n" +
-		"Related Content: [{related content description related content url related content title}]\n" +
-		"Lowest Geography: lowest geography\n"
-}
-
 func TestMetadataToString(t *testing.T) {
 	Convey("If metadata model is empty", t, func() {
 		Convey("Test that the `ToString()` method returns the correct string", func() {
+			m := Metadata{}
 			expectedString := "Title: \n" +
 				"Description: \n" +
 				"Issued: \n" +
@@ -616,9 +572,81 @@ func TestMetadataToString(t *testing.T) {
 				"Canonical Topic: \n" +
 				"Survey: \n" +
 				"Lowest Geography: \n"
-			m := Metadata{}
-			returnedString := m.ToString()
-			So(returnedString, ShouldEqual, expectedString)
+
+			So(m.ToString(), ShouldEqual, expectedString)
+		})
+	})
+	Convey("If metadata model is not empty", t, func() {
+		Convey("Test that the `ToString()` method returns the correct string", func() {
+			nationalStatistic := false
+			m := Metadata{
+				EditableMetadata: EditableMetadata{
+					CanonicalTopic: "canon",
+					Contacts: []ContactDetails{
+						{
+							Email:     "test.user@ons.gov.uk",
+							Name:      "Test User",
+							Telephone: "01234 567890",
+						},
+						{
+							Email:     "best.user@ons.gov.uk",
+							Name:      "Best User",
+							Telephone: "09876 543210",
+						},
+					},
+					Description: "metadata description",
+					Keywords:    []string{"key1", "key2", "key3"},
+					LatestChanges: &[]LatestChange{
+						{
+							Description: "my 1st change",
+							Name:        "change-1",
+							Type:        "revision",
+						},
+						{
+							Description: "my 2nd change",
+							Name:        "change-2",
+							Type:        "correction",
+						},
+					},
+					License:           "MIT",
+					NationalStatistic: &nationalStatistic,
+					NextRelease:       "2025-06-06T16:06:00.000Z",
+					ReleaseDate:       "2025-05-06T16:06:00.000Z",
+					ReleaseFrequency:  "monthly",
+					Survey:            "my survey",
+					Title:             "metadata title",
+					UnitOfMeasure:     "miles",
+				},
+				Temporal: &[]TemporalFrequency{
+					{
+						EndDate:   "2025-06-06T16:06:00.000Z",
+						Frequency: "every day",
+						StartDate: "2025-05-06T16:06:00.000Z",
+					},
+					{
+						EndDate:   "2025-06-06T16:06:00.000Z",
+						Frequency: "every week",
+						StartDate: "2025-05-06T16:06:00.000Z",
+					},
+				},
+				Version: 1,
+			}
+			expectedString := fmt.Sprintf("Title: %s\n", m.Title) +
+				fmt.Sprintf("Description: %s\n", m.Description) +
+				fmt.Sprintf("Issued: %s\n", m.ReleaseDate) +
+				fmt.Sprintf("Next Release: %s\n", m.NextRelease) +
+				fmt.Sprintf("Identifier: %s\n", m.Title) +
+				"Language: English\n" +
+				fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency) +
+				"Distribution:\n" +
+				fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure) +
+				fmt.Sprintf("License: %s\n", m.License) +
+				fmt.Sprintf("National Statistic: %v\n", nationalStatistic) +
+				fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic) +
+				fmt.Sprintf("Survey: %s\n", m.Survey) +
+				"Lowest Geography: \n"
+
+			So(m.ToString(), ShouldEqual, expectedString)
 		})
 	})
 }

--- a/models/metadata_test.go
+++ b/models/metadata_test.go
@@ -689,34 +689,47 @@ func TestMetadataToString(t *testing.T) {
 
 			So(m.ToString(), ShouldEqual, expectedString)
 		})
-		// Convey("Test that the `ToString()` method contains downloads information", func() {
-		// 	// Update the model to include downloads
-		// 	m.Downloads = &DownloadList{
-		// 		CSV:  &csvDownload,
-		// 		CSVW: &csvwDownload,
-		// 		XLS:  &xlsDownload,
-		// 		TXT:  &txtDownload,
-		// 		XLSX: &xlsxDownload,
-		// 	}
-		// 	expectedDownloadsString := getDistribution(m.Downloads)
+		Convey("Test that the `ToString()` method contains downloads information", func() {
+			// Update the model to include downloads
+			m.Downloads = &DownloadList{
+				CSV:  &csvDownload,
+				CSVW: &csvwDownload,
+				XLS:  &xlsDownload,
+				TXT:  &txtDownload,
+				XLSX: &xlsxDownload,
+			}
 
-		// 	expectedString := fmt.Sprintf("Title: %s\n", m.Title) +
-		// 		fmt.Sprintf("Description: %s\n", m.Description) +
-		// 		fmt.Sprintf("Issued: %s\n", m.ReleaseDate) +
-		// 		fmt.Sprintf("Next Release: %s\n", m.NextRelease) +
-		// 		fmt.Sprintf("Identifier: %s\n", m.Title) +
-		// 		"Language: English\n" +
-		// 		fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency) +
-		// 		"Distribution:\n" +
-		// 		fmt.Sprintf("\t%s", expectedDownloadsString) +
-		// 		fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure) +
-		// 		fmt.Sprintf("License: %s\n", m.License) +
-		// 		fmt.Sprintf("National Statistic: %v\n", nationalStatistic) +
-		// 		fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic) +
-		// 		fmt.Sprintf("Survey: %s\n", m.Survey)
+			expectedString := fmt.Sprintf("Title: %s\n", m.Title) +
+				fmt.Sprintf("Description: %s\n", m.Description) +
+				fmt.Sprintf("Issued: %s\n", m.ReleaseDate) +
+				fmt.Sprintf("Next Release: %s\n", m.NextRelease) +
+				fmt.Sprintf("Identifier: %s\n", m.Title) +
+				"Language: English\n" +
+				fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency) +
+				"Distribution:\n" +
+				fmt.Sprintf("\tExtension: %s\n", "csv") +
+				fmt.Sprintf("\tSize: %s\n", m.Downloads.CSV.Size) +
+				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.CSV.HRef) +
+				fmt.Sprintf("\tExtension: %s\n", "csvw") +
+				fmt.Sprintf("\tSize: %s\n", m.Downloads.CSVW.Size) +
+				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.CSVW.HRef) +
+				fmt.Sprintf("\tExtension: %s\n", "txt") +
+				fmt.Sprintf("\tSize: %s\n", m.Downloads.TXT.Size) +
+				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.TXT.HRef) +
+				fmt.Sprintf("\tExtension: %s\n", "xls") +
+				fmt.Sprintf("\tSize: %s\n", m.Downloads.XLS.Size) +
+				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.XLS.HRef) +
+				fmt.Sprintf("\tExtension: %s\n", "xlsx") +
+				fmt.Sprintf("\tSize: %s\n", m.Downloads.XLSX.Size) +
+				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.XLSX.HRef) +
+				fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure) +
+				fmt.Sprintf("License: %s\n", m.License) +
+				fmt.Sprintf("National Statistic: %v\n", nationalStatistic) +
+				fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic) +
+				fmt.Sprintf("Survey: %s\n", m.Survey)
 
-		// 	So(m.ToString(), ShouldEqual, expectedString)
-		// })
+			So(m.ToString(), ShouldEqual, expectedString)
+		})
 		Convey("Test that the `ToString()` method contains methodology information", func() {
 			// Update the model to include methodology
 			m.EditableMetadata.Methodologies = []GeneralDetails{

--- a/models/metadata_test.go
+++ b/models/metadata_test.go
@@ -699,36 +699,31 @@ func TestMetadataToString(t *testing.T) {
 				XLSX: &xlsxDownload,
 			}
 
-			expectedString := fmt.Sprintf("Title: %s\n", m.Title) +
-				fmt.Sprintf("Description: %s\n", m.Description) +
-				fmt.Sprintf("Issued: %s\n", m.ReleaseDate) +
-				fmt.Sprintf("Next Release: %s\n", m.NextRelease) +
-				fmt.Sprintf("Identifier: %s\n", m.Title) +
-				"Language: English\n" +
-				fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency) +
-				"Distribution:\n" +
-				fmt.Sprintf("\tExtension: %s\n", "csv") +
+			// Using `ShouldContainSubstring` here as we can't guarantee the ordering of download files output
+			expectedStringCsv := fmt.Sprintf("\tExtension: %s\n", "csv") +
 				fmt.Sprintf("\tSize: %s\n", m.Downloads.CSV.Size) +
-				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.CSV.HRef) +
-				fmt.Sprintf("\tExtension: %s\n", "csvw") +
-				fmt.Sprintf("\tSize: %s\n", m.Downloads.CSVW.Size) +
-				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.CSVW.HRef) +
-				fmt.Sprintf("\tExtension: %s\n", "txt") +
-				fmt.Sprintf("\tSize: %s\n", m.Downloads.TXT.Size) +
-				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.TXT.HRef) +
-				fmt.Sprintf("\tExtension: %s\n", "xls") +
-				fmt.Sprintf("\tSize: %s\n", m.Downloads.XLS.Size) +
-				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.XLS.HRef) +
-				fmt.Sprintf("\tExtension: %s\n", "xlsx") +
-				fmt.Sprintf("\tSize: %s\n", m.Downloads.XLSX.Size) +
-				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.XLSX.HRef) +
-				fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure) +
-				fmt.Sprintf("License: %s\n", m.License) +
-				fmt.Sprintf("National Statistic: %v\n", nationalStatistic) +
-				fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic) +
-				fmt.Sprintf("Survey: %s\n", m.Survey)
+				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.CSV.HRef)
+			So(m.ToString(), ShouldContainSubstring, expectedStringCsv)
 
-			So(m.ToString(), ShouldEqual, expectedString)
+			expectedStringCsvw := fmt.Sprintf("\tExtension: %s\n", "csvw") +
+				fmt.Sprintf("\tSize: %s\n", m.Downloads.CSVW.Size) +
+				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.CSVW.HRef)
+			So(m.ToString(), ShouldContainSubstring, expectedStringCsvw)
+
+			expectedStringTxt := fmt.Sprintf("\tExtension: %s\n", "txt") +
+				fmt.Sprintf("\tSize: %s\n", m.Downloads.TXT.Size) +
+				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.TXT.HRef)
+			So(m.ToString(), ShouldContainSubstring, expectedStringTxt)
+
+			expectedStringXls := fmt.Sprintf("\tExtension: %s\n", "xls") +
+				fmt.Sprintf("\tSize: %s\n", m.Downloads.XLS.Size) +
+				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.XLS.HRef)
+			So(m.ToString(), ShouldContainSubstring, expectedStringXls)
+
+			expectedStringXlsx := fmt.Sprintf("\tExtension: %s\n", "xlsx") +
+				fmt.Sprintf("\tSize: %s\n", m.Downloads.XLSX.Size) +
+				fmt.Sprintf("\tURL: %s\n\n", m.Downloads.XLSX.HRef)
+			So(m.ToString(), ShouldContainSubstring, expectedStringXlsx)
 		})
 		Convey("Test that the `ToString()` method contains methodology information", func() {
 			// Update the model to include methodology

--- a/models/metadata_test.go
+++ b/models/metadata_test.go
@@ -577,60 +577,48 @@ func TestMetadataToString(t *testing.T) {
 		})
 	})
 	Convey("If metadata model is not empty", t, func() {
+		nationalStatistic := false
+		m := Metadata{
+			EditableMetadata: EditableMetadata{
+				CanonicalTopic: "canon",
+				Description:    "metadata description",
+				Keywords:       []string{"key1", "key2", "key3"},
+				LatestChanges: &[]LatestChange{
+					{
+						Description: "my 1st change",
+						Name:        "change-1",
+						Type:        "revision",
+					},
+					{
+						Description: "my 2nd change",
+						Name:        "change-2",
+						Type:        "correction",
+					},
+				},
+				License:           "MIT",
+				NationalStatistic: &nationalStatistic,
+				NextRelease:       "2025-06-06T16:06:00.000Z",
+				ReleaseDate:       "2025-05-06T16:06:00.000Z",
+				ReleaseFrequency:  "monthly",
+				Survey:            "my survey",
+				Title:             "metadata title",
+				UnitOfMeasure:     "miles",
+			},
+			Temporal: &[]TemporalFrequency{
+				{
+					EndDate:   "2025-06-06T16:06:00.000Z",
+					Frequency: "every day",
+					StartDate: "2025-05-06T16:06:00.000Z",
+				},
+				{
+					EndDate:   "2025-06-06T16:06:00.000Z",
+					Frequency: "every week",
+					StartDate: "2025-05-06T16:06:00.000Z",
+				},
+			},
+			Version: 1,
+		}
 		Convey("Test that the `ToString()` method returns the correct string", func() {
-			nationalStatistic := false
-			m := Metadata{
-				EditableMetadata: EditableMetadata{
-					CanonicalTopic: "canon",
-					Contacts: []ContactDetails{
-						{
-							Email:     "test.user@ons.gov.uk",
-							Name:      "Test User",
-							Telephone: "01234 567890",
-						},
-						{
-							Email:     "best.user@ons.gov.uk",
-							Name:      "Best User",
-							Telephone: "09876 543210",
-						},
-					},
-					Description: "metadata description",
-					Keywords:    []string{"key1", "key2", "key3"},
-					LatestChanges: &[]LatestChange{
-						{
-							Description: "my 1st change",
-							Name:        "change-1",
-							Type:        "revision",
-						},
-						{
-							Description: "my 2nd change",
-							Name:        "change-2",
-							Type:        "correction",
-						},
-					},
-					License:           "MIT",
-					NationalStatistic: &nationalStatistic,
-					NextRelease:       "2025-06-06T16:06:00.000Z",
-					ReleaseDate:       "2025-05-06T16:06:00.000Z",
-					ReleaseFrequency:  "monthly",
-					Survey:            "my survey",
-					Title:             "metadata title",
-					UnitOfMeasure:     "miles",
-				},
-				Temporal: &[]TemporalFrequency{
-					{
-						EndDate:   "2025-06-06T16:06:00.000Z",
-						Frequency: "every day",
-						StartDate: "2025-05-06T16:06:00.000Z",
-					},
-					{
-						EndDate:   "2025-06-06T16:06:00.000Z",
-						Frequency: "every week",
-						StartDate: "2025-05-06T16:06:00.000Z",
-					},
-				},
-				Version: 1,
-			}
 			expectedString := fmt.Sprintf("Title: %s\n", m.Title) +
 				fmt.Sprintf("Description: %s\n", m.Description) +
 				fmt.Sprintf("Issued: %s\n", m.ReleaseDate) +
@@ -646,6 +634,37 @@ func TestMetadataToString(t *testing.T) {
 				fmt.Sprintf("Survey: %s\n", m.Survey) +
 				"Lowest Geography: \n"
 
+			So(m.ToString(), ShouldEqual, expectedString)
+		})
+		Convey("Test that the `ToString()` method contains contact details", func() {
+			// Update the model to include contacts
+			m.EditableMetadata.Contacts = []ContactDetails{
+				{
+					Email:     "test.user@ons.gov.uk",
+					Name:      "Test User",
+					Telephone: "01234 567890",
+				},
+				{
+					Email:     "my.user@ons.gov.uk",
+					Name:      "My User",
+					Telephone: "01098 765432",
+				},
+			}
+			expectedString := fmt.Sprintf("Title: %s\n", m.Title) +
+				fmt.Sprintf("Description: %s\n", m.Description) +
+				fmt.Sprintf("Issued: %s\n", m.ReleaseDate) +
+				fmt.Sprintf("Next Release: %s\n", m.NextRelease) +
+				fmt.Sprintf("Identifier: %s\n", m.Title) +
+				"Language: English\n" +
+				fmt.Sprintf("Contact: %s, %s, %s\n", m.Contacts[0].Name, m.Contacts[0].Email, m.Contacts[0].Telephone) +
+				fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency) +
+				"Distribution:\n" +
+				fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure) +
+				fmt.Sprintf("License: %s\n", m.License) +
+				fmt.Sprintf("National Statistic: %v\n", nationalStatistic) +
+				fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic) +
+				fmt.Sprintf("Survey: %s\n", m.Survey) +
+				"Lowest Geography: \n"
 			So(m.ToString(), ShouldEqual, expectedString)
 		})
 	})

--- a/models/metadata_test.go
+++ b/models/metadata_test.go
@@ -694,8 +694,8 @@ func TestMetadataToString(t *testing.T) {
 			m.Downloads = &DownloadList{
 				CSV:  &csvDownload,
 				CSVW: &csvwDownload,
-				XLS:  &xlsDownload,
 				TXT:  &txtDownload,
+				XLS:  &xlsDownload,
 				XLSX: &xlsxDownload,
 			}
 

--- a/models/metadata_test.go
+++ b/models/metadata_test.go
@@ -552,3 +552,73 @@ func TestUpdateMetadata(t *testing.T) {
 		})
 	})
 }
+
+func expectedData(isEmpty bool) string {
+	if isEmpty {
+		return "Title: \n" +
+			"Description: \n" +
+			"Issued: \n" +
+			"Next Release: \n" +
+			"Identifier: \n" +
+			"Language: English\n" +
+			"Periodicity: \n" +
+			"Distribution:\n" +
+			"Unit of measure: \n" +
+			"License: \n" +
+			"National Statistic: false\n" +
+			"Canonical Topic: \n" +
+			"Survey: \n" +
+			"Lowest Geography: \n"
+	}
+
+	return "Title: title\n" +
+		"Description: description\n" +
+		"Publisher: {url name type}\n" +
+		"Issued: release date\n" +
+		"Next Release: next release\n" +
+		"Identifier: title\n" +
+		"Keywords: [keyword_1 keyword_2]\n" +
+		"Language: English\n" +
+		"Contact: Bob, bob@test.com, 01657923723\n" +
+		"Latest Changes: [{change description change name change type}]\n" +
+		"Periodicity: release frequency\n" +
+		"Distribution:\n" +
+		"\tExtension: xls\n" +
+		"\tSize: size\n" +
+		"\tURL: url\n\n" +
+		"Unit of measure: unit of measure\n" +
+		"License: license\n" +
+		"Methodologies: [{methodology description methodology url methodology title}]\n" +
+		"National Statistic: true\n" +
+		"Publications: [{publication description publication url publication title}]\n" +
+		"Related Links: [{related dataset url related dataset title}]\n" +
+		"Canonical Topic: canonicalTopicID\n" +
+		"Subtopics: [secondaryTopic1ID secondaryTopic2ID]\n" +
+		"Survey: census\n" +
+		"Related Content: [{related content description related content url related content title}]\n" +
+		"Lowest Geography: lowest geography\n"
+}
+
+func TestMetadataToString(t *testing.T) {
+	Convey("If metadata model is empty", t, func() {
+		Convey("Test that the `ToString()` method returns the correct string", func() {
+			expectedString := "Title: \n" +
+				"Description: \n" +
+				"Issued: \n" +
+				"Next Release: \n" +
+				"Identifier: \n" +
+				"Language: English\n" +
+				"Periodicity: \n" +
+				"Distribution:\n" +
+				"Unit of measure: \n" +
+				"License: \n" +
+				"National Statistic: false\n" +
+				"Canonical Topic: \n" +
+				"Survey: \n" +
+				"Lowest Geography: \n"
+			m := Metadata{}
+			returnedString := m.ToString()
+			So(returnedString, ShouldEqual, expectedString)
+		})
+	})
+}

--- a/models/version.go
+++ b/models/version.go
@@ -87,6 +87,17 @@ type DownloadObject struct {
 	Size string `bson:"size,omitempty" json:"size,omitempty"`
 }
 
+// Maps `DownloadObjects` in input `DownloadList` to their corresponding extension strings
+func (dl *DownloadList) ExtensionsMapping() map[*DownloadObject]string {
+	return map[*DownloadObject]string{
+		dl.CSV:  "csv",
+		dl.CSVW: "csvw",
+		dl.TXT:  "txt",
+		dl.XLS:  "xls",
+		dl.XLSX: "xlsx",
+	}
+}
+
 // LatestChange represents an object containing
 // information on a single change between versions
 type LatestChange struct {


### PR DESCRIPTION
### What

[DIS-3157](https://jira.ons.gov.uk/browse/DIS-3157) FilterableLanding handler needs to calculate metadata text size

- Updated `models/metadata.go` to add new `ToString()` method to metadata model. This outputs metadata text that will be used to output a text file by a `dp-frontend-dataset-controller` endpoint
- Updated `models/metadata_test.go` to include new tests for `ToString()` method
- Updated `models/version.go` to add new `ExtensionsMapping()` method to the `DownloadList` model to map file extension strings to `DownloadObjects`

### How to review

Check that all CI tests pass
