### PR TITLE
fix state transition error

### DIFF
--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -3660,3 +3660,108 @@ func TestPutVersionEditionValidationNonStatic(t *testing.T) {
 		})
 	})
 }
+
+func TestPublishDistributionFilesErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	Convey("When testing error mapping logic in publishDistributionFiles", t, func() {
+		Convey("Given files.ErrFileNotFound", func() {
+			err := files.ErrFileNotFound
+			var filesAPIError error
+
+			if errors.Is(err, files.ErrFileNotFound) ||
+				strings.Contains(err.Error(), "FileNotRegistered") ||
+				strings.Contains(err.Error(), "file not registered") ||
+				strings.Contains(err.Error(), "not found") {
+				filesAPIError = errs.ErrFileMetadataNotFound
+			}
+
+			Convey("Then it should be mapped to ErrFileMetadataNotFound", func() {
+				So(filesAPIError, ShouldEqual, errs.ErrFileMetadataNotFound)
+			})
+		})
+
+		Convey("Given files.ErrInvalidState", func() {
+			err := files.ErrInvalidState
+			var filesAPIError error
+
+			if errors.Is(err, files.ErrInvalidState) {
+				filesAPIError = errs.ErrFileNotInCorrectState
+			}
+
+			Convey("Then it should be mapped to ErrFileNotInCorrectState", func() {
+				So(filesAPIError, ShouldEqual, errs.ErrFileNotInCorrectState)
+			})
+		})
+
+		Convey("Given error with 'FileNotRegistered' in message", func() {
+			err := errors.New("FileNotRegistered: file not found")
+			var filesAPIError error
+
+			if errors.Is(err, files.ErrFileNotFound) ||
+				strings.Contains(err.Error(), "FileNotRegistered") ||
+				strings.Contains(err.Error(), "file not registered") ||
+				strings.Contains(err.Error(), "not found") {
+				filesAPIError = errs.ErrFileMetadataNotFound
+			}
+
+			Convey("Then it should be mapped to ErrFileMetadataNotFound", func() {
+				So(filesAPIError, ShouldEqual, errs.ErrFileMetadataNotFound)
+			})
+		})
+
+		Convey("Given error with 'file not registered' in message", func() {
+			err := errors.New("file not registered")
+			var filesAPIError error
+
+			if errors.Is(err, files.ErrFileNotFound) ||
+				strings.Contains(err.Error(), "FileNotRegistered") ||
+				strings.Contains(err.Error(), "file not registered") ||
+				strings.Contains(err.Error(), "not found") {
+				filesAPIError = errs.ErrFileMetadataNotFound
+			}
+
+			Convey("Then it should be mapped to ErrFileMetadataNotFound", func() {
+				So(filesAPIError, ShouldEqual, errs.ErrFileMetadataNotFound)
+			})
+		})
+
+		Convey("Given error with 'not found' in message", func() {
+			err := errors.New("resource not found")
+			var filesAPIError error
+
+			if errors.Is(err, files.ErrFileNotFound) ||
+				strings.Contains(err.Error(), "FileNotRegistered") ||
+				strings.Contains(err.Error(), "file not registered") ||
+				strings.Contains(err.Error(), "not found") {
+				filesAPIError = errs.ErrFileMetadataNotFound
+			}
+
+			Convey("Then it should be mapped to ErrFileMetadataNotFound", func() {
+				So(filesAPIError, ShouldEqual, errs.ErrFileMetadataNotFound)
+			})
+		})
+	})
+}
+
+func TestErrorStatusCodeMapping(t *testing.T) {
+	t.Parallel()
+
+	Convey("When getVersionAPIErrStatusCode is called with file-related errors", t, func() {
+		Convey("Given ErrFileMetadataNotFound", func() {
+			statusCode := getVersionAPIErrStatusCode(errs.ErrFileMetadataNotFound)
+
+			Convey("Then it should return 404", func() {
+				So(statusCode, ShouldEqual, http.StatusNotFound)
+			})
+		})
+
+		Convey("Given ErrFileNotInCorrectState", func() {
+			statusCode := getVersionAPIErrStatusCode(errs.ErrFileNotInCorrectState)
+
+			Convey("Then it should return 409", func() {
+				So(statusCode, ShouldEqual, http.StatusConflict)
+			})
+		})
+	})
+}

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -55,6 +55,8 @@ var (
 	ErrMissingDatasetID                   = errors.New("invalid fields: missing dataset id in request body")
 	ErrEditionAlreadyExists               = errors.New("the edition-id already exists")
 	ErrInvalidDatasetTypeForEditionUpdate = errors.New("unable to update edition-id, invalid dataset type")
+	ErrFileMetadataNotFound               = errors.New("file metadata not found")
+	ErrFileNotInCorrectState              = errors.New("file not in correct state")
 
 	ErrExpectedResourceStateOfCreated          = errors.New("unable to update resource, expected resource to have a state of created")
 	ErrExpectedResourceStateOfSubmitted        = errors.New("unable to update resource, expected resource to have a state of submitted")
@@ -71,6 +73,7 @@ var (
 		ErrEditionNotFound:         true,
 		ErrInstanceNotFound:        true,
 		ErrVersionNotFound:         true,
+		ErrFileMetadataNotFound:    true,
 	}
 
 	BadRequestMap = map[error]bool{
@@ -92,6 +95,7 @@ var (
 		ErrConflictUpdatingInstance: true,
 		ErrInstanceConflict:         true,
 		ErrEditionAlreadyExists:     true,
+		ErrFileNotInCorrectState:    true,
 	}
 
 	ForbiddenMap = map[error]bool{

--- a/application/state_machine.go
+++ b/application/state_machine.go
@@ -85,7 +85,7 @@ func (sm *StateMachine) Transition(ctx context.Context, smDS *StateMachineDatase
 	}
 
 	if !match {
-		if currentVersion.State == versionUpdate.State && versionUpdate.State == "published" {
+		if currentVersion.State == versionUpdate.State && versionUpdate.State == models.PublishedState {
 			log.Info(ctx, "state machine: version already published, treating as successful")
 			return nil
 		}

--- a/application/state_machine.go
+++ b/application/state_machine.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 type State struct {
@@ -84,6 +85,10 @@ func (sm *StateMachine) Transition(ctx context.Context, smDS *StateMachineDatase
 	}
 
 	if !match {
+		if currentVersion.State == versionUpdate.State && versionUpdate.State == "published" {
+			log.Info(ctx, "state machine: version already published, treating as successful")
+			return nil
+		}
 		return errors.New("state not allowed to transition")
 	}
 

--- a/application/state_machine_test.go
+++ b/application/state_machine_test.go
@@ -79,4 +79,25 @@ func TestTransition(t *testing.T) {
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, "state not allowed to transition")
 	})
+
+	Convey("The transition handles idempotent state changes correctly", t, func() {
+		currentVersionApproved := &models.Version{
+			State:       "published",
+			ReleaseDate: "2024-12-31",
+			Version:     1,
+			ID:          "789",
+		}
+
+		versionUpdateApproved := &models.Version{
+			State:       "published",
+			ReleaseDate: "2024-12-31",
+			Version:     1,
+			ID:          "789",
+		}
+
+		err := smDS.StateMachine.Transition(testContext, smDS, currentVersionApproved, versionUpdateApproved, versionDetails, "true")
+
+		So(err, ShouldBeNil)
+		So(len(mockedDataStore.UpdateVersionCalls()), ShouldEqual, 2)
+	})
 }

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -407,3 +407,51 @@ Scenario: PUT fails when updating edition-id to existing edition for static data
             }
             """
         Then the HTTP status code should be "200"
+
+Scenario: PUT state handles idempotent transitions correctly
+    Given I have a static dataset with version:
+        """
+        {
+            "dataset": {
+                "id": "static-dataset-published",
+                "title": "Static Dataset Published Test",
+                "state": "published",
+                "type": "static"
+            },
+            "edition": {
+                "edition": "2025",
+                "edition_title": "2025 Edition"
+            },
+            "version": {
+                "id": "static-version-published",
+                "edition": "2025",
+                "edition_title": "2025 Edition",
+                "links": {
+                    "dataset": {
+                        "id": "static-dataset-published"
+                    },
+                    "edition": {
+                        "href": "/datasets/static-dataset-published/editions/2025",
+                        "id": "2025"
+                    },
+                    "self": {
+                        "href": "/datasets/static-dataset-published/editions/2025/versions/1"
+                    }
+                },
+                "version": 1,
+                "release_date": "2025-01-01T09:00:00.000Z",
+                "state": "published",
+                "type": "static"
+            }
+        }
+        """
+    And private endpoints are enabled
+    And I am identified as "user@ons.gov.uk"
+    And I am authorised
+    When I PUT "/datasets/static-dataset-published/editions/2025/versions/1/state"
+        """
+        {
+            "state": "published"
+        }
+        """
+    Then the HTTP status code should be "200"


### PR DESCRIPTION
### What

Fix error messaging on PUT /versions/{version}/state endpoint in dp-dataset-api
Jira - https://officefornationalstatistics.atlassian.net/browse/DIS-3647

To explain further, when a request is made to transition from `approved` > `published`, the state machine successfully transitions the version to `published`. If a file publishing fails (files API error) then an auto retry mechanism kicks in and calls the state machine again, attempting to go from `published` > `published`, and the `state not allowed to transition` error is returned rather than an error from files API indicating that the file publish has failed. This fix catches this and allows the idempotent state transition (only if going from `published` to `published`), so that the user now sees the correct files API error instead of state transition error.

### How to review

To test locally - 

1. Create a new static dataset and version, ensuring that the distributions field is populated when creating the version. Something like this - 

```
    "distributions": [
        {
            "title": "A01 August 2024",
            "format": "xls",
            "download_url": "dataset-uploads/a01aug2024.xls",
            "byte_size": 3145728

        }
    ],
```
2. Add a file to the metadata collection in the files db with a `path` that matches the `download-url` from the distributions field from the previous step - 

<img width="1125" height="640" alt="Screenshot 2025-09-18 at 15 12 14" src="https://github.com/user-attachments/assets/d15ded21-5e50-4624-b9df-957de161688b" />

3. Make a request to PUT /versions/{version}/state endpoint and transition to the `approved` state.
4. Update the file metadata via the db, so that the `state` field is not in the `UPLOADED` state
5. Make a request to PUT /versions/{version}/state endpoint and transition to the `published` state. You should receive a `409` error with a `file not in correct state` response as per acceptance criteria 2
6. Update the file metadata via the db, so that the `path` field does not match `download_url` from the original distributions field. Repeat step 5 and you should receive a `404` error with `file metadata not found` response as per acceptance criteria 1

Changes make sense
Tests pass

### Who can review

Anyone
