### PR TITLE
Feature/update dp net and distribution rewriting tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.6.4
 	github.com/ONSdigital/dp-kafka/v4 v4.2.0
 	github.com/ONSdigital/dp-mongodb/v3 v3.8.0
-	github.com/ONSdigital/dp-net/v3 v3.3.0
+	github.com/ONSdigital/dp-net/v3 v3.4.0
 	github.com/ONSdigital/dp-otel-go v0.0.8
 	github.com/ONSdigital/log.go/v2 v2.4.6
 	github.com/cucumber/godog v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/ONSdigital/dp-net v1.0.12/go.mod h1:2lvIKOlD4T3BjWQwjHhBUO2UNWDk82u/+
 github.com/ONSdigital/dp-net v1.2.0/go.mod h1:NinlaqcsPbIR+X7j5PXCl3UI5G2zCL041SDF6WIiiO4=
 github.com/ONSdigital/dp-net/v2 v2.22.0 h1:LY9C5x1+sfK9QyjNpB2G3TPvAtSuOFR9FRcXsR9twqs=
 github.com/ONSdigital/dp-net/v2 v2.22.0/go.mod h1:F6yL3jjuVwBLVMFIKgHF3zhMRbmZysAxBiu+aIAi3Z0=
-github.com/ONSdigital/dp-net/v3 v3.3.0 h1:NAH9z+nvbJxoK6OnDpOyJJ+52dqBhVtaugk5bqEDt0Y=
-github.com/ONSdigital/dp-net/v3 v3.3.0/go.mod h1:ur4LLCvd2xW2jpa785pElE6HB2bPvszZxdAjqv0XFGg=
+github.com/ONSdigital/dp-net/v3 v3.4.0 h1:15PsiBoo78Bwu7HAt1m63Rv4VlE5FPCL6UOFX9iAPic=
+github.com/ONSdigital/dp-net/v3 v3.4.0/go.mod h1:ur4LLCvd2xW2jpa785pElE6HB2bPvszZxdAjqv0XFGg=
 github.com/ONSdigital/dp-otel-go v0.0.8 h1:jSX32oDmOUKlHyH3FPCBkBpiBKYmWKELoNo6jontKRM=
 github.com/ONSdigital/dp-otel-go v0.0.8/go.mod h1:pCDuFqZX8+7CBQX1nMlLMPj52VsMAN3Y8h0uLmzC3cU=
 github.com/ONSdigital/dp-permissions-api v1.0.0 h1:oUhELcS47C+BXhr62VNFUJr+thuE1db2EbifjpgXpV4=

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -6145,6 +6145,20 @@ func TestRewriteDistributions_Success(t *testing.T) {
 					DownloadURL: "/datasets/cpih01/editions/time-series/versions/1.xls",
 					ByteSize:    30000,
 				},
+				{
+					Title:       "Distribution 4",
+					Format:      "XLS",
+					MediaType:   "text/xls",
+					DownloadURL: "dataset-uploads/somefile.xls",
+					ByteSize:    40000,
+				},
+				{
+					Title:       "Distribution 5",
+					Format:      "XLSX",
+					MediaType:   "text/xlsx",
+					DownloadURL: "/dataset-uploads/somefile.xlsx",
+					ByteSize:    50000,
+				},
 			}
 
 			distributions, err := RewriteDistributions(ctx, distributions, downloadServiceURL)
@@ -6154,6 +6168,8 @@ func TestRewriteDistributions_Success(t *testing.T) {
 				So((*distributions)[0].DownloadURL, ShouldEqual, "http://localhost:23600/downloads-new/datasets/cpih01/editions/time-series/versions/1.csv")
 				So((*distributions)[1].DownloadURL, ShouldEqual, "http://localhost:23600/downloads-new/datasets/cpih01/editions/time-series/versions/1.xlsx")
 				So((*distributions)[2].DownloadURL, ShouldEqual, "http://localhost:23600/downloads-new/datasets/cpih01/editions/time-series/versions/1.xls")
+				So((*distributions)[3].DownloadURL, ShouldEqual, "http://localhost:23600/downloads-new/dataset-uploads/somefile.xls")
+				So((*distributions)[4].DownloadURL, ShouldEqual, "http://localhost:23600/downloads-new/dataset-uploads/somefile.xlsx")
 			})
 		})
 


### PR DESCRIPTION
### What

- Work part of https://officefornationalstatistics.atlassian.net/browse/DIS-3582
- Upgrade dp-net to use updated download link rewriting
- `download_url` can be rewritten with or without a `/` prefix

### How to review

Check changes are ok

- Run the `dataset-catalogue` stack
- Within the `versions` collection in mongo, edit version 2 so the `download_url` for both distributions are the following:
- First distribution `dataset-uploads/RM086/editions/2021/versions/2.csv` (doesn't have `/`)
- Second distribution `/dataset-uploads/RM086/editions/2021/versions/2.csv` (has `/`)
- Try  the `GET` `/editions`, `/editions/{edition-id}`, `/versions`, and `/versions/{version}` endpoints and ensure the `download_url` returned is the correct format for version 2.
- Example path for version 2 is `/datasets/static-test-dataset/editions/time-series/versions/2`
- Correct format is `http://localhost:23600/downloads-new/dataset-uploads/RM086/editions/2021/versions/2.csv`

### Who can review

Anyone
