### PR TITLE
Feature/add json response to put version endpoint

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -326,10 +326,24 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = api.smDatasetAPI.AmendVersion(r.Context(), vars, version)
+	var amendedVersion *models.Version
+
+	amendedVersion, err = api.smDatasetAPI.AmendVersion(r.Context(), vars, version)
 	if err != nil {
 		handleVersionAPIErr(ctx, err, w, data)
 		return
+	}
+
+	versionBytes, err := json.Marshal(amendedVersion)
+	if err != nil {
+		log.Error(ctx, "failed to marshal version resource into bytes", err, data)
+		handleVersionAPIErr(ctx, err, w, data)
+	}
+
+	_, err = w.Write(versionBytes)
+	if err != nil {
+		log.Error(ctx, "failed writing bytes to response", err, data)
+		handleVersionAPIErr(ctx, err, w, data)
 	}
 
 	setJSONContentType(w)
@@ -836,7 +850,7 @@ func (api *DatasetAPI) putState(w http.ResponseWriter, r *http.Request) {
 		currentVersion.Type = models.Static.String()
 	}
 
-	err = api.smDatasetAPI.AmendVersion(r.Context(), vars, currentVersion)
+	_, err = api.smDatasetAPI.AmendVersion(r.Context(), vars, currentVersion)
 	if err != nil {
 		handleVersionAPIErr(ctx, err, w, logData)
 		return

--- a/api/versions.go
+++ b/api/versions.go
@@ -340,13 +340,13 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 		handleVersionAPIErr(ctx, err, w, data)
 	}
 
+	setJSONContentType(w)
 	_, err = w.Write(versionBytes)
 	if err != nil {
 		log.Error(ctx, "failed writing bytes to response", err, data)
 		handleVersionAPIErr(ctx, err, w, data)
 	}
 
-	setJSONContentType(w)
 	w.WriteHeader(http.StatusOK)
 	log.Info(ctx, "putVersion endpoint: request successful", data)
 }

--- a/application/application.go
+++ b/application/application.go
@@ -64,7 +64,7 @@ func (v VersionDetails) baseLogData() log.Data {
 	return log.Data{"dataset_id": v.datasetID, "edition": v.edition, "version": v.version}
 }
 
-func (smDS *StateMachineDatasetAPI) AmendVersion(ctx context.Context, vars map[string]string, version *models.Version) error {
+func (smDS *StateMachineDatasetAPI) AmendVersion(ctx context.Context, vars map[string]string, version *models.Version) (*models.Version, error) {
 	versionDetails := VersionDetails{
 		datasetID: vars["dataset_id"],
 		edition:   vars["edition"],
@@ -74,7 +74,7 @@ func (smDS *StateMachineDatasetAPI) AmendVersion(ctx context.Context, vars map[s
 	if version.Type == models.Static.String() {
 		lockID, lockErr := smDS.DataStore.Backend.AcquireVersionsLock(ctx, version.ID)
 		if lockErr != nil {
-			return lockErr
+			return nil, lockErr
 		}
 		defer func() {
 			smDS.DataStore.Backend.UnlockVersions(ctx, lockID)
@@ -82,7 +82,7 @@ func (smDS *StateMachineDatasetAPI) AmendVersion(ctx context.Context, vars map[s
 	} else {
 		lockID, lockErr := smDS.DataStore.Backend.AcquireInstanceLock(ctx, version.ID)
 		if lockErr != nil {
-			return lockErr
+			return nil, lockErr
 		}
 		defer func() {
 			smDS.DataStore.Backend.UnlockInstance(ctx, lockID)
@@ -92,15 +92,15 @@ func (smDS *StateMachineDatasetAPI) AmendVersion(ctx context.Context, vars map[s
 	currentVersion, versionUpdate, err := smDS.PopulateVersionInfo(ctx, version, versionDetails)
 	if err != nil {
 		log.Error(ctx, "amendVersion: creating models failed", err)
-		return err
+		return nil, err
 	}
 
 	if err := smDS.StateMachine.Transition(ctx, smDS, currentVersion, versionUpdate, versionDetails, vars[hasDownloads]); err != nil {
 		log.Error(ctx, "amendVersion: state machine transition failed", err)
-		return err
+		return nil, err
 	}
 
-	return nil
+	return versionUpdate, nil
 }
 
 func (smDS *StateMachineDatasetAPI) PopulateVersionInfo(ctx context.Context, versionUpdate *models.Version, versionDetails VersionDetails) (currentVersion, combinedVersionUpdate *models.Version, err error) {

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -157,8 +157,9 @@ func TestAmendVersionInvalidState(t *testing.T) {
 		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
 		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
 
-		_, err := smDS.AmendVersion(testContext, vars, publishVersionUpdate)
+		amendedVersion, err := smDS.AmendVersion(testContext, vars, publishVersionUpdate)
 		So(err, ShouldNotBeNil)
+		So(amendedVersion, ShouldBeNil)
 		So(err.Error(), ShouldContainSubstring, "state not allowed to transition")
 		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
@@ -197,8 +198,9 @@ func TestAmendVersionPopulateModelsFails(t *testing.T) {
 		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
 		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
 
-		_, err := smDS.AmendVersion(testContext, vars, publishVersionUpdate)
+		amendedVersion, err := smDS.AmendVersion(testContext, vars, publishVersionUpdate)
 		So(err, ShouldNotBeNil)
+		So(amendedVersion, ShouldBeNil)
 		So(err.Error(), ShouldContainSubstring, "edition not found")
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.AcquireInstanceLockCalls()), ShouldEqual, 1)
@@ -265,8 +267,9 @@ func TestAmendVersionPopulateVersionFails(t *testing.T) {
 		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
 		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
 
-		_, err := smDS.AmendVersion(testContext, vars, versionUpdateInvalid)
+		amendedVersion, err := smDS.AmendVersion(testContext, vars, versionUpdateInvalid)
 		So(err, ShouldNotBeNil)
+		So(amendedVersion, ShouldBeNil)
 		So(err.Error(), ShouldContainSubstring, "missing mandatory fields: [release_date]")
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.AcquireInstanceLockCalls()), ShouldEqual, 1)
@@ -337,8 +340,10 @@ func TestAmendVersionStaticSuccess(t *testing.T) {
 		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
 		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
 
-		_, err := smDS.AmendVersion(testContext, vars, versionUpdateAssociatedStatic)
+		amendedVersion, err := smDS.AmendVersion(testContext, vars, versionUpdateAssociatedStatic)
 		So(err, ShouldBeNil)
+		So(amendedVersion, ShouldNotBeNil)
+		So(amendedVersion.State, ShouldEqual, models.AssociatedState)
 		So(len(mockedDataStore.AcquireVersionsLockCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UnlockVersionsCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsStaticCalls()), ShouldEqual, 1)
@@ -409,8 +414,10 @@ func TestAmendVersionSuccess(t *testing.T) {
 		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
 		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
 
-		_, err := smDS.AmendVersion(testContext, vars, versionUpdateAssociated)
+		amendedVersion, err := smDS.AmendVersion(testContext, vars, versionUpdateAssociated)
 		So(err, ShouldBeNil)
+		So(amendedVersion, ShouldNotBeNil)
+		So(amendedVersion.State, ShouldEqual, models.AssociatedState)
 		So(len(mockedDataStore.AcquireInstanceLockCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UnlockInstanceCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
@@ -447,9 +454,10 @@ func TestAmendVersionErrorLockFails(t *testing.T) {
 		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
 		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
 
-		_, err := smDS.AmendVersion(testContext, vars, publishVersionUpdate)
+		amendedVersion, err := smDS.AmendVersion(testContext, vars, publishVersionUpdate)
 
 		So(err, ShouldNotBeNil)
+		So(amendedVersion, ShouldBeNil)
 		So(err.Error(), ShouldContainSubstring, "Unable to acquire lock")
 	})
 
@@ -466,9 +474,10 @@ func TestAmendVersionErrorLockFails(t *testing.T) {
 		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
 		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
 
-		_, err := smDS.AmendVersion(testContext, vars, publishVersionUpdateStatic)
+		amendedVersion, err := smDS.AmendVersion(testContext, vars, publishVersionUpdateStatic)
 
 		So(err, ShouldNotBeNil)
+		So(amendedVersion, ShouldBeNil)
 		So(err.Error(), ShouldContainSubstring, "Unable to acquire lock")
 	})
 }

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -157,7 +157,7 @@ func TestAmendVersionInvalidState(t *testing.T) {
 		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
 		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
 
-		err := smDS.AmendVersion(testContext, vars, publishVersionUpdate)
+		_, err := smDS.AmendVersion(testContext, vars, publishVersionUpdate)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, "state not allowed to transition")
 		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 0)
@@ -197,7 +197,7 @@ func TestAmendVersionPopulateModelsFails(t *testing.T) {
 		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
 		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
 
-		err := smDS.AmendVersion(testContext, vars, publishVersionUpdate)
+		_, err := smDS.AmendVersion(testContext, vars, publishVersionUpdate)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, "edition not found")
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
@@ -265,7 +265,7 @@ func TestAmendVersionPopulateVersionFails(t *testing.T) {
 		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
 		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
 
-		err := smDS.AmendVersion(testContext, vars, versionUpdateInvalid)
+		_, err := smDS.AmendVersion(testContext, vars, versionUpdateInvalid)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, "missing mandatory fields: [release_date]")
 		So(len(mockedDataStore.CheckEditionExistsCalls()), ShouldEqual, 1)
@@ -337,7 +337,7 @@ func TestAmendVersionStaticSuccess(t *testing.T) {
 		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
 		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
 
-		err := smDS.AmendVersion(testContext, vars, versionUpdateAssociatedStatic)
+		_, err := smDS.AmendVersion(testContext, vars, versionUpdateAssociatedStatic)
 		So(err, ShouldBeNil)
 		So(len(mockedDataStore.AcquireVersionsLockCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UnlockVersionsCalls()), ShouldEqual, 1)
@@ -409,7 +409,7 @@ func TestAmendVersionSuccess(t *testing.T) {
 		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
 		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
 
-		err := smDS.AmendVersion(testContext, vars, versionUpdateAssociated)
+		_, err := smDS.AmendVersion(testContext, vars, versionUpdateAssociated)
 		So(err, ShouldBeNil)
 		So(len(mockedDataStore.AcquireInstanceLockCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UnlockInstanceCalls()), ShouldEqual, 1)
@@ -447,7 +447,7 @@ func TestAmendVersionErrorLockFails(t *testing.T) {
 		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
 		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
 
-		err := smDS.AmendVersion(testContext, vars, publishVersionUpdate)
+		_, err := smDS.AmendVersion(testContext, vars, publishVersionUpdate)
 
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, "Unable to acquire lock")
@@ -466,7 +466,7 @@ func TestAmendVersionErrorLockFails(t *testing.T) {
 		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
 		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
 
-		err := smDS.AmendVersion(testContext, vars, publishVersionUpdateStatic)
+		_, err := smDS.AmendVersion(testContext, vars, publishVersionUpdateStatic)
 
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, "Unable to acquire lock")

--- a/features/versions.feature
+++ b/features/versions.feature
@@ -792,7 +792,25 @@ Feature: Dataset API
     And these generate downloads events are produced:
       | InstanceID  | DatasetID            | Edition | Version | FilterOutputID |
       | test-item-3 | population-estimates | hellov2 | 3       |                |
-    Then the HTTP status code should be "200"
+    Then I should receive the following JSON response with status "200":
+        """
+            {
+                "collection_id": "bla",
+                "dataset_id": "population-estimates",
+                "id": "test-item-3",
+                "last_updated": "0001-01-01T00:00:00Z",
+                "links": {
+                    "dataset": {
+                    "id": "population-estimates"
+                    },
+                    "self": {
+                    "href": "/datasets/population-estimates/editions/hellov2/versions/3"
+                    }
+                },
+                "release_date": "2017-04-04",
+                "state": "associated"
+            }
+        """
 
 
   Scenario: PUT versions for Cantabular dataset produces Kafka event and returns OK
@@ -813,7 +831,25 @@ Feature: Dataset API
     And these cantabular generator downloads events are produced:
       | InstanceID                | DatasetID                 | Edition | Version |FilterOutputID| Dimensions |
       | test-cantabular-version-1 | test-cantabular-dataset-1 | 2021    | 1       |              | []         |
-    Then the HTTP status code should be "200"
+    Then I should receive the following JSON response with status "200":
+        """
+            {
+                "collection_id": "bla",
+                "dataset_id": "test-cantabular-dataset-1",
+                "id": "test-cantabular-version-1",
+                "last_updated": "0001-01-01T00:00:00Z",
+                "links": {
+                    "dataset": {
+                    "id": "test-cantabular-dataset-1"
+                    },
+                    "self": {
+                    "href": "/datasets/test-cantabular-dataset-1/editions/2021/versions/1"
+                    }
+                },
+                "release_date": "2017-04-04",
+                "state": "associated"
+            }
+        """
 
 
   Scenario: PUT published version for Cantabular dataset produces Kafka event and returns OK
@@ -849,4 +885,27 @@ Feature: Dataset API
     And these cantabular generator downloads events are produced:
       | InstanceID                | DatasetID                 | Edition | Version |FilterOutputID| Dimensions |
       | test-cantabular-version-2 | test-cantabular-dataset-2 | 2021    | 1       |              | []         |
-    Then the HTTP status code should be "200"
+    Then I should receive the following JSON response with status "200":
+        """
+            {
+                "dataset_id": "test-cantabular-dataset-2",
+                "downloads": {
+                    "csv": {
+                    "href": "/downloads/datasets/test-cantabular-dataset-2/editions/2021/versions/1.csv",
+                    "size": "1"
+                    }
+                },
+                "id": "test-cantabular-version-2",
+                "last_updated": "0001-01-01T00:00:00Z",
+                "links": {
+                    "dataset": {
+                    "id": "test-cantabular-dataset-2"
+                    },
+                    "self": {
+                    "href": "/datasets/test-cantabular-dataset-2/editions/2021/versions/1"
+                    }
+                },
+                "release_date": "2017-04-04",
+                "state": "published"
+            }
+        """


### PR DESCRIPTION
### What

`PUT /datasets/{dataset-id}/editions/{edition-id}/versions/{version}` will now respond with the updated version in the response body. This was added to fix an issue with the data-admin-ui.

Ticket: https://jira.ons.gov.uk/browse/DIS-3228

### How to review

Check changes are ok
Component tests and unit tests make sense with expected responses

Run locally and ensure the updated version is being returned

### Who can review

Anyone
