### PR TITLE
change duplicate error status code from 403 to 409

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -18,13 +18,6 @@ import (
 )
 
 var (
-	// errors that should return a 403 status
-	datasetsForbidden = map[error]bool{
-		errs.ErrDeletePublishedDatasetForbidden: true,
-		errs.ErrAddDatasetAlreadyExists:         true,
-		errs.ErrAddDatasetTitleAlreadyExists:    true,
-	}
-
 	// errors that should return a 204 status
 	datasetsNoContent = map[error]bool{
 		errs.ErrDeleteDatasetNotFound: true,
@@ -38,11 +31,22 @@ var (
 		errs.ErrInvalidQueryParameter:      true,
 	}
 
+	// errors that should return a 403 status
+	datasetsForbidden = map[error]bool{
+		errs.ErrDeletePublishedDatasetForbidden: true,
+	}
+
 	// errors that should return a 404 status
 	resourcesNotFound = map[error]bool{
 		errs.ErrDatasetNotFound:  true,
 		errs.ErrEditionsNotFound: true,
 		errs.ErrEditionNotFound:  true,
+	}
+
+	// errors that should return a 409 status
+	datasetsConflict = map[error]bool{
+		errs.ErrAddDatasetAlreadyExists:      true,
+		errs.ErrAddDatasetTitleAlreadyExists: true,
 	}
 )
 
@@ -609,6 +613,8 @@ func handleDatasetAPIErr(ctx context.Context, err error, w http.ResponseWriter, 
 		status = http.StatusNoContent
 	case datasetsBadRequest[err], strings.HasPrefix(err.Error(), "invalid fields:"):
 		status = http.StatusBadRequest
+	case datasetsConflict[err]:
+		status = http.StatusConflict
 	case resourcesNotFound[err]:
 		status = http.StatusNotFound
 	default:

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -953,7 +953,7 @@ func TestPostDatasetsReturnsCreated(t *testing.T) {
 }
 
 func TestPostDatasetsReturnsError(t *testing.T) {
-	Convey("When the request contains duplicate dataset title a forbidden request status is returned", t, func() {
+	Convey("When the request contains duplicate dataset title a conflict request status is returned", t, func() {
 		b := datasetPayloadWithID
 		r := createRequestWithAuth("POST", "http://localhost:22000/datasets", bytes.NewBufferString(b))
 
@@ -972,7 +972,7 @@ func TestPostDatasetsReturnsError(t *testing.T) {
 		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
 		api.Router.ServeHTTP(w, r)
 
-		So(w.Code, ShouldEqual, http.StatusForbidden)
+		So(w.Code, ShouldEqual, http.StatusConflict)
 		So(datasetPermissions.Required.Calls, ShouldEqual, 1)
 		So(permissions.Required.Calls, ShouldEqual, 0)
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrAddDatasetTitleAlreadyExists.Error())
@@ -1113,7 +1113,7 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		})
 	})
 
-	Convey("When the dataset already exists and a request is sent to create the same dataset return status forbidden", t, func() {
+	Convey("When the dataset already exists and a request is sent to create the same dataset return status conflict", t, func() {
 		b := datasetPayload
 		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
@@ -1136,10 +1136,10 @@ func TestPostDatasetReturnsError(t *testing.T) {
 		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
 		api.Router.ServeHTTP(w, r)
 
-		So(w.Code, ShouldEqual, http.StatusForbidden)
+		So(w.Code, ShouldEqual, http.StatusConflict)
 		So(datasetPermissions.Required.Calls, ShouldEqual, 1)
 		So(permissions.Required.Calls, ShouldEqual, 0)
-		So(w.Body.String(), ShouldResemble, "forbidden - dataset already exists\n")
+		So(w.Body.String(), ShouldResemble, "dataset already exists\n")
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 
@@ -1834,7 +1834,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		})
 	})
 
-	Convey("When updating the static dataset with a title that already exists returns 403 forbidden", t, func() {
+	Convey("When updating the static dataset with a title that already exists returns 409 conflict", t, func() {
 		b := datasetPayloadWithTypeStatic
 		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
@@ -1854,8 +1854,8 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, datasetPermissions, permissions)
 		api.Router.ServeHTTP(w, r)
 
-		So(w.Code, ShouldEqual, http.StatusForbidden)
-		So(w.Body.String(), ShouldResemble, "forbidden - dataset title already exists\n")
+		So(w.Code, ShouldEqual, http.StatusConflict)
+		So(w.Body.String(), ShouldResemble, "dataset title already exists\n")
 		So(datasetPermissions.Required.Calls, ShouldEqual, 1)
 		So(permissions.Required.Calls, ShouldEqual, 0)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -15,8 +15,8 @@ func (e ErrInvalidPatch) Error() string {
 
 // A list of error messages for Dataset API
 var (
-	ErrAddDatasetAlreadyExists           = errors.New("forbidden - dataset already exists")
-	ErrAddDatasetTitleAlreadyExists      = errors.New("forbidden - dataset title already exists")
+	ErrAddDatasetAlreadyExists           = errors.New("dataset already exists")
+	ErrAddDatasetTitleAlreadyExists      = errors.New("dataset title already exists")
 	ErrDatasetTypeInvalid                = errors.New("invalid dataset type")
 	ErrTypeMismatch                      = errors.New("type mismatch")
 	ErrAddUpdateDatasetBadRequest        = errors.New("failed to parse json body")

--- a/features/private_datasets.feature
+++ b/features/private_datasets.feature
@@ -48,10 +48,10 @@ Feature: Private Dataset API
                 "title": "Hello"
             }
             """
-        Then the HTTP status code should be "403"
+        Then the HTTP status code should be "409"
         And I should receive the following response:
             """
-            forbidden - dataset already exists
+            dataset already exists
             """
 
     Scenario: Adding survey field to a dataset
@@ -382,10 +382,10 @@ Feature: Private Dataset API
                 "license":"license"
             }
             """
-        Then the HTTP status code should be "403"
+        Then the HTTP status code should be "409"
         And I should receive the following response:
             """
-            forbidden - dataset already exists
+            dataset already exists
             """
 
     Scenario: Missing dataset ID in body when creating a new dataset

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -281,8 +281,8 @@ paths:
           description: "Invalid request body"
         401:
           description: "Unauthorised to create/overwrite dataset"
-        403:
-          description: "Forbidden to overwrite dataset, dataset already exists"
+        409:
+          description: "dataset already exists"
         500:
           $ref: "#/responses/InternalError"
 
@@ -357,6 +357,8 @@ paths:
           description: "Bad Request due to invalid json in the request body"
         401:
           description: "Unauthorised to update dataset"
+        409:
+          description: "Dataset title already exists"
         404:
           description: "No dataset was found using the id provided"
         500:


### PR DESCRIPTION
### What

Changed response status code from 403 to 409 for duplicate field errors

### How to review

Check changes are ok
Try `POST /datasets` and `PUT /datasets/{id}` to see if 409 status code is returned when entering duplicate title or id

### Who can review

Anyone
