### PR TITLE
set default version type to static when POST /versions called

### DIFF
--- a/api/static_versions.go
+++ b/api/static_versions.go
@@ -111,6 +111,12 @@ func (api *DatasetAPI) addDatasetVersionCondensed(ctx context.Context, w http.Re
 		return nil, models.NewErrorResponse(http.StatusBadRequest, nil, models.NewValidationError(ctx, models.ErrMissingParameters, models.ErrMissingParametersDescription+" "+strings.Join(missingFields, " ")))
 	}
 
+	// validate versiontype
+	if versionRequest.Type != "" && versionRequest.Type != models.Static.String() {
+		log.Error(ctx, "addDatasetVersionCondensed endpoint: only allowed to create static type versions", errs.ErrInvalidQueryParameter, logData)
+		return nil, models.NewErrorResponse(http.StatusBadRequest, nil, models.NewValidationError(ctx, models.ErrInvalidQueryParameter, models.ErrInvalidType))
+	}
+
 	// Validate dataset existence
 	if err := api.dataStore.Backend.CheckDatasetExists(ctx, datasetID, ""); err != nil {
 		log.Error(ctx, "failed to find dataset", err, logData)
@@ -145,6 +151,7 @@ func (api *DatasetAPI) addDatasetVersionCondensed(ctx context.Context, w http.Re
 	versionRequest.Version = nextVersion
 	versionRequest.DatasetID = datasetID
 	versionRequest.Links = api.generateVersionLinks(datasetID, edition, nextVersion, versionRequest.Links)
+	versionRequest.Type = models.Static.String()
 
 	// Store version in 'versions' collection
 	newVersion, err := api.dataStore.Backend.AddVersionStatic(ctx, versionRequest)

--- a/models/error_content.go
+++ b/models/error_content.go
@@ -1,19 +1,20 @@
 package models
 
 const (
-	BodyReadError           = "RequestBodyReadError"
-	JSONMarshalError        = "JSONMarshalError"
-	JSONUnmarshalError      = "JSONUnmarshalError"
-	WriteResponseError      = "WriteResponseError"
-	ErrDatasetNotFound      = "ErrDatasetNotFound"
-	ErrMissingParameters    = "ErrMissingParameters"
-	ErrVersionAlreadyExists = "ErrVersionAlreadyExists"
-	InternalError           = "InternalServerError"
-	NotFoundError           = "NotFound"
-	MissingConfigError      = "MissingConfig"
-	UnknownRequestTypeError = "UnknownRequestType"
-	NotImplementedError     = "NotImplemented"
-	BodyCloseError          = "BodyCloseError"
+	BodyReadError            = "RequestBodyReadError"
+	JSONMarshalError         = "JSONMarshalError"
+	JSONUnmarshalError       = "JSONUnmarshalError"
+	WriteResponseError       = "WriteResponseError"
+	ErrDatasetNotFound       = "ErrDatasetNotFound"
+	ErrMissingParameters     = "ErrMissingParameters"
+	ErrVersionAlreadyExists  = "ErrVersionAlreadyExists"
+	InternalError            = "InternalServerError"
+	NotFoundError            = "NotFound"
+	MissingConfigError       = "MissingConfig"
+	UnknownRequestTypeError  = "UnknownRequestType"
+	NotImplementedError      = "NotImplemented"
+	BodyCloseError           = "BodyCloseError"
+	ErrInvalidQueryParameter = "invalid query parameter"
 )
 
 // API error descriptions
@@ -29,4 +30,5 @@ const (
 	ErrDatasetNotFoundDescription      = "dataset not found"
 	ErrMissingParametersDescription    = "missing properties in JSON"
 	ErrVersionAlreadyExistsDescription = "an unpublished version of this dataset already exists"
+	ErrInvalidType                     = "version type should be static"
 )


### PR DESCRIPTION
### What

- updated POST /versions endpoint to check the type. if empty static type is  set, if not static: 400 error is thrown. 

### How to review

- check if when POST /version endpoint is called, the type is set properly or 400 error is thrown.
 
### Who can review

anyone