### PR TITLE
remove collection id validation on static datasets

### DIFF
--- a/models/version.go
+++ b/models/version.go
@@ -434,7 +434,7 @@ func ValidateVersion(version *Version) error {
 			return ErrPublishedVersionCollectionIDInvalid
 		}
 	case AssociatedState:
-		if version.CollectionID == "" {
+		if version.Type != Static.String() && version.CollectionID == "" {
 			return ErrAssociatedVersionCollectionIDInvalid
 		}
 	default:

--- a/models/version_test.go
+++ b/models/version_test.go
@@ -40,6 +40,23 @@ func TestCreateVersion(t *testing.T) {
 			So(version.QualityDesignation, ShouldEqual, QualityDesignationOfficial)
 			So(version.Distributions, ShouldResemble, &[]Distribution{distribution})
 		})
+
+		Convey("when the version state is associated for a static dataset without collection_id", func() {
+			staticVersion := Version{
+				ReleaseDate: "2017-10-12",
+				State:       AssociatedState,
+				Type:        Static.String(),
+				Downloads: &DownloadList{
+					CSV: &DownloadObject{
+						HRef: "test-href",
+						Size: "1234",
+					},
+				},
+			}
+
+			err := ValidateVersion(&staticVersion)
+			So(err, ShouldBeNil)
+		})
 	})
 
 	Convey("Return with error when the request body contains the correct fields but of the wrong type", t, func() {
@@ -154,6 +171,24 @@ func TestValidateVersion(t *testing.T) {
 
 			v.Downloads = &DownloadList{TXT: &DownloadObject{HRef: "/", Size: "bob"}}
 			assertVersionDownloadError(fmt.Errorf("invalid fields: %v", []string{"Downloads.TXT.Size not a number"}), v)
+		})
+
+		Convey("when the version state is associated for a non-static dataset without collection_id", func() {
+			nonStaticVersion := Version{
+				ReleaseDate: "2017-10-12",
+				State:       AssociatedState,
+				Type:        "filterable",
+				Downloads: &DownloadList{
+					CSV: &DownloadObject{
+						HRef: "test-href",
+						Size: "1234",
+					},
+				},
+			}
+
+			err := ValidateVersion(&nonStaticVersion)
+			So(err, ShouldNotBeNil)
+			So(err, ShouldEqual, ErrAssociatedVersionCollectionIDInvalid)
 		})
 	})
 }


### PR DESCRIPTION
### What

Update validation to no longer require `collection_id` for static datasets when making PUT request

### How to review

- run dataset-catalogue stack
- create a new version of a static dataset
- make a request to PUT `/datasets/{dataset-id}/editions/{edition-id}/versions/{version}/state` and set the "state" value to be "associated" in the body of the request
- confirm that there is no error returned

### Who can review

Anyone
