### PR TITLE
added ToString method to VersionDimensionOptionsList

### DIFF
--- a/sdk/version.go
+++ b/sdk/version.go
@@ -100,7 +100,8 @@ func (m VersionDimensionOptionsList) ToString() string {
 		b.WriteString(fmt.Sprintf("\n\tTitle: %s\n", m.Items[0].Name))
 		var labels, options []string
 
-		for _, dim := range m.Items {
+		for i := range m.Items {
+			dim := m.Items[i]
 			labels = append(labels, dim.Label)
 			options = append(options, dim.Option)
 		}

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -90,6 +91,25 @@ func (c *Client) GetVersionDimensions(ctx context.Context, headers Headers, data
 // VersionDimensionOptionsList represent a list of PublicDimensionOption
 type VersionDimensionOptionsList struct {
 	Items []models.PublicDimensionOption
+}
+
+func (m VersionDimensionOptionsList) ToString() string {
+	var b bytes.Buffer
+
+	if len(m.Items) > 0 {
+		b.WriteString(fmt.Sprintf("\n\tTitle: %s\n", m.Items[0].Name))
+		var labels, options []string
+
+		for _, dim := range m.Items {
+			labels = append(labels, dim.Label)
+			options = append(options, dim.Option)
+		}
+
+		b.WriteString(fmt.Sprintf("\tLabels: %s\n", labels))
+		b.WriteString(fmt.Sprintf("\tOptions: %v\n", options))
+	}
+
+	return b.String()
 }
 
 // Returns the options for a dimension

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -253,6 +253,40 @@ func TestGetVersionDimensionOptions(t *testing.T) {
 	})
 }
 
+// Tests for the `GetVersionDimensionOptions` model `ToString` method
+func TestGetVersionDimensionOptionsToString(t *testing.T) {
+	Convey("If VersionDimensionOptionsList model is empty", t, func() {
+		m := VersionDimensionOptionsList{}
+		Convey("Test `ToString()` method returns an empty string", func() {
+			So(m.ToString(), ShouldEqual, "")
+		})
+	})
+	Convey("If VersionDimensionOptionsList model is not empty", t, func() {
+		dimensionOptions := []models.PublicDimensionOption{
+			{
+				Label:  "my 1st option",
+				Name:   "Option 1",
+				Option: "op1",
+			},
+			{
+				Label:  "my 2nd option",
+				Name:   "Option 2",
+				Option: "op2",
+			},
+		}
+		m := VersionDimensionOptionsList{
+			Items: dimensionOptions,
+		}
+		Convey("Test `ToString()` method returns the correct string", func() {
+			expectedString := fmt.Sprintf("\n\tTitle: %s\n", dimensionOptions[0].Name) +
+				fmt.Sprintf("\tLabels: %s\n", []string{dimensionOptions[0].Label, dimensionOptions[1].Label}) +
+				fmt.Sprintf("\tOptions: %s\n", []string{dimensionOptions[0].Option, dimensionOptions[1].Option})
+
+			So(m.ToString(), ShouldEqual, expectedString)
+		})
+	})
+}
+
 // Tests for the `GetVersionMetadata` client method
 func TestGetVersionMetadata(t *testing.T) {
 	versionID := 1


### PR DESCRIPTION
### What

[DIS-3157](https://jira.ons.gov.uk/browse/DIS-3157) FilterableLanding handler needs to calculate metadata text size

- Updated `sdk/version.go` to add new `ToString()` method to `VersionDimensionOptionsList` model. This outputs metadata text that will be used to output a text file by a `dp-frontend-dataset-controller` endpoint
- Updated `sdk/version_test.go` to include new tests for `ToString()` method

### How to review

Check that all CI tests pass
