### PR TITLE
include state for getEditions and getEdition response

### DIFF
--- a/api/editions_test.go
+++ b/api/editions_test.go
@@ -39,6 +39,7 @@ var exampleStaticVersion = &models.Version{
 		},
 	},
 	LastUpdated: time.Date(2025, 3, 11, 0, 0, 0, 0, time.UTC),
+	State:       models.AssociatedState,
 }
 
 func TestGetEditionsReturnsOK(t *testing.T) {
@@ -92,6 +93,7 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 						Self:          &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023", ID: "2023"},
 						Versions:      &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023/versions", ID: ""},
 					},
+					State: models.PublishedState,
 					Alerts: &[]models.Alert{
 						{
 							Date:        "",
@@ -129,6 +131,7 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 						Self:          &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023", ID: "2023"},
 						Versions:      &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023/versions", ID: ""},
 					},
+					State: models.PublishedState,
 					Alerts: &[]models.Alert{
 						{
 							Date:        "",
@@ -284,6 +287,7 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 						Self:          &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023", ID: "2023"},
 						Versions:      &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023/versions", ID: ""},
 					},
+					State: models.PublishedState,
 					Alerts: &[]models.Alert{
 						{
 							Date:        "",
@@ -321,6 +325,7 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 						Self:          &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023", ID: "2023"},
 						Versions:      &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023/versions", ID: ""},
 					},
+					State: models.AssociatedState,
 					Alerts: &[]models.Alert{
 						{
 							Date:        "",
@@ -452,7 +457,7 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 			UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
 			Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
 			QualityDesignation: "Test quality designation",
-			State:              "assosiated",
+			State:              "associated",
 		}
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -108,6 +108,7 @@ func MapVersionToEdition(version *models.Version) *models.Edition {
 				HRef: version.Links.Edition.HRef + "/versions",
 			},
 		},
+		State:              version.State,
 		Version:            version.Version,
 		LastUpdated:        version.LastUpdated,
 		Alerts:             version.Alerts,

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -40,6 +40,7 @@ func TestMapVersionToEdition(t *testing.T) {
 					ID:   "2023",
 				},
 			},
+			State:              models.AssociatedState,
 			Version:            1,
 			LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
 			Alerts:             &[]models.Alert{{Description: "Test alert"}},
@@ -62,6 +63,7 @@ func TestMapVersionToEdition(t *testing.T) {
 				So(edition.Links.Self.HRef, ShouldEqual, version.Links.Edition.HRef)
 				So(edition.Links.Self.ID, ShouldEqual, version.Links.Edition.ID)
 				So(edition.Links.Versions.HRef, ShouldEqual, version.Links.Edition.HRef+"/versions")
+				So(edition.State, ShouldEqual, version.State)
 				So(edition.Version, ShouldEqual, version.Version)
 				So(edition.LastUpdated, ShouldEqual, version.LastUpdated)
 				So(edition.Alerts, ShouldResemble, version.Alerts)
@@ -150,6 +152,7 @@ func TestMapVersionsToEditions(t *testing.T) {
 				So(edition.Current.UsageNotes, ShouldResemble, publishedVersion.UsageNotes)
 				So(edition.Current.Distributions, ShouldResemble, publishedVersion.Distributions)
 				So(edition.Current.QualityDesignation, ShouldEqual, publishedVersion.QualityDesignation)
+				So(edition.Current.State, ShouldEqual, publishedVersion.State)
 			})
 
 			Convey("And the unpublished version should be mapped to the 'Next' field", func() {
@@ -169,6 +172,7 @@ func TestMapVersionsToEditions(t *testing.T) {
 				So(edition.Next.UsageNotes, ShouldResemble, unpublishedVersion.UsageNotes)
 				So(edition.Next.Distributions, ShouldResemble, unpublishedVersion.Distributions)
 				So(edition.Next.QualityDesignation, ShouldEqual, unpublishedVersion.QualityDesignation)
+				So(edition.Next.State, ShouldEqual, unpublishedVersion.State)
 			})
 		})
 
@@ -193,6 +197,7 @@ func TestMapVersionsToEditions(t *testing.T) {
 				So(edition.Current.UsageNotes, ShouldResemble, publishedVersion.UsageNotes)
 				So(edition.Current.Distributions, ShouldResemble, publishedVersion.Distributions)
 				So(edition.Current.QualityDesignation, ShouldEqual, publishedVersion.QualityDesignation)
+				So(edition.Current.State, ShouldEqual, publishedVersion.State)
 
 				So(edition.Next.DatasetID, ShouldEqual, publishedVersion.DatasetID)
 				So(edition.Next.Edition, ShouldEqual, publishedVersion.Edition)
@@ -210,6 +215,7 @@ func TestMapVersionsToEditions(t *testing.T) {
 				So(edition.Next.UsageNotes, ShouldResemble, publishedVersion.UsageNotes)
 				So(edition.Next.Distributions, ShouldResemble, publishedVersion.Distributions)
 				So(edition.Next.QualityDesignation, ShouldEqual, publishedVersion.QualityDesignation)
+				So(edition.Next.State, ShouldEqual, publishedVersion.State)
 			})
 		})
 
@@ -235,6 +241,7 @@ func TestMapVersionsToEditions(t *testing.T) {
 				So(edition.Next.UsageNotes, ShouldResemble, unpublishedVersion.UsageNotes)
 				So(edition.Next.Distributions, ShouldResemble, unpublishedVersion.Distributions)
 				So(edition.Next.QualityDesignation, ShouldEqual, unpublishedVersion.QualityDesignation)
+				So(edition.Next.State, ShouldEqual, unpublishedVersion.State)
 			})
 		})
 


### PR DESCRIPTION
### What

Return `state` field when calling `getEditions` and `getEdition` for static datasets

### How to review

Check changes are ok
call `getEditions` and `getEdition` for static datasets that have published/unpublished versions

### Who can review

Anyone
