### PR TITLE
fix(sdk): Add PutVersionState to Clienter interface + update mock

### DIFF
--- a/sdk/interface.go
+++ b/sdk/interface.go
@@ -26,4 +26,5 @@ type Clienter interface {
 	GetVersionDimensionOptions(ctx context.Context, headers Headers, datasetID, editionID, versionID, dimensionID string, queryParams *QueryParams) (versionDimensionOptionsList VersionDimensionOptionsList, err error)
 	GetVersionMetadata(ctx context.Context, headers Headers, datasetID, editionID, versionID string) (metadata models.Metadata, err error)
 	GetVersions(ctx context.Context, headers Headers, datasetID, editionID string, queryParams *QueryParams) (versionsList VersionsList, err error)
+	PutVersionState(ctx context.Context, headers Headers, datasetID, editionID, versionID, state string) (err error)
 }

--- a/sdk/mocks/client.go
+++ b/sdk/mocks/client.go
@@ -60,6 +60,9 @@ var _ sdk.Clienter = &ClienterMock{}
 //			HealthFunc: func() *health.Client {
 //				panic("mock out the Health method")
 //			},
+//			PutVersionStateFunc: func(ctx context.Context, headers sdk.Headers, datasetID string, editionID string, versionID string, state string) error {
+//				panic("mock out the PutVersionState method")
+//			},
 //			URLFunc: func() string {
 //				panic("mock out the URL method")
 //			},
@@ -105,6 +108,9 @@ type ClienterMock struct {
 
 	// HealthFunc mocks the Health method.
 	HealthFunc func() *health.Client
+
+	// PutVersionStateFunc mocks the PutVersionState method.
+	PutVersionStateFunc func(ctx context.Context, headers sdk.Headers, datasetID string, editionID string, versionID string, state string) error
 
 	// URLFunc mocks the URL method.
 	URLFunc func() string
@@ -241,6 +247,21 @@ type ClienterMock struct {
 		// Health holds details about calls to the Health method.
 		Health []struct {
 		}
+		// PutVersionState holds details about calls to the PutVersionState method.
+		PutVersionState []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Headers is the headers argument value.
+			Headers sdk.Headers
+			// DatasetID is the datasetID argument value.
+			DatasetID string
+			// EditionID is the editionID argument value.
+			EditionID string
+			// VersionID is the versionID argument value.
+			VersionID string
+			// State is the state argument value.
+			State string
+		}
 		// URL holds details about calls to the URL method.
 		URL []struct {
 		}
@@ -257,6 +278,7 @@ type ClienterMock struct {
 	lockGetVersionMetadata         sync.RWMutex
 	lockGetVersions                sync.RWMutex
 	lockHealth                     sync.RWMutex
+	lockPutVersionState            sync.RWMutex
 	lockURL                        sync.RWMutex
 }
 
@@ -780,6 +802,58 @@ func (mock *ClienterMock) HealthCalls() []struct {
 	mock.lockHealth.RLock()
 	calls = mock.calls.Health
 	mock.lockHealth.RUnlock()
+	return calls
+}
+
+// PutVersionState calls PutVersionStateFunc.
+func (mock *ClienterMock) PutVersionState(ctx context.Context, headers sdk.Headers, datasetID string, editionID string, versionID string, state string) error {
+	if mock.PutVersionStateFunc == nil {
+		panic("ClienterMock.PutVersionStateFunc: method is nil but Clienter.PutVersionState was just called")
+	}
+	callInfo := struct {
+		Ctx       context.Context
+		Headers   sdk.Headers
+		DatasetID string
+		EditionID string
+		VersionID string
+		State     string
+	}{
+		Ctx:       ctx,
+		Headers:   headers,
+		DatasetID: datasetID,
+		EditionID: editionID,
+		VersionID: versionID,
+		State:     state,
+	}
+	mock.lockPutVersionState.Lock()
+	mock.calls.PutVersionState = append(mock.calls.PutVersionState, callInfo)
+	mock.lockPutVersionState.Unlock()
+	return mock.PutVersionStateFunc(ctx, headers, datasetID, editionID, versionID, state)
+}
+
+// PutVersionStateCalls gets all the calls that were made to PutVersionState.
+// Check the length with:
+//
+//	len(mockedClienter.PutVersionStateCalls())
+func (mock *ClienterMock) PutVersionStateCalls() []struct {
+	Ctx       context.Context
+	Headers   sdk.Headers
+	DatasetID string
+	EditionID string
+	VersionID string
+	State     string
+} {
+	var calls []struct {
+		Ctx       context.Context
+		Headers   sdk.Headers
+		DatasetID string
+		EditionID string
+		VersionID string
+		State     string
+	}
+	mock.lockPutVersionState.RLock()
+	calls = mock.calls.PutVersionState
+	mock.lockPutVersionState.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
### What

Added `PutVersionState` method to the `Clienter` interface, and updated the `ClienterMock`

### How to review

Ensure the above is done correctly. The functionality has been tested previously in another PR, but this was missed.

### Who can review

Anyone but me