### PR TITLE
feat(sdk): add method for updating version state

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -57,6 +58,17 @@ func (c *Client) DoAuthenticatedGetRequest(ctx context.Context, headers Headers,
 	// Add auth headers to the request
 	headers.Add(req)
 
+	return c.hcCli.Client.Do(ctx, req)
+}
+
+// Creates new request object, executes a put request using the input `headers`, `uri`, and payload, and returns the response
+func (c *Client) DoAuthenticatedPutRequest(ctx context.Context, headers Headers, uri *url.URL, payload []byte) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPut, uri.RequestURI(), bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, err
+	}
+
+	headers.Add(req)
 	return c.hcCli.Client.Do(ctx, req)
 }
 
@@ -130,4 +142,15 @@ func unmarshalResponseBodyExpectingErrorResponse(response *http.Response, target
 	}
 
 	return json.Unmarshal(b, &target)
+}
+
+func getStringResponseBody(resp *http.Response) (*string, error) {
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.New("failed to ready response body")
+	}
+
+	bodyString := string(bodyBytes)
+
+	return &bodyString, nil
 }

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -3,10 +3,12 @@ package sdk
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/ONSdigital/dp-dataset-api/models"
 )
@@ -217,4 +219,65 @@ func (c *Client) GetVersions(ctx context.Context, headers Headers, datasetID, ed
 	err = unmarshalResponseBodyExpectingStringError(resp, &versionsList)
 
 	return versionsList, err
+}
+
+func (c *Client) PutVersionState(ctx context.Context, headers Headers, datasetID, editionID, versionID, state string) (err error) {
+	if err := validateRequiredParams(map[string]string{
+		"datasetID": datasetID,
+		"editionID": editionID,
+		"versionID": versionID,
+		"state":     state,
+	}); err != nil {
+		return err
+	}
+
+	uri := &url.URL{}
+	uri.Path, err = url.JoinPath(c.hcCli.URL, "datasets", datasetID, "editions", editionID, "versions", versionID, "state")
+	if err != nil {
+		return err
+	}
+
+	stateUpdate := models.StateUpdate{
+		State: state,
+	}
+
+	requestBody, err := json.Marshal(stateUpdate)
+
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.DoAuthenticatedPutRequest(ctx, headers, uri, requestBody)
+	defer closeResponseBody(ctx, resp)
+
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode > 299 || resp.StatusCode < 200 {
+		responseBody, err := getStringResponseBody(resp)
+		if err != nil {
+			return fmt.Errorf("did not receive sucess response. received status %d", resp.StatusCode)
+		}
+
+		return fmt.Errorf("did not receive sucess response. received status %d, response body: %s", resp.StatusCode, *responseBody)
+	}
+
+	return nil
+}
+
+// Validate that all the specified params are not empty, and return an error message describing which ones are empty (if any)
+func validateRequiredParams(params map[string]string) error {
+	var missing []string
+	for name, value := range params {
+		if value == "" {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("required args cannot be empty: %s", strings.Join(missing, ", "))
+	}
+
+	return nil
 }


### PR DESCRIPTION
### What

Adds a method to the dp-dataset-api SDK module to update a version's state.

**Notes**:
1. Currently, if there is an error response, I just read the respone body as a string and append that in the returned `error`. However this _should_ change in the future once proper error response bodies are returned.
 
### How to review

Use the SDK to try and update a version's state using the relevant method.

E.g.

```go
import (
	sdk "github.com/ONSdigital/dp-dataset-api/sdk"
)

client := sdk.New("http://127.0.0.1:22000")
err := client.PutVersionState(ctx, sdk.Headers{ServiceToken: "SERVICE-TOKEN"}, "example-dataset-id", "example-edition-id, 1, "published")
```

Ensure:

1. Errors are caught, handled, and returned properly
3. Validation occurs on the method params
4. Successful version state updates return no errors

### Who can review

Anyone but me