### PR TITLE
feat: Add approved to states

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -376,6 +376,29 @@ func AssociateVersion(ctx context.Context, smDS *StateMachineDatasetAPI,
 	return nil
 }
 
+func ApproveVersion(ctx context.Context, smDS *StateMachineDatasetAPI,
+	currentVersion *models.Version, // Called Instances in Mongo
+	versionUpdate *models.Version, // Next version, that is the new version
+	versionDetails VersionDetails,
+	hasDownloads string) error {
+	data := versionDetails.baseLogData()
+	log.Info(ctx, "putVersion endpoint (associateVersion): beginning associate version", data)
+
+	errModel := models.ValidateVersion(versionUpdate)
+	if errModel != nil {
+		log.Error(ctx, "State machine - Approving: ValidateVersion : failed to validate version", errModel, data)
+		return errModel
+	}
+
+	_, err := UpdateVersionInfo(ctx, smDS, currentVersion, versionUpdate, versionDetails)
+	if err != nil {
+		log.Error(ctx, "State machine - Approving: UpdateVersionInfo : failed to update the version", err, data)
+		return err
+	}
+
+	return nil
+}
+
 func EditionConfirmVersion(ctx context.Context, smDS *StateMachineDatasetAPI,
 	currentVersion *models.Version, // Called Instances in Mongo
 	versionUpdate *models.Version, // Next version, that is the new version

--- a/application/state_machine.go
+++ b/application/state_machine.go
@@ -46,6 +46,8 @@ func castStateToState(state string) (*State, bool) {
 		return &Published, true
 	case "associated":
 		return &Associated, true
+	case "approved":
+		return &Approved, true
 	case "edition-confirmed":
 		return &EditionConfirmed, true
 	default:

--- a/application/states.go
+++ b/application/states.go
@@ -14,3 +14,8 @@ var Associated = State{
 	Name:      "associated",
 	EnterFunc: AssociateVersion,
 }
+
+var Approved = State{
+	Name:      "approved",
+	EnterFunc: ApproveVersion,
+}

--- a/models/state.go
+++ b/models/state.go
@@ -13,6 +13,7 @@ const (
 	CompletedState        = "completed"
 	EditionConfirmedState = "edition-confirmed"
 	AssociatedState       = "associated"
+	ApprovedState         = "approved"
 	PublishedState        = "published"
 	DetachedState         = "detached"
 	FailedState           = "failed"
@@ -21,6 +22,7 @@ const (
 var validVersionStates = map[string]int{
 	EditionConfirmedState: 1,
 	AssociatedState:       1,
+	ApprovedState:         1,
 	PublishedState:        1,
 }
 
@@ -29,6 +31,7 @@ var validStates = map[string]int{
 	SubmittedState:        1,
 	CompletedState:        1,
 	EditionConfirmedState: 1,
+	ApprovedState:         1,
 	AssociatedState:       1,
 	PublishedState:        1,
 	FailedState:           1,

--- a/models/test_data.go
+++ b/models/test_data.go
@@ -226,6 +226,22 @@ var associatedVersion = Version{
 	Distributions:      &[]Distribution{distribution},
 }
 
+var approvedVersion = Version{
+	CollectionID:       collectionID,
+	Dimensions:         []Dimension{dimension},
+	Downloads:          &downloads,
+	Edition:            "2017",
+	LatestChanges:      &[]LatestChange{latestChange},
+	Links:              &links,
+	ReleaseDate:        "2017-10-12",
+	State:              ApprovedState,
+	Temporal:           &[]TemporalFrequency{temporal},
+	Version:            1,
+	QualityDesignation: QualityDesignationOfficial,
+	Distributions:      &[]Distribution{distribution},
+	Type:               Static.String(),
+}
+
 var publishedVersion = Version{
 	Alerts:        &[]Alert{alert},
 	Dimensions:    []Dimension{dimension},

--- a/models/version.go
+++ b/models/version.go
@@ -21,7 +21,8 @@ import (
 var (
 	ErrAssociatedVersionCollectionIDInvalid = errors.New("missing collection_id for association between version and a collection")
 	ErrPublishedVersionCollectionIDInvalid  = errors.New("unexpected collection_id in published version")
-	ErrVersionStateInvalid                  = errors.New("incorrect state, can be one of the following: edition-confirmed, associated or published")
+	ErrVersionStateDatasetTypeInvalid       = errors.New("incorrect state for dataset type")
+	ErrVersionStateInvalid                  = errors.New("incorrect state, can be one of the following: edition-confirmed, associated, approved or published")
 )
 
 // Version represents information related to a single version for an edition of a dataset
@@ -447,6 +448,10 @@ func ValidateVersion(version *Version) error {
 	case AssociatedState:
 		if version.Type != Static.String() && version.CollectionID == "" {
 			return ErrAssociatedVersionCollectionIDInvalid
+		}
+	case ApprovedState:
+		if version.Type != Static.String() {
+			return ErrVersionStateDatasetTypeInvalid
 		}
 	default:
 		return ErrVersionStateInvalid

--- a/models/version_test.go
+++ b/models/version_test.go
@@ -91,6 +91,11 @@ func TestValidateVersion(t *testing.T) {
 			err := ValidateVersion(&publishedVersion)
 			So(err, ShouldBeNil)
 		})
+
+		Convey("when the version state is approved and type is static", func() {
+			err := ValidateVersion(&approvedVersion)
+			So(err, ShouldBeNil)
+		})
 	})
 
 	Convey("Return with errors", t, func() {
@@ -103,7 +108,7 @@ func TestValidateVersion(t *testing.T) {
 		Convey("when the version state is set to an invalid value", func() {
 			err := ValidateVersion(&Version{State: SubmittedState})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldResemble, errors.New("incorrect state, can be one of the following: edition-confirmed, associated or published").Error())
+			So(err.Error(), ShouldResemble, ErrVersionStateInvalid.Error())
 		})
 
 		Convey("when mandatory fields are missing from version document when state is set to created", func() {
@@ -189,6 +194,17 @@ func TestValidateVersion(t *testing.T) {
 			err := ValidateVersion(&nonStaticVersion)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldEqual, ErrAssociatedVersionCollectionIDInvalid)
+		})
+
+		Convey("when the version state is approved for a non-static dataset", func() {
+			nonStaticVersion := Version{
+				State: ApprovedState,
+				Type:  "filterable",
+			}
+
+			err := ValidateVersion(&nonStaticVersion)
+			So(err, ShouldNotBeNil)
+			So(err, ShouldEqual, ErrVersionStateDatasetTypeInvalid)
 		})
 	})
 }

--- a/service/service.go
+++ b/service/service.go
@@ -90,7 +90,7 @@ func GetListStaticTransitions() []application.Transition {
 	publishedTransition := application.Transition{
 		Label:               "published",
 		TargetState:         application.Published,
-		AllowedSourceStates: []string{"created", "associated", "published"},
+		AllowedSourceStates: []string{"approved"},
 		Type:                "static",
 	}
 
@@ -101,8 +101,15 @@ func GetListStaticTransitions() []application.Transition {
 		Type:                "static",
 	}
 
+	approvedTransition := application.Transition{
+		Label:               "approved",
+		TargetState:         application.Approved,
+		AllowedSourceStates: []string{"associated"},
+		Type:                "static",
+	}
+
 	return []application.Transition{publishedTransition,
-		associatedTransition}
+		associatedTransition, approvedTransition}
 }
 
 func GetListCantabularTransitions() []application.Transition {


### PR DESCRIPTION
### What

Complets ticket DIS-3325

#### Add `approved` to list of states

1. Added `ApprovedState` to state constants

3. Created an instance of `State` called `Approved`  which links to a new method `ApproveVersion`

4. Copy and pasted code from elsewhere for `ApproveVersion` since that seems to how it's done. Assuming there's good reason for this not to have been refactored

6. Updated `publishedTransition` to only allow transitions from `approved` state (for static datasets only), as per ticket:
```
When a dataset version is updated to the published state, then it's previous state should be approved.  
```

7. Added new `approvedTransition` for `associated` -> `approved` (for static datasets only), as per ticket
```
A dataset version can move to the approved state if it is in the associated state.  
```

### How to review

Validate the above works as expected, that static datasets can transition from `associated` -> `approved`, and `approved` -> `published`, but no other transitions are allowed for the target states.

### Who can review

Anyone but me
