### PR TITLE
Feature/add search by dataset id param

### DIFF
--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -262,7 +262,7 @@ func TestGetDatasetsReturnsOK(t *testing.T) {
 		So(err, ShouldBeNil)
 		r.URL = address
 		mockedDataStore := &storetest.StorerMock{
-			GetDatasetsByQueryParamsFunc: func(ctx context.Context, ID, datasetType, sortOrder string, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
+			GetDatasetsByQueryParamsFunc: func(ctx context.Context, ID, datasetType, sortOrder, datasetID string, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
 				return []*models.DatasetUpdate{{ID: "123-456", Current: &models.Dataset{ID: "123-456", Type: "static"}, Next: &models.Dataset{ID: "123-456", Type: "static"}}}, 1, nil
 			},
 		}
@@ -287,7 +287,7 @@ func TestGetDatasetsReturnsOK(t *testing.T) {
 		So(err, ShouldBeNil)
 		r.URL = address
 		mockedDataStore := &storetest.StorerMock{
-			GetDatasetsByQueryParamsFunc: func(ctx context.Context, ID, datasetType, sortOrder string, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
+			GetDatasetsByQueryParamsFunc: func(ctx context.Context, ID, datasetType, sortOrder, datasetID string, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
 				return []*models.DatasetUpdate{{ID: "123-456", Current: &models.Dataset{ID: "123-456", Type: "static", IsBasedOn: &models.IsBasedOn{ID: "Example"}}, Next: &models.Dataset{ID: "123-456", Type: "static", IsBasedOn: &models.IsBasedOn{ID: "Example"}}}}, 1, nil
 			},
 		}
@@ -312,7 +312,7 @@ func TestGetDatasetsReturnsOK(t *testing.T) {
 		r.URL = address
 
 		mockedDataStore := &storetest.StorerMock{
-			GetDatasetsByQueryParamsFunc: func(ctx context.Context, ID, datasetType, sortOrder string, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
+			GetDatasetsByQueryParamsFunc: func(ctx context.Context, ID, datasetType, sortOrder, datasetID string, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
 				So(sortOrder, ShouldEqual, "ASC")
 				return []*models.DatasetUpdate{
 					{ID: "a-dataset", Current: &models.Dataset{ID: "a-dataset"}},
@@ -430,7 +430,7 @@ func TestGetDatasetsReturnsError(t *testing.T) {
 		So(err, ShouldBeNil)
 		r.URL = address
 		mockedDataStore := &storetest.StorerMock{
-			GetDatasetsByQueryParamsFunc: func(ctx context.Context, ID, datasetType, sortOrder string, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
+			GetDatasetsByQueryParamsFunc: func(ctx context.Context, ID, datasetType, sortOrder, datasetID string, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
 				return nil, 0, errs.ErrDatasetTypeInvalid
 			},
 		}

--- a/features/dataset_using_datasset_id.feature
+++ b/features/dataset_using_datasset_id.feature
@@ -1,0 +1,68 @@
+Feature: Dataset saearch by dataset_id
+
+    Background:
+        Given I have these datasets:
+            """
+            [
+                {
+                    "id": "static-dataset-1",
+                    "title": "Static Dataset 1",
+                    "state": "created",
+                    "type": "static"
+                },
+                {
+                    "id": "static-dataset-2",
+                    "title": "Static Dataset 2",
+                    "state": "created",
+                    "type": "static"
+                },
+                {
+                    "id": "static-dataset-3",
+                    "title": "Static Dataset 3",
+                    "state": "created",
+                    "type": "static"
+                },
+                {
+                    "id": "static-dataset-4",
+                    "title": "Static Dataset 4",
+                    "state": "created",
+                    "type": "static"
+                }
+            ]
+            """
+
+    Scenario: Using an existing dataset_id as the param
+        When I GET "/datasets?dataset_id=static-dataset-4"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "count": 1,
+                "total_count": 1,
+                "limit": 20,
+                "offset": 0,
+                "items": [
+                    {
+                        "id": "static-dataset-4",
+                        "title": "Static Dataset 4",
+                        "state": "created",
+                        "type": "static",
+                        "last_updated": "0001-01-01T00:00:00Z"
+                    }
+                ]
+            }
+            """
+    Scenario: dataset_id is invalid
+        When I GET "/datasets?dataset_id=invalid-dataset-id"
+        Then the HTTP status code should be "404"
+        And I should receive the following response:
+            """
+            dataset not found
+            """
+
+    Scenario: dataset_id is empty
+        When I GET "/datasets?dataset_id="
+        Then the HTTP status code should be "400"
+        And I should receive the following response:
+            """
+            invalid query parameter
+            """

--- a/mocks/generate_downloads_mocks.go
+++ b/mocks/generate_downloads_mocks.go
@@ -4,7 +4,6 @@
 package mocks
 
 import (
-	//"github.com/ONSdigital/dp-dataset-api/download"
 	kafka "github.com/ONSdigital/dp-kafka/v4"
 	"sync"
 )

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -100,7 +100,10 @@ func buildDatasetsQueryUsingParameters(based_on_id, datasetType, dataset_id stri
 
 		// Create the filter for the dataset ID using the converted ObjectID
 		datasetIdFilter := bson.M{
-			"_id": bson.M{"$eq": dataset_id},
+			"_id": bson.M{
+				"$regex":   dataset_id,
+				"$options": "i", // Case-insensitive (optional)
+			},
 		}
 
 		if len(filter) > 0 {

--- a/mongo/dataset_test.go
+++ b/mongo/dataset_test.go
@@ -333,12 +333,12 @@ func TestVersionUpdateQuery(t *testing.T) {
 	})
 }
 
-func TestBuildDatasetsQueryWithIsBasedOnAndType(t *testing.T) {
+func TestBuildDatasetsQueryUsingParameters(t *testing.T) {
 	t.Parallel()
 
 	Convey("When no datasetType and id are provided", t, func() {
 		expectedFilter := bson.M{}
-		filter, err := buildDatasetsQueryWithIsBasedOnAndType("", "", true)
+		filter, err := buildDatasetsQueryUsingParameters("", "", "", true)
 
 		So(err, ShouldBeNil)
 		So(filter, ShouldResemble, expectedFilter)
@@ -352,7 +352,7 @@ func TestBuildDatasetsQueryWithIsBasedOnAndType(t *testing.T) {
 				bson.M{"next.type": mockDatasetType.String()},
 			},
 		}
-		filter, err := buildDatasetsQueryWithIsBasedOnAndType("", mockDatasetType.String(), true)
+		filter, err := buildDatasetsQueryUsingParameters("", mockDatasetType.String(), "", true)
 
 		So(err, ShouldBeNil)
 		So(filter, ShouldResemble, expectedFilter)
@@ -367,7 +367,7 @@ func TestBuildDatasetsQueryWithIsBasedOnAndType(t *testing.T) {
 			},
 		}
 
-		filter, err := buildDatasetsQueryWithIsBasedOnAndType(mockID, "", true)
+		filter, err := buildDatasetsQueryUsingParameters(mockID, "", "", true)
 
 		So(err, ShouldBeNil)
 		So(filter, ShouldResemble, expectedFilter)
@@ -393,7 +393,7 @@ func TestBuildDatasetsQueryWithIsBasedOnAndType(t *testing.T) {
 			},
 		}
 
-		filter, err := buildDatasetsQueryWithIsBasedOnAndType(mockID, mockDatasetType.String(), true)
+		filter, err := buildDatasetsQueryUsingParameters(mockID, mockDatasetType.String(), "", true)
 
 		So(err, ShouldBeNil)
 		So(filter, ShouldResemble, expectedFilter)
@@ -404,7 +404,7 @@ func TestBuildDatasetsQueryWithIsBasedOnAndType(t *testing.T) {
 			"current": bson.M{"$exists": true},
 		}
 
-		filter, err := buildDatasetsQueryWithIsBasedOnAndType("", "", false)
+		filter, err := buildDatasetsQueryUsingParameters("", "", "", false)
 
 		So(err, ShouldBeNil)
 		So(filter, ShouldResemble, expectedFilter)
@@ -431,7 +431,7 @@ func TestBuildDatasetsQueryWithIsBasedOnAndType(t *testing.T) {
 			"current": bson.M{"$exists": true},
 		}
 
-		filter, err := buildDatasetsQueryWithIsBasedOnAndType(mockID, mockDatasetType.String(), false)
+		filter, err := buildDatasetsQueryUsingParameters(mockID, mockDatasetType.String(), "", false)
 
 		So(err, ShouldBeNil)
 		So(filter, ShouldResemble, expectedFilter)
@@ -440,7 +440,7 @@ func TestBuildDatasetsQueryWithIsBasedOnAndType(t *testing.T) {
 	Convey("When an invalid datasetType is provided", t, func() {
 		invalidType := "invalid_type"
 
-		filter, err := buildDatasetsQueryWithIsBasedOnAndType("", invalidType, true)
+		filter, err := buildDatasetsQueryUsingParameters("", invalidType, "", true)
 
 		So(err, ShouldNotBeNil)
 		So(filter, ShouldBeNil)

--- a/mongo/dataset_test.go
+++ b/mongo/dataset_test.go
@@ -336,7 +336,7 @@ func TestVersionUpdateQuery(t *testing.T) {
 func TestBuildDatasetsQueryUsingParameters(t *testing.T) {
 	t.Parallel()
 
-	Convey("When no datasetType and id are provided", t, func() {
+	Convey("When no datasetType and is_based_on are provided", t, func() {
 		expectedFilter := bson.M{}
 		filter, err := buildDatasetsQueryUsingParameters("", "", "", true)
 
@@ -358,7 +358,7 @@ func TestBuildDatasetsQueryUsingParameters(t *testing.T) {
 		So(filter, ShouldResemble, expectedFilter)
 	})
 
-	Convey("When an id is provided", t, func() {
+	Convey("When an is_based_on is provided", t, func() {
 		mockID := "12345"
 		expectedFilter := bson.M{
 			"$or": bson.A{
@@ -373,7 +373,7 @@ func TestBuildDatasetsQueryUsingParameters(t *testing.T) {
 		So(filter, ShouldResemble, expectedFilter)
 	})
 
-	Convey("When both datasetType and id are provided", t, func() {
+	Convey("When both datasetType and is_based_on are provided", t, func() {
 		mockID := "12345"
 		mockDatasetType := models.Static
 		expectedFilter := bson.M{
@@ -394,6 +394,38 @@ func TestBuildDatasetsQueryUsingParameters(t *testing.T) {
 		}
 
 		filter, err := buildDatasetsQueryUsingParameters(mockID, mockDatasetType.String(), "", true)
+
+		So(err, ShouldBeNil)
+		So(filter, ShouldResemble, expectedFilter)
+	})
+
+	Convey("When both dataset_id is provided", t, func() {
+		mockID := "12345"
+		expectedFilter := bson.M{"_id": bson.M{"$eq": mockID}}
+
+		filter, err := buildDatasetsQueryUsingParameters("", "", mockID, true)
+
+		So(err, ShouldBeNil)
+		So(filter, ShouldResemble, expectedFilter)
+	})
+
+	Convey("When dataset_type is 'static' and dataset_id is provided", t, func() {
+		mockID := "12345"
+		mockType := models.Static
+
+		expectedFilter := bson.M{
+			"$and": bson.A{
+				bson.M{
+					"$or": bson.A{
+						bson.M{"current.type": mockType.String()},
+						bson.M{"next.type": mockType.String()},
+					},
+				},
+				bson.M{"_id": bson.M{"$eq": mockID}},
+			},
+		}
+
+		filter, err := buildDatasetsQueryUsingParameters("", mockType.String(), mockID, true)
 
 		So(err, ShouldBeNil)
 		So(filter, ShouldResemble, expectedFilter)

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -30,7 +30,7 @@ type dataMongoDB interface {
 	GetDataset(ctx context.Context, ID string) (*models.DatasetUpdate, error)
 	GetUnpublishedDatasetStatic(ctx context.Context, id string) (*models.Dataset, error)
 	GetDatasets(ctx context.Context, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
-	GetDatasetsByQueryParams(ctx context.Context, ID, datasetType, sortOrder string, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
+	GetDatasetsByQueryParams(ctx context.Context, ID, datasetType, sortOrder, datasetID string, offset, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
 	GetDatasetType(ctx context.Context, datasetID string, authorised bool) (string, error)
 	GetDimensionsFromInstance(ctx context.Context, ID string, offset, limit int) ([]*models.DimensionOption, int, error)
 	GetDimensions(ctx context.Context, versionID string) ([]bson.M, error)

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -69,7 +69,7 @@ var _ store.Storer = &StorerMock{}
 //			GetDatasetsFunc: func(ctx context.Context, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
 //				panic("mock out the GetDatasets method")
 //			},
-//			GetDatasetsByQueryParamsFunc: func(ctx context.Context, ID string, datasetType string, sortOrder string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
+//			GetDatasetsByQueryParamsFunc: func(ctx context.Context, ID string, datasetType string, sortOrder string, datasetID string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
 //				panic("mock out the GetDatasetsByQueryParams method")
 //			},
 //			GetDimensionOptionsFunc: func(ctx context.Context, version *models.Version, dimension string, offset int, limit int) ([]*models.PublicDimensionOption, int, error) {
@@ -245,7 +245,7 @@ type StorerMock struct {
 	GetDatasetsFunc func(ctx context.Context, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
 
 	// GetDatasetsByQueryParamsFunc mocks the GetDatasetsByQueryParams method.
-	GetDatasetsByQueryParamsFunc func(ctx context.Context, ID string, datasetType string, sortOrder string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
+	GetDatasetsByQueryParamsFunc func(ctx context.Context, ID string, datasetType string, sortOrder string, datasetID string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
 
 	// GetDimensionOptionsFunc mocks the GetDimensionOptions method.
 	GetDimensionOptionsFunc func(ctx context.Context, version *models.Version, dimension string, offset int, limit int) ([]*models.PublicDimensionOption, int, error)
@@ -520,6 +520,8 @@ type StorerMock struct {
 			DatasetType string
 			// SortOrder is the sortOrder argument value.
 			SortOrder string
+			// DatasetID is the datasetID argument value.
+			DatasetID string
 			// Offset is the offset argument value.
 			Offset int
 			// Limit is the limit argument value.
@@ -1640,7 +1642,7 @@ func (mock *StorerMock) GetDatasetsCalls() []struct {
 }
 
 // GetDatasetsByQueryParams calls GetDatasetsByQueryParamsFunc.
-func (mock *StorerMock) GetDatasetsByQueryParams(ctx context.Context, ID string, datasetType string, sortOrder string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
+func (mock *StorerMock) GetDatasetsByQueryParams(ctx context.Context, ID string, datasetType string, sortOrder string, datasetID string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
 	if mock.GetDatasetsByQueryParamsFunc == nil {
 		panic("StorerMock.GetDatasetsByQueryParamsFunc: method is nil but Storer.GetDatasetsByQueryParams was just called")
 	}
@@ -1649,6 +1651,7 @@ func (mock *StorerMock) GetDatasetsByQueryParams(ctx context.Context, ID string,
 		ID          string
 		DatasetType string
 		SortOrder   string
+		DatasetID   string
 		Offset      int
 		Limit       int
 		Authorised  bool
@@ -1657,6 +1660,7 @@ func (mock *StorerMock) GetDatasetsByQueryParams(ctx context.Context, ID string,
 		ID:          ID,
 		DatasetType: datasetType,
 		SortOrder:   sortOrder,
+		DatasetID:   datasetID,
 		Offset:      offset,
 		Limit:       limit,
 		Authorised:  authorised,
@@ -1664,7 +1668,7 @@ func (mock *StorerMock) GetDatasetsByQueryParams(ctx context.Context, ID string,
 	mock.lockGetDatasetsByQueryParams.Lock()
 	mock.calls.GetDatasetsByQueryParams = append(mock.calls.GetDatasetsByQueryParams, callInfo)
 	mock.lockGetDatasetsByQueryParams.Unlock()
-	return mock.GetDatasetsByQueryParamsFunc(ctx, ID, datasetType, sortOrder, offset, limit, authorised)
+	return mock.GetDatasetsByQueryParamsFunc(ctx, ID, datasetType, sortOrder, datasetID, offset, limit, authorised)
 }
 
 // GetDatasetsByQueryParamsCalls gets all the calls that were made to GetDatasetsByQueryParams.
@@ -1676,6 +1680,7 @@ func (mock *StorerMock) GetDatasetsByQueryParamsCalls() []struct {
 	ID          string
 	DatasetType string
 	SortOrder   string
+	DatasetID   string
 	Offset      int
 	Limit       int
 	Authorised  bool
@@ -1685,6 +1690,7 @@ func (mock *StorerMock) GetDatasetsByQueryParamsCalls() []struct {
 		ID          string
 		DatasetType string
 		SortOrder   string
+		DatasetID   string
 		Offset      int
 		Limit       int
 		Authorised  bool

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -73,7 +73,7 @@ var _ store.MongoDB = &MongoDBMock{}
 //			GetDatasetsFunc: func(ctx context.Context, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
 //				panic("mock out the GetDatasets method")
 //			},
-//			GetDatasetsByQueryParamsFunc: func(ctx context.Context, ID string, datasetType string, sortOrder string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
+//			GetDatasetsByQueryParamsFunc: func(ctx context.Context, ID string, datasetType string, sortOrder string, datasetID string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
 //				panic("mock out the GetDatasetsByQueryParams method")
 //			},
 //			GetDimensionOptionsFunc: func(ctx context.Context, version *models.Version, dimension string, offset int, limit int) ([]*models.PublicDimensionOption, int, error) {
@@ -249,7 +249,7 @@ type MongoDBMock struct {
 	GetDatasetsFunc func(ctx context.Context, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
 
 	// GetDatasetsByQueryParamsFunc mocks the GetDatasetsByQueryParams method.
-	GetDatasetsByQueryParamsFunc func(ctx context.Context, ID string, datasetType string, sortOrder string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
+	GetDatasetsByQueryParamsFunc func(ctx context.Context, ID string, datasetType string, sortOrder string, datasetID string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error)
 
 	// GetDimensionOptionsFunc mocks the GetDimensionOptions method.
 	GetDimensionOptionsFunc func(ctx context.Context, version *models.Version, dimension string, offset int, limit int) ([]*models.PublicDimensionOption, int, error)
@@ -520,6 +520,8 @@ type MongoDBMock struct {
 			DatasetType string
 			// SortOrder is the sortOrder argument value.
 			SortOrder string
+			// DatasetID is the datasetID argument value.
+			DatasetID string
 			// Offset is the offset argument value.
 			Offset int
 			// Limit is the limit argument value.
@@ -1653,7 +1655,7 @@ func (mock *MongoDBMock) GetDatasetsCalls() []struct {
 }
 
 // GetDatasetsByQueryParams calls GetDatasetsByQueryParamsFunc.
-func (mock *MongoDBMock) GetDatasetsByQueryParams(ctx context.Context, ID string, datasetType string, sortOrder string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
+func (mock *MongoDBMock) GetDatasetsByQueryParams(ctx context.Context, ID string, datasetType string, sortOrder string, datasetID string, offset int, limit int, authorised bool) ([]*models.DatasetUpdate, int, error) {
 	if mock.GetDatasetsByQueryParamsFunc == nil {
 		panic("MongoDBMock.GetDatasetsByQueryParamsFunc: method is nil but MongoDB.GetDatasetsByQueryParams was just called")
 	}
@@ -1662,6 +1664,7 @@ func (mock *MongoDBMock) GetDatasetsByQueryParams(ctx context.Context, ID string
 		ID          string
 		DatasetType string
 		SortOrder   string
+		DatasetID   string
 		Offset      int
 		Limit       int
 		Authorised  bool
@@ -1670,6 +1673,7 @@ func (mock *MongoDBMock) GetDatasetsByQueryParams(ctx context.Context, ID string
 		ID:          ID,
 		DatasetType: datasetType,
 		SortOrder:   sortOrder,
+		DatasetID:   datasetID,
 		Offset:      offset,
 		Limit:       limit,
 		Authorised:  authorised,
@@ -1677,7 +1681,7 @@ func (mock *MongoDBMock) GetDatasetsByQueryParams(ctx context.Context, ID string
 	mock.lockGetDatasetsByQueryParams.Lock()
 	mock.calls.GetDatasetsByQueryParams = append(mock.calls.GetDatasetsByQueryParams, callInfo)
 	mock.lockGetDatasetsByQueryParams.Unlock()
-	return mock.GetDatasetsByQueryParamsFunc(ctx, ID, datasetType, sortOrder, offset, limit, authorised)
+	return mock.GetDatasetsByQueryParamsFunc(ctx, ID, datasetType, sortOrder, datasetID, offset, limit, authorised)
 }
 
 // GetDatasetsByQueryParamsCalls gets all the calls that were made to GetDatasetsByQueryParams.
@@ -1689,6 +1693,7 @@ func (mock *MongoDBMock) GetDatasetsByQueryParamsCalls() []struct {
 	ID          string
 	DatasetType string
 	SortOrder   string
+	DatasetID   string
 	Offset      int
 	Limit       int
 	Authorised  bool
@@ -1698,6 +1703,7 @@ func (mock *MongoDBMock) GetDatasetsByQueryParamsCalls() []struct {
 		ID          string
 		DatasetType string
 		SortOrder   string
+		DatasetID   string
 		Offset      int
 		Limit       int
 		Authorised  bool


### PR DESCRIPTION
### What

- added query parameter dataset_id into GET /datasets endpoint
- added unit & component tests

### How to review

- check when GET /datasets?dataset_id=existing-dataset-id is called a valid response 200 is returned
- when invalid parameter "/datasets?dataset_id=" is called 400 is returned
- when invalid parameter "/datasets?dataset_id="non-existing-dataset" is called 400 is returned

### Who can review

anyone