### PR TITLE
chore: Remove CVE-2025-4673 ignore

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,1 +1,0 @@
-CVE-2025-4673 # Ignored due to golang.org/x/net v0.41.0 being the latest release


### PR DESCRIPTION
### What

v0.41.0 does not contain the exploit so this should be unneeded.

### How to review

Ensure the audit test passed for this PR

### Who can review

Anyone but me