### PR TITLE
add component tests for PUT and POST static versions

### DIFF
--- a/features/static_versions_post.feature
+++ b/features/static_versions_post.feature
@@ -1,0 +1,154 @@
+Feature: Static Dataset Versions POST API
+
+    Background: We have static datasets for POST version testing
+        Given I have these datasets:
+            """
+            [
+                {
+                    "id": "static-dataset-test",
+                    "title": "Static dataset Test",
+                    "state": "created",
+                    "type": "static"
+                },
+                {
+                    "id": "static-dataset-existing",
+                    "title": "static dataset with published version",
+                    "state": "associated",
+                    "type": "static"
+                }
+            ]
+            """
+        And I have these static versions:
+            """
+            [
+                {
+                    "id": "static-version-published",
+                    "edition": "2024",
+                    "edition_title": "2024 Edition",
+                    "links": {
+                        "dataset": {
+                            "id": "static-dataset-existing"
+                        },
+                        "edition": {
+                            "href": "/datasets/static-dataset-existing/editions/2024",
+                            "id": "2024"
+                        }
+                    },
+                    "version": 1,
+                    "release_date": "2024-01-01T09:00:00.000Z",
+                    "state": "published",
+                    "type": "static",
+                    "distributions": [
+                        {
+                            "title": "Published Dataset CSV",
+                            "format": "csv",
+                            "media_type": "text/csv",
+                            "download_url": "/downloads/datasets/static-dataset-existing/editions/2024/versions/1.csv",
+                            "byte_size": 150000
+                        }
+                    ]
+                }
+            ]
+            """
+
+    Scenario: POST creates a new static dataset version successfully
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I POST "/datasets/static-dataset-test/editions/2024/versions"
+            """
+            {
+                "release_date": "2024-12-01T09:00:00.000Z",
+                "edition_title": "2024",
+                "type": "static",
+                "distributions": [
+                    {
+                        "title": "Full Dataset CSV",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "download_url": "/downloads/datasets/static-dataset-test/editions/2024/versions/1.csv",
+                        "byte_size": 100000
+                    }
+                ]
+            }
+            """
+        Then the HTTP status code should be "201"
+
+    Scenario: POST creates version 2 when version 1 is published
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I POST "/datasets/static-dataset-existing/editions/2024/versions"
+            """
+            {
+                "release_date": "2024-06-01T09:00:00.000Z",
+                "edition_title": "2024 Edition Updated",
+                "type": "static",
+                "distributions": [
+                    {
+                        "title": "Updated Dataset CSV",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "download_url": "/downloads/datasets/static-dataset-existing/editions/2024/versions/2.csv",
+                        "byte_size": 200000
+                    }
+                ]
+            }
+            """
+        Then the HTTP status code should be "201"
+
+    Scenario: POST fails with missing mandatory fields
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I POST "/datasets/static-dataset-test/editions/2024/versions"
+            """
+            {
+                "type": "static"
+            }
+            """
+        Then the HTTP status code should be "400"
+
+    Scenario: POST fails for non-existent dataset
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I POST "/datasets/non-existent-dataset/editions/2024/versions"
+            """
+            {
+                "release_date": "2024-12-01T09:00:00.000Z",
+                "edition_title": "Test Edition",
+                "type": "static",
+                "distributions": [
+                    {
+                        "title": "Test CSV",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "download_url": "/downloads/test.csv",
+                        "byte_size": 100000
+                    }
+                ]
+            }
+            """
+        Then the HTTP status code should be "404"
+
+    Scenario: POST fails when not authorised
+        Given private endpoints are enabled
+        When I POST "/datasets/static-dataset-test/editions/2024/versions"
+            """
+            {
+                "release_date": "2024-12-01T09:00:00.000Z",
+                "edition_title": "Test Edition",
+                "type": "static",
+                "distributions": [
+                    {
+                        "title": "Test CSV",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "download_url": "/downloads/test.csv",
+                        "byte_size": 100000
+                    }
+                ]
+            }
+            """
+        Then the HTTP status code should be "401"

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -1,0 +1,294 @@
+Feature: Static Dataset Versions PUT API
+
+    Background: We have static datasets for PUT version testing
+        Given I have a static dataset with version:
+            """
+            {
+                "dataset": {
+                    "id": "static-dataset-update",
+                    "title": "Static Dataset for Updates",
+                    "state": "associated",
+                    "type": "static"
+                },
+                "edition": {
+                    "edition": "2025",
+                    "edition_title": "2025 Edition"
+                },
+                "version": {
+                    "id": "static-version-update",
+                    "edition": "2025",
+                    "edition_title": "2025 Edition",
+                    "links": {
+                        "dataset": {
+                            "id": "static-dataset-update"
+                        },
+                        "edition": {
+                            "href": "/datasets/static-dataset-update/editions/2025",
+                            "id": "2025"
+                        },
+                        "self": {
+                            "href": "/datasets/static-dataset-update/editions/2025/versions/1"
+                        }
+                    },
+                    "version": 1,
+                    "release_date": "2025-01-01T09:00:00.000Z",
+                    "state": "associated",
+                    "type": "static",
+                    "distributions": [
+                        {
+                            "title": "csv",
+                            "format": "csv",
+                            "media_type": "text/csv",
+                            "download_url": "/downloads/datasets/static-dataset-update/editions/2025/versions/1.csv",
+                            "byte_size": 125000
+                        }
+                    ]
+                }
+            }
+            """
+
+    Scenario: PUT updates static dataset version successfully
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I PUT "/datasets/static-dataset-update/editions/2025/versions/1"
+            """
+            {
+                "state": "approved",
+                "type": "static"
+            }
+            """
+        Then the HTTP status code should be "200"
+        And I should receive the following JSON response:
+            """
+            {
+                "dataset_id": "static-dataset-update",
+                "distributions": [
+                    {
+                        "byte_size": 125000,
+                        "download_url": "/downloads/datasets/static-dataset-update/editions/2025/versions/1.csv",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "title": "csv"
+                    }
+                ],
+                "edition": "2025",
+                "id": "static-version-update",
+                "last_updated": "0001-01-01T00:00:00Z",
+                "links": {
+                    "dataset": {
+                        "id": "static-dataset-update"
+                    },
+                    "edition": {
+                        "href": "/datasets/static-dataset-update/editions/2025",
+                        "id": "2025"
+                    },
+                    "self": {
+                        "href": "/datasets/static-dataset-update/editions/2025/versions/1"
+                    }
+                },
+                "release_date": "2025-01-01T09:00:00.000Z",
+                "state": "approved",
+                "type": "static"
+            }
+            """
+
+    Scenario: PUT updates static dataset version with new data
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I PUT "/datasets/static-dataset-update/editions/2025/versions/1"
+            """
+            {
+                "release_date": "2025-03-01T09:00:00.000Z",
+                "edition_title": "Updated 2025 Edition",
+                "state": "approved",
+                "type": "static"
+            }
+            """
+        Then the HTTP status code should be "200"
+
+    Scenario: PUT updates static dataset version distributions
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I PUT "/datasets/static-dataset-update/editions/2025/versions/1"
+            """
+            {
+                "distributions": [
+                    {
+                        "title": "updated csv",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "download_url": "/downloads/datasets/static-dataset-update/editions/2025/versions/1-updated.csv",
+                        "byte_size": 150000
+                    },
+                    {
+                        "title": "xlsx",
+                        "format": "xlsx",
+                        "media_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                        "download_url": "/downloads/datasets/static-dataset-update/editions/2025/versions/1.xlsx",
+                        "byte_size": 175000
+                    }
+                ],
+                "type": "static"
+            }
+            """
+        Then the HTTP status code should be "200"
+
+    Scenario: PUT updates static dataset version edition
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I PUT "/datasets/static-dataset-update/editions/2025/versions/1"
+            """
+            {
+                "edition": "2025-revised",
+                "edition_title": "2025 Revised Edition",
+                "type": "static"
+            }
+            """
+        Then the HTTP status code should be "200"
+
+    Scenario: PUT fails for non-existent version
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I PUT "/datasets/static-dataset-update/editions/2025/versions/999"
+            """
+            {
+                "state": "approved",
+                "type": "static"
+            }
+            """
+        Then the HTTP status code should be "404"
+
+    Scenario: PUT fails for non-existent dataset
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I PUT "/datasets/non-existent/editions/2025/versions/1"
+            """
+            {
+                "state": "approved",
+                "type": "static"
+            }
+            """
+        Then the HTTP status code should be "404"
+
+    Scenario: PUT fails when not authorised
+        Given private endpoints are enabled
+        When I PUT "/datasets/static-dataset-update/editions/2025/versions/1"
+            """
+            {
+                "state": "approved",
+                "type": "static"
+            }
+            """
+        Then the HTTP status code should be "401"
+
+    Scenario: PUT state endpoint updates successfully
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I PUT "/datasets/static-dataset-update/editions/2025/versions/1/state"
+            """
+            {
+                "state": "approved"
+            }
+            """
+        Then the HTTP status code should be "200"
+
+    Scenario: PUT state transitions from associated to approved
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I PUT "/datasets/static-dataset-update/editions/2025/versions/1/state"
+            """
+            {
+                "state": "approved"
+            }
+            """
+        Then the HTTP status code should be "200"
+
+    Scenario: PUT state transitions from approved to published
+        Given I have a static dataset with version:
+            """
+            {
+                "dataset": {
+                    "id": "static-dataset-publish",
+                    "title": "Static Dataset for Publishing",
+                    "state": "associated",
+                    "type": "static",
+                    "links": {
+                        "editions": {
+                            "href": "/datasets/static-dataset-publish/editions"
+                        },
+                        "self": {
+                            "href": "/datasets/static-dataset-publish"
+                        }
+                    }
+                },
+                "edition": {
+                    "edition": "2025",
+                    "edition_title": "2025 Edition"
+                },
+                "version": {
+                    "id": "static-version-approved",
+                    "edition": "2025",
+                    "edition_title": "2025 Edition",
+                    "links": {
+                        "dataset": {
+                            "id": "static-dataset-publish"
+                        },
+                        "edition": {
+                            "href": "/datasets/static-dataset-publish/editions/2025",
+                            "id": "2025"
+                        },
+                        "self": {
+                            "href": "/datasets/static-dataset-publish/editions/2025/versions/1"
+                        },
+                        "version": {
+                            "href": "/datasets/static-dataset-publish/editions/2025/versions/1",
+                            "id": "1"
+                        }
+                    },
+                    "version": 1,
+                    "release_date": "2025-02-01T09:00:00.000Z",
+                    "state": "approved",
+                    "type": "static"
+                }
+            }
+            """
+        And private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I PUT "/datasets/static-dataset-publish/editions/2025/versions/1/state"
+            """
+            {
+                "state": "published"
+            }
+            """
+        Then the HTTP status code should be "200"
+
+    Scenario: PUT state fails with invalid state
+        Given private endpoints are enabled
+        And I am identified as "user@ons.gov.uk"
+        And I am authorised
+        When I PUT "/datasets/static-dataset-update/editions/2025/versions/1/state"
+            """
+            {
+                "state": "invalid-state"
+            }
+            """
+        Then the HTTP status code should be "400"
+
+    Scenario: PUT state fails when not authorised
+        Given private endpoints are enabled
+        When I PUT "/datasets/static-dataset-update/editions/2025/versions/1/state"
+            """
+            {
+                "state": "approved"
+            }
+            """
+        Then the HTTP status code should be "401"


### PR DESCRIPTION
### What

Added component tests for `static` datasets for the following endpoints - 

POST - `/datasets/{dataset_id}/editions/{edition}/versions`
PUT - `/datasets/{dataset_id}/editions/{edition}/versions/{version}`
PUT - `/datasets/{dataset_id}/editions/{edition}/versions/{version}/state`

### How to review

Confirm changes make sense, component tests pass

### Who can review

Anyone
