### PR TITLE
Feature/prevent duplication of dataset title put endpoint

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -448,6 +448,19 @@ func (api *DatasetAPI) putDataset(w http.ResponseWriter, r *http.Request) {
 			return nil, err
 		}
 
+		if dataset.Type == models.Static.String() {
+			datasetTitleExists, err := api.dataStore.Backend.CheckDatasetTitleExist(ctx, dataset.Title)
+			if err != nil {
+				log.Error(ctx, "putDataset endpoint: error checking if dataset title exists", err, data)
+				return nil, err
+			}
+
+			if datasetTitleExists && dataset.Title != currentDataset.Next.Title {
+				log.Error(ctx, "putDataset endpoint: unable to update a dataset with title that already exists", errs.ErrAddDatasetTitleAlreadyExists, data)
+				return nil, errs.ErrAddDatasetTitleAlreadyExists
+			}
+		}
+
 		if dataset.State == models.PublishedState {
 			if err := api.publishDataset(ctx, currentDataset, nil); err != nil {
 				log.Error(ctx, "putDataset endpoint: failed to update dataset document to published", err, data)

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -41,6 +41,7 @@ var (
 	datasetPayloadWithEmptyKeywords            = `{"contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"census","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"CensusEthnicity","theme":"population","state":"completed","id": "ageing-population-estimates", "next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","href":"https://www.ons.gov.uk/"},"type":"static"}`
 	datasetPayloadWithEmptyTopicsAndTypeStatic = `{"contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"census","keywords":["keyword"],"links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"CensusEthnicity","theme":"population","state":"completed","id": "ageing-population-estimates", "next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","href":"https://www.ons.gov.uk/"},"type":"static","topics":[]}`
 	datasetPayloadWithEmptyContacts            = `{"contacts":[],"description":"census","keywords":["keyword"],"links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"CensusEthnicity","theme":"population","state":"completed","id": "ageing-population-estimates", "next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","href":"https://www.ons.gov.uk/"},"type":"static","topics":["theme"]}`
+	datasetPayloadWithTypeStatic               = `{"id":"123","contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"census","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"CensusEthnicity","theme":"population","state":"completed","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","href":"https://www.ons.gov.uk/"},"type":"static","keywords":["keyword","keyword 2"],"topics":["topic-0","topic-1"],"license":"Open Government Licence v3.0"}`
 
 	codeListAPIURL     = &neturl.URL{Scheme: "http", Host: "localhost:22400"}
 	datasetAPIURL      = &neturl.URL{Scheme: "http", Host: "localhost:22000"}
@@ -1356,6 +1357,54 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		})
 	})
 
+	Convey("A successful request to put dataset with static dataset type returns 200 OK response", t, func() {
+		b := datasetPayloadWithTypeStatic
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{Type: "static"}}, nil
+			},
+			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
+				return false, nil
+			},
+			UpdateDatasetFunc: func(context.Context, string, *models.Dataset, string) error {
+				return nil
+			},
+		}
+
+		datasetPermissions := getAuthorisationHandlerMock()
+		permissions := getAuthorisationHandlerMock()
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusOK)
+		So(datasetPermissions.Required.Calls, ShouldEqual, 1)
+		So(permissions.Required.Calls, ShouldEqual, 0)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.CheckDatasetTitleExistCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 1)
+
+		Convey("then the request body has been drained", func() {
+			_, err := r.Body.Read(make([]byte, 1))
+			So(err, ShouldEqual, io.EOF)
+		})
+
+		Convey("and the response body contains the dataset we sent with the request", func() {
+			var expected, actual models.Dataset
+
+			err := json.Unmarshal([]byte(datasetPayloadWithTypeStatic), &expected)
+			So(err, ShouldBeNil)
+
+			err = json.Unmarshal(w.Body.Bytes(), &actual)
+			So(err, ShouldBeNil)
+
+			So(actual, ShouldResemble, expected)
+		})
+	})
+
 	Convey("When update dataset type has a value of filterable and stored dataset type is nomis return status ok", t, func() {
 		// Dataset type field cannot be updated and hence is ignored in any updates to the dataset
 
@@ -1782,6 +1831,72 @@ func TestPutDatasetReturnsError(t *testing.T) {
 
 		Convey("then the request body has been drained", func() {
 			_, err = r.Body.Read(make([]byte, 1))
+			So(err, ShouldEqual, io.EOF)
+		})
+	})
+
+	Convey("When updating the static dataset with a title that already exists returns 403 forbidden", t, func() {
+		b := datasetPayloadWithTypeStatic
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{Type: "static"}}, nil
+			},
+			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
+				return true, nil
+			},
+		}
+
+		datasetPermissions := getAuthorisationHandlerMock()
+		permissions := getAuthorisationHandlerMock()
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusForbidden)
+		So(w.Body.String(), ShouldResemble, "forbidden - dataset title already exists\n")
+		So(datasetPermissions.Required.Calls, ShouldEqual, 1)
+		So(permissions.Required.Calls, ShouldEqual, 0)
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.CheckDatasetTitleExistCalls()), ShouldEqual, 1)
+
+		Convey("then the request body has been drained", func() {
+			_, err := r.Body.Read(make([]byte, 1))
+			So(err, ShouldEqual, io.EOF)
+		})
+	})
+
+	Convey("When the CheckDatasetTitleExist call fails return an internal server error", t, func() {
+		b := datasetPayloadWithTypeStatic
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
+
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{Type: "static"}}, nil
+			},
+			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
+				return false, errs.ErrInternalServer
+			},
+		}
+
+		datasetPermissions := getAuthorisationHandlerMock()
+		permissions := getAuthorisationHandlerMock()
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
+
+		api.Router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(datasetPermissions.Required.Calls, ShouldEqual, 1)
+		So(permissions.Required.Calls, ShouldEqual, 0)
+		So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
+		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.CheckDatasetTitleExistCalls()), ShouldEqual, 1)
+
+		Convey("then the request body has been drained", func() {
+			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
 	})

--- a/features/private_datasets.feature
+++ b/features/private_datasets.feature
@@ -84,6 +84,95 @@ Feature: Private Dataset API
             }
         """
 
+    Scenario: Successfully change title of a static dataset
+        Given I have these datasets:
+            """
+            [
+                {
+                    "id": "static-dataset",
+                    "next": {
+                        "id": "static-dataset",
+                        "contacts": [
+                            {
+                                "name": "abc",
+                                "email": "abc@email.com"
+                            }
+                        ],
+                        "type": "static",
+                        "title": "example 1",
+                        "description": "some description",
+                        "license": "Open Government Licence v3.0",
+                        "topics": [ 
+                            "topic-0", 
+                            "topic-1"
+                        ]
+                    }
+                }
+            ]
+            """
+        When I PUT "/datasets/static-dataset"
+            """
+            {
+                "id": "static-dataset",
+                "contacts": [
+                    {
+                        "name": "abc",
+                        "email": "abc@email.com"
+                    }
+                ],
+                "type": "static",
+                "title": "new title",
+                "description": "some description",
+                "license": "Open Government Licence v3.0",
+                "topics": [ 
+                    "topic-0", 
+                    "topic-1"
+                ]
+            }
+            """
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "contacts": [
+                    {
+                        "name": "abc",
+                        "email": "abc@email.com"
+                    }
+                ],
+                "description": "some description",
+                "license": "Open Government Licence v3.0",
+                "title": "new title",
+                "topics": [ 
+                    "topic-0", 
+                    "topic-1"
+                ],
+                "id": "static-dataset",
+                "last_updated": "0001-01-01T00:00:00Z"
+            }
+            """
+        And the document in the database for id "static-dataset" should be:
+        """
+            {
+                "id": "static-dataset",
+                "contacts": [
+                    {
+                        "name": "abc",
+                        "email": "abc@email.com"
+                    }
+                ],
+                "title": "new title",
+                "description": "some description",
+                "license": "Open Government Licence v3.0",
+                "next": {
+                    "topics": [ 
+                        "topic-0", 
+                        "topic-1"
+                    ],
+                    "type": "static"
+                }
+            }
+        """
+
     Scenario: Adding topic fields to a dataset
         Given I have these datasets:
             """


### PR DESCRIPTION
### What

Add validation so that a static dataset cannot be edited to have a title that already exists. (match logic with POST endpoint)
[Ticket](https://jira.ons.gov.uk/browse/DIS-3203)

### How to review

Check changes are ok

1. Run the latest dataset catalogue stack
2. Make a PUT request to `http://localhost:23200/v1/datasets/cpih01` with body:

```
{
    "id" : "cpih01",
   
        "state" : "edition-confirmed",
        "type" : "filterable",
        
        "contacts" : [
            {
                "name" : "aryan"
            }
        ],
        "description" : "text here",
        "keywords" : [],
        "methodologies" : [],
        "national_statistic" : false,
        "publications" : [],
        "qmi" : {
            "description" : "",
            "href" : "",
            "title" : ""
        },
        "related_datasets" : [],
        "title" : "this is a dataset"
     
}
```
3. This should work with the title of the `next` cpih01 being changed
4. Make a PUT request to `http://localhost:23200/v1/datasets/static-test-dataset` with body:

```
{
    "id" : "static-test-dataset",
   
        "state" : "edition-confirmed",
        "type" : "static",
        
        "contacts" : [
            {
                "name" : "aryan"
            }
        ],
        "description" : "text here",
        "keywords" : [ 
            "keyword", 
            "keyword 2"
        ],
        "methodologies" : [],
        "national_statistic" : false,
        "publications" : [],
        "qmi" : {
            "description" : "",
            "href" : "",
            "title" : ""
        },
        "related_datasets" : [],
        "title" : "this is a dataset",
        "topics" : [ 
            "topic-3", 
            "topic-4"
        ],
        "license" : "Open Government Licence v3.0",
        "next_release" : "tomorrow"

     
}
```
5. This should return a 403 - forbidden with a message saying the title already exists. This should return a 200 once the title is unique
6. Ensure all the acceptance criteria from the ticket is met

### Who can review

Anyone
