### PR TITLE
Feature/return state within metadata

### DIFF
--- a/api/metadata_test.go
+++ b/api/metadata_test.go
@@ -333,6 +333,7 @@ func TestGetMetadataReturnsOk(t *testing.T) {
 		}
 		So(metaData.Temporal, ShouldResemble, &[]models.TemporalFrequency{temporal})
 		So(metaData.UnitOfMeasure, ShouldEqual, "Pounds Sterling")
+		So(metaData.State, ShouldEqual, versionDoc.State)
 	})
 
 	// Subtle difference between the test above and below, keywords is Not nil
@@ -392,6 +393,7 @@ func TestGetMetadataReturnsOk(t *testing.T) {
 		}
 		So(metaData.Temporal, ShouldResemble, &[]models.TemporalFrequency{temporal})
 		So(metaData.UnitOfMeasure, ShouldEqual, "Pounds Sterling")
+		So(metaData.State, ShouldEqual, versionDoc.State)
 	})
 
 	Convey("Successfully return metadata resource for a static dataset type", t, func() {
@@ -456,6 +458,7 @@ func TestGetMetadataReturnsOk(t *testing.T) {
 		}
 		So(metaData.Temporal, ShouldResemble, &[]models.TemporalFrequency{temporal})
 		So(metaData.UnitOfMeasure, ShouldEqual, "Pounds Sterling")
+		So(metaData.State, ShouldEqual, versionDoc.State)
 	})
 }
 

--- a/features/metadata.feature
+++ b/features/metadata.feature
@@ -537,7 +537,8 @@ Feature: Dataset API - metadata
             "title": "title",
             "unit_of_measure": "people",
             "uri": "http://example.com/population-estimates",
-            "version": 1
+            "version": 1,
+            "state": "published"
             }
             """
 
@@ -636,7 +637,8 @@ Feature: Dataset API - metadata
             "next_release": "2022",
             "release_date": "2023-01-01T00:00:00.000Z",
             "title": "title",
-            "version": 1
+            "version": 1,
+            "state": "associated"
             }
             """
 
@@ -817,7 +819,8 @@ Feature: Dataset API - metadata
             "release_date": "2023-01-01T00:00:00.000Z",
             "title": "title",
             "uri": "http://example.com/cantabular-flexible-table",
-            "version": 1
+            "version": 1,
+            "state": "published"
             }
             """
             
@@ -842,16 +845,6 @@ Scenario: GET metadata for a static dataset
                     }
                 ],
                 "topics": ["economy", "demographics"]
-            },
-            "edition": {
-                "id": "time-series",
-                "edition": "time-series",
-                "state": "published",
-                "links": {
-                    "dataset": {
-                        "id": "static-dataset"
-                    }
-                }
             },
             "version": {
                 "version": 1,
@@ -934,6 +927,7 @@ Scenario: GET metadata for a static dataset
             ],
             "type": "static",
             "version": 1,
+            "state": "published",
             "distributions": [
                 {
                     "title": "Distribution 1",
@@ -967,16 +961,6 @@ Scenario: GET metadata for a static dataset with URL rewriting enabled
                     }
                 ],
                 "topics": ["economy", "demographics"]
-            },
-            "edition": {
-                "id": "time-series",
-                "edition": "time-series",
-                "state": "published",
-                "links": {
-                    "dataset": {
-                        "id": "static-dataset"
-                    }
-                }
             },
             "version": {
                 "version": 1,
@@ -1062,12 +1046,129 @@ Scenario: GET metadata for a static dataset with URL rewriting enabled
             ],
             "type": "static",
             "version": 1,
+            "state": "published",
             "distributions": [
                 {
                     "title": "Distribution 1",
                     "format": "csv",
                     "media_type": "text/csv",
                     "download_url": "http://localhost:23600/downloads-new/datasets/static-dataset/editions/time-series/versions/1.csv",
+                    "byte_size": 100000
+                }
+            ]
+        }
+        """
+
+Scenario: GET metadata for an unpublished static dataset
+    Given I have a static dataset with version:
+        """
+        {
+            "dataset": {
+                "id": "static-dataset",
+                "title": "static title",
+                "description": "static description",
+                "state": "created",
+                "type": "static",
+                "next_release": "2023-12-01",
+                "license": "license",
+                "keywords": ["statistics", "population"],
+                "contacts": [
+                    {
+                        "name": "name",
+                        "email": "name@example.com",
+                        "telephone": "01234 567890"
+                    }
+                ],
+                "topics": ["economy", "demographics"]
+            },
+            "version": {
+                "version": 1,
+                "state": "edition-confirmed",
+                "release_date": "2023-01-15",
+                "temporal": [
+                    {
+                        "frequency": "Monthly",
+                        "start_date": "2023-01-01",
+                        "end_date": "2023-01-31"
+                    }
+                ],
+                "links": {
+                    "dataset": {
+                        "id": "static-dataset"
+                    },
+                    "edition": {
+                        "id": "time-series"
+                    },
+                    "self": {
+                        "href": "/datasets/static-dataset/editions/time-series/versions/1"
+                    },
+                    "version": {
+                        "href": "/datasets/static-dataset/editions/time-series/versions/1",
+                        "id": "1"
+                    }
+                },
+                "edition": "time-series",
+                "distributions": [
+                    {
+                        "title": "Distribution 1",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "download_url": "/datasets/static-dataset/editions/time-series/versions/1.csv",
+                        "byte_size": 100000
+                    }
+                ]
+            }
+        }
+        """
+    When I GET "/datasets/static-dataset/editions/time-series/versions/1/metadata"
+    Then I should receive the following JSON response with status "200":
+        """
+        {
+            "contacts": [
+                {
+                    "name": "name",
+                    "email": "name@example.com",
+                    "telephone": "01234 567890"
+                }
+            ],
+            "description": "static description",
+            "keywords": ["statistics", "population"],
+            "last_updated": "0001-01-01T00:00:00Z",
+            "license": "license",
+            "next_release": "2023-12-01",
+            "release_date": "2023-01-15",
+            "title": "static title",
+            "topics": ["economy", "demographics"],
+            "links": {
+                "self": {
+                    "href": "/datasets/static-dataset/editions/time-series/versions/1/metadata"
+                },
+                "version": {
+                    "href": "/datasets/static-dataset/editions/time-series/versions/1",
+                    "id": "1"
+                },
+                "website_version": {
+                    "href": "http://localhost:20000/datasets/static-dataset/editions/time-series/versions/1"
+                }
+            },
+            "edition": "time-series",
+            "id": "static-dataset",
+            "temporal": [
+                {
+                    "frequency": "Monthly",
+                    "start_date": "2023-01-01",
+                    "end_date": "2023-01-31"
+                }
+            ],
+            "type": "static",
+            "version": 1,
+            "state": "edition-confirmed",
+            "distributions": [
+                {
+                    "title": "Distribution 1",
+                    "format": "csv",
+                    "media_type": "text/csv",
+                    "download_url": "/datasets/static-dataset/editions/time-series/versions/1.csv",
                     "byte_size": 100000
                 }
             ]

--- a/features/metadata_web.feature
+++ b/features/metadata_web.feature
@@ -1,0 +1,542 @@
+Feature: Dataset API - metadata in WEB mode
+
+Scenario: GET metadata for a published static dataset
+    Given I have a static dataset with version:
+        """
+        {
+            "dataset": {
+                "id": "static-dataset",
+                "title": "static title",
+                "description": "static description",
+                "state": "published",
+                "type": "static",
+                "next_release": "2023-12-01",
+                "license": "license",
+                "keywords": ["statistics", "population"],
+                "contacts": [
+                    {
+                        "name": "name",
+                        "email": "name@example.com",
+                        "telephone": "01234 567890"
+                    }
+                ],
+                "topics": ["economy", "demographics"]
+            },
+            "version": {
+                "version": 1,
+                "state": "published",
+                "release_date": "2023-01-15",
+                "temporal": [
+                    {
+                        "frequency": "Monthly",
+                        "start_date": "2023-01-01",
+                        "end_date": "2023-01-31"
+                    }
+                ],
+                "links": {
+                    "dataset": {
+                        "id": "static-dataset"
+                    },
+                    "edition": {
+                        "id": "time-series"
+                    },
+                    "self": {
+                        "href": "/datasets/static-dataset/editions/time-series/versions/1"
+                    },
+                    "version": {
+                        "href": "/datasets/static-dataset/editions/time-series/versions/1",
+                        "id": "1"
+                    }
+                },
+                "edition": "time-series",
+                "distributions": [
+                    {
+                        "title": "Distribution 1",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "download_url": "/datasets/static-dataset/editions/time-series/versions/1.csv",
+                        "byte_size": 100000
+                    }
+                ]
+            }
+        }
+        """
+    When I GET "/datasets/static-dataset/editions/time-series/versions/1/metadata"
+    Then I should receive the following JSON response with status "200":
+        """
+        {
+            "contacts": [
+                {
+                    "name": "name",
+                    "email": "name@example.com",
+                    "telephone": "01234 567890"
+                }
+            ],
+            "description": "static description",
+            "keywords": ["statistics", "population"],
+            "last_updated": "0001-01-01T00:00:00Z",
+            "license": "license",
+            "next_release": "2023-12-01",
+            "release_date": "2023-01-15",
+            "title": "static title",
+            "topics": ["economy", "demographics"],
+            "links": {
+                "self": {
+                    "href": "/datasets/static-dataset/editions/time-series/versions/1/metadata"
+                },
+                "version": {
+                    "href": "/datasets/static-dataset/editions/time-series/versions/1",
+                    "id": "1"
+                },
+                "website_version": {
+                    "href": "http://localhost:20000/datasets/static-dataset/editions/time-series/versions/1"
+                }
+            },
+            "edition": "time-series",
+            "id": "static-dataset",
+            "temporal": [
+                {
+                    "frequency": "Monthly",
+                    "start_date": "2023-01-01",
+                    "end_date": "2023-01-31"
+                }
+            ],
+            "type": "static",
+            "version": 1,
+            "state": "published",
+            "distributions": [
+                {
+                    "title": "Distribution 1",
+                    "format": "csv",
+                    "media_type": "text/csv",
+                    "download_url": "/datasets/static-dataset/editions/time-series/versions/1.csv",
+                    "byte_size": 100000
+                }
+            ]
+        }
+        """
+
+Scenario: GET metadata for an unpublished static dataset
+    Given I have a static dataset with version:
+        """
+        {
+            "dataset": {
+                "id": "static-dataset",
+                "title": "static title",
+                "description": "static description",
+                "state": "created",
+                "type": "static",
+                "next_release": "2023-12-01",
+                "license": "license",
+                "keywords": ["statistics", "population"],
+                "contacts": [
+                    {
+                        "name": "name",
+                        "email": "name@example.com",
+                        "telephone": "01234 567890"
+                    }
+                ],
+                "topics": ["economy", "demographics"]
+            },
+            "version": {
+                "version": 1,
+                "state": "edition-confirmed",
+                "release_date": "2023-01-15",
+                "temporal": [
+                    {
+                        "frequency": "Monthly",
+                        "start_date": "2023-01-01",
+                        "end_date": "2023-01-31"
+                    }
+                ],
+                "links": {
+                    "dataset": {
+                        "id": "static-dataset"
+                    },
+                    "edition": {
+                        "id": "time-series"
+                    },
+                    "self": {
+                        "href": "/datasets/static-dataset/editions/time-series/versions/1"
+                    },
+                    "version": {
+                        "href": "/datasets/static-dataset/editions/time-series/versions/1",
+                        "id": "1"
+                    }
+                },
+                "edition": "time-series",
+                "distributions": [
+                    {
+                        "title": "Distribution 1",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "download_url": "/datasets/static-dataset/editions/time-series/versions/1.csv",
+                        "byte_size": 100000
+                    }
+                ]
+            }
+        }
+        """
+    When I GET "/datasets/static-dataset/editions/time-series/versions/1/metadata"
+    Then the HTTP status code should be "404"
+
+Scenario: GET metadata for Cantabular flexible table dataset
+    Given I have these datasets:
+        """
+        [
+            {
+                "id": "cantabular-flexible-table",
+                "title": "title",
+                "description": "description",
+                "state": "published",
+                "type": "cantabular_flexible_table",
+                "uri": "http://example.com/cantabular-flexible-table",
+                "is_based_on": {
+                    "id": "cpih01",
+                    "@type": "cantabular_flexible_table"
+                },
+                "links": {
+                    "self": {
+                        "href": "/datasets/cantabular-flexible-table",
+                        "id": "cantabular-flexible-table"
+                    }
+                }
+            }
+        ]
+        """
+    And I have these editions:
+        """
+        [
+            {
+                "id": "cantabular-edition-1",
+                "edition": "2023",
+                "state": "published",
+                "links": {
+                    "dataset": {
+                        "id": "cantabular-flexible-table"
+                    }
+                }
+            }
+        ]
+        """
+    And I have these versions:
+        """
+        [
+            {
+                "id": "cantabular-version-1",
+                "version": 1,
+                "state": "published",
+                "release_date": "2023-01-01T00:00:00.000Z",
+                "dimensions": [
+                    {
+                        "name": "region",
+                        "label": "region",
+                        "description": "region"
+                    },
+                    {
+                        "name": "age",
+                        "label": "label",
+                        "description": "description"
+                    }
+                ],
+                "downloads": {
+                    "csv": {
+                        "href": "http://download-service/cantabular-data.csv",
+                        "size": "5000"
+                    }
+                },
+                "links": {
+                    "dataset": {
+                        "id": "cantabular-flexible-table"
+                    },
+                    "edition": {
+                        "id": "2023"
+                    },
+                    "self": {
+                        "href": "/datasets/cantabular-flexible-table/editions/2023/versions/1"
+                    },
+                    "version": {
+                        "href": "/datasets/cantabular-flexible-table/editions/2023/versions/1",
+                        "id": "1"
+                    }
+                },
+                "edition": "2023"
+            }
+        ]
+        """
+    When I GET "/datasets/cantabular-flexible-table/editions/2023/versions/1/metadata"
+    Then I should receive the following JSON response with status "200":
+        """
+        {
+        "dataset_links": {
+            "self": {
+            "href": "/datasets/cantabular-flexible-table", 
+            "id": "cantabular-flexible-table"
+            }
+        },
+        "description": "description",
+        "dimensions": [
+            {
+            "description": "region",
+            "label": "region",
+            "links": {
+                "code_list": {},
+                "options": {},
+                "version": {}
+            },
+            "name": "region"
+            },
+            {
+            "description": "description",
+            "label": "label",
+            "links": {
+                "code_list": {},
+                "options": {},
+                "version": {}
+            },
+            "name": "age"
+            }
+        ],
+        "distribution": ["json", "csv"],
+        "downloads": {
+            "csv": {
+            "href": "http://download-service/cantabular-data.csv",
+            "size": "5000"
+            }
+        },
+        "is_based_on": {
+            "@id": "",
+            "@type": "cantabular_flexible_table"
+        },
+        "last_updated": "0001-01-01T00:00:00Z",
+        "release_date": "2023-01-01T00:00:00.000Z",
+        "title": "title",
+        "uri": "http://example.com/cantabular-flexible-table",
+        "version": 1,
+        "state": "published"
+        }
+        """
+
+Scenario: GET metadata for an unpublished Cantabular flexible table dataset
+    Given I have these datasets:
+        """
+        [
+            {
+                "id": "cantabular-flexible-table",
+                "title": "title",
+                "description": "description",
+                "state": "published",
+                "type": "cantabular_flexible_table",
+                "uri": "http://example.com/cantabular-flexible-table",
+                "is_based_on": {
+                    "id": "cpih01",
+                    "@type": "cantabular_flexible_table"
+                },
+                "links": {
+                    "self": {
+                        "href": "/datasets/cantabular-flexible-table",
+                        "id": "cantabular-flexible-table"
+                    }
+                }
+            }
+        ]
+        """
+    And I have these editions:
+        """
+        [
+            {
+                "id": "cantabular-edition-1",
+                "edition": "2023",
+                "state": "published",
+                "links": {
+                    "dataset": {
+                        "id": "cantabular-flexible-table"
+                    }
+                }
+            }
+        ]
+        """
+    And I have these versions:
+        """
+        [
+            {
+                "id": "cantabular-version-1",
+                "version": 1,
+                "state": "published",
+                "release_date": "2023-01-01T00:00:00.000Z",
+                "dimensions": [
+                    {
+                        "name": "region",
+                        "label": "region",
+                        "description": "region"
+                    },
+                    {
+                        "name": "age",
+                        "label": "label",
+                        "description": "description"
+                    }
+                ],
+                "downloads": {
+                    "csv": {
+                        "href": "http://download-service/cantabular-data.csv",
+                        "size": "5000"
+                    }
+                },
+                "links": {
+                    "dataset": {
+                        "id": "cantabular-flexible-table"
+                    },
+                    "edition": {
+                        "id": "2023"
+                    },
+                    "self": {
+                        "href": "/datasets/cantabular-flexible-table/editions/2023/versions/1"
+                    },
+                    "version": {
+                        "href": "/datasets/cantabular-flexible-table/editions/2023/versions/1",
+                        "id": "1"
+                    }
+                },
+                "edition": "2023"
+            }
+        ]
+        """
+    When I GET "/datasets/cantabular-flexible-table/editions/2023/versions/1/metadata"
+    Then I should receive the following JSON response with status "200":
+        """
+            {
+            "dataset_links": {
+                "self": {
+                "href": "/datasets/cantabular-flexible-table", 
+                "id": "cantabular-flexible-table"
+                }
+            },
+            "description": "description",
+            "dimensions": [
+                {
+                "description": "region",
+                "label": "region",
+                "links": {
+                    "code_list": {},
+                    "options": {},
+                    "version": {}
+                },
+                "name": "region"
+                },
+                {
+                "description": "description",
+                "label": "label",
+                "links": {
+                    "code_list": {},
+                    "options": {},
+                    "version": {}
+                },
+                "name": "age"
+                }
+            ],
+            "distribution": ["json", "csv"],
+            "downloads": {
+                "csv": {
+                "href": "http://download-service/cantabular-data.csv",
+                "size": "5000"
+                }
+            },
+            "is_based_on": {
+                "@id": "",
+                "@type": "cantabular_flexible_table"
+            },
+            "last_updated": "0001-01-01T00:00:00Z",
+            "release_date": "2023-01-01T00:00:00.000Z",
+            "title": "title",
+            "uri": "http://example.com/cantabular-flexible-table",
+            "version": 1,
+            "state": "published"
+            }
+        """
+
+Scenario: GET metadata for a Cantabular flexible table dataset
+    Given I have these datasets:
+        """
+        [
+            {
+                "id": "cantabular-flexible-table",
+                "title": "title",
+                "description": "description",
+                "state": "associated",
+                "type": "cantabular_flexible_table",
+                "uri": "http://example.com/cantabular-flexible-table",
+                "is_based_on": {
+                    "id": "cpih01",
+                    "@type": "cantabular_flexible_table"
+                },
+                "links": {
+                    "self": {
+                        "href": "/datasets/cantabular-flexible-table",
+                        "id": "cantabular-flexible-table"
+                    }
+                }
+            }
+        ]
+        """
+    And I have these editions:
+        """
+        [
+            {
+                "id": "cantabular-edition-1",
+                "edition": "2023",
+                "state": "associated",
+                "links": {
+                    "dataset": {
+                        "id": "cantabular-flexible-table"
+                    }
+                }
+            }
+        ]
+        """
+    And I have these versions:
+        """
+        [
+            {
+                "id": "cantabular-version-1",
+                "version": 1,
+                "state": "associated",
+                "release_date": "2023-01-01T00:00:00.000Z",
+                "dimensions": [
+                    {
+                        "name": "region",
+                        "label": "region",
+                        "description": "region"
+                    },
+                    {
+                        "name": "age",
+                        "label": "label",
+                        "description": "description"
+                    }
+                ],
+                "downloads": {
+                    "csv": {
+                        "href": "http://download-service/cantabular-data.csv",
+                        "size": "5000"
+                    }
+                },
+                "links": {
+                    "dataset": {
+                        "id": "cantabular-flexible-table"
+                    },
+                    "edition": {
+                        "id": "2023"
+                    },
+                    "self": {
+                        "href": "/datasets/cantabular-flexible-table/editions/2023/versions/1"
+                    },
+                    "version": {
+                        "href": "/datasets/cantabular-flexible-table/editions/2023/versions/1",
+                        "id": "1"
+                    }
+                },
+                "edition": "2023"
+            }
+        ]
+        """
+    When I GET "/datasets/cantabular-flexible-table/editions/2023/versions/1/metadata"
+    Then the HTTP status code should be "404"

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -10,10 +10,6 @@ Feature: Static Dataset Versions PUT API
                     "state": "associated",
                     "type": "static"
                 },
-                "edition": {
-                    "edition": "2025",
-                    "edition_title": "2025 Edition"
-                },
                 "version": {
                     "id": "static-version-update",
                     "edition": "2025",
@@ -229,10 +225,6 @@ Feature: Static Dataset Versions PUT API
                         }
                     }
                 },
-                "edition": {
-                    "edition": "2025",
-                    "edition_title": "2025 Edition"
-                },
                 "version": {
                     "id": "static-version-approved",
                     "edition": "2025",
@@ -315,10 +307,6 @@ Scenario: PUT fails when updating edition-id to existing edition for static data
                     "state": "associated",
                     "type": "static"
                 },
-                "edition": {
-                    "edition": "2025",
-                    "edition_title": "2025 Edition"
-                },
                 "version": {
                     "id": "static-version-conflict",
                     "edition": "2025",
@@ -350,10 +338,6 @@ Scenario: PUT fails when updating edition-id to existing edition for static data
                     "title": "Static Dataset Conflict Test",
                     "state": "associated",
                     "type": "static"
-                },
-                "edition": {
-                    "edition": "existing-edition",
-                    "edition_title": "Existing Edition"
                 },
                 "version": {
                     "id": "static-version-existing",
@@ -417,10 +401,6 @@ Scenario: PUT state handles idempotent transitions correctly
                 "title": "Static Dataset Published Test",
                 "state": "published",
                 "type": "static"
-            },
-            "edition": {
-                "edition": "2025",
-                "edition_title": "2025 Edition"
             },
             "version": {
                 "id": "static-version-published",

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -491,7 +491,6 @@ func (c *DatasetComponent) putDocumentInDatabase(document interface{}, id, colle
 func (c *DatasetComponent) iHaveStaticDatasetWithVersion(jsonData *godog.DocString) error {
 	var data struct {
 		Dataset models.Dataset `json:"dataset"`
-		Edition models.Edition `json:"edition"`
 		Version models.Version `json:"version"`
 	}
 

--- a/models/metadata.go
+++ b/models/metadata.go
@@ -11,28 +11,29 @@ import (
 
 // Metadata represents information (metadata) relevant to a version
 type Metadata struct {
-	EditableMetadata
-	Distribution    []string             `json:"distribution,omitempty"`
-	Downloads       *DownloadList        `json:"downloads,omitempty"`
-	Links           *MetadataLinks       `json:"links,omitempty"`
-	TableID         string               `json:"table_id,omitempty"`
-	CSVHeader       []string             `json:"headers,omitempty"`
-	Edition         string               `json:"edition,omitempty"`
-	EditionTitle    string               `json:"edition_title,omitempty"`
-	DatasetLinks    *DatasetLinks        `json:"dataset_links,omitempty"`
-	ID              string               `json:"id,omitempty"`
-	Publisher       *Publisher           `json:"publisher,omitempty"`
-	Temporal        *[]TemporalFrequency `json:"temporal,omitempty"`
-	Theme           string               `json:"theme,omitempty"`
-	URI             string               `json:"uri,omitempty"`
-	Coverage        string               `json:"coverage,omitempty"`
-	TablePopulation string               `json:"table_population,omitempty"`
 	AreaType        string               `json:"area_type,omitempty"`
 	Classifications string               `json:"classifications,omitempty"`
-	Source          string               `json:"source,omitempty"`
+	Coverage        string               `json:"coverage,omitempty"`
+	CSVHeader       []string             `json:"headers,omitempty"`
+	DatasetLinks    *DatasetLinks        `json:"dataset_links,omitempty"`
+	Distribution    []string             `json:"distribution,omitempty"`
+	Downloads       *DownloadList        `json:"downloads,omitempty"`
+	Edition         string               `json:"edition,omitempty"`
+	EditionTitle    string               `json:"edition_title,omitempty"`
+	ID              string               `json:"id,omitempty"`
 	IsBasedOn       *IsBasedOn           `json:"is_based_on,omitempty"`
+	Links           *MetadataLinks       `json:"links,omitempty"`
+	Publisher       *Publisher           `json:"publisher,omitempty"`
+	State           string               `json:"state,omitempty"`
+	Source          string               `json:"source,omitempty"`
+	TableID         string               `json:"table_id,omitempty"`
+	TablePopulation string               `json:"table_population,omitempty"`
+	Temporal        *[]TemporalFrequency `json:"temporal,omitempty"`
+	Theme           string               `json:"theme,omitempty"`
 	Type            string               `json:"type,omitempty"`
+	URI             string               `json:"uri,omitempty"`
 	Version         int                  `json:"version,omitempty"`
+	EditableMetadata
 }
 
 // EditableMetadata represents the metadata fields that can be edited
@@ -119,14 +120,15 @@ func CreateMetaDataDoc(datasetDoc *Dataset, versionDoc *Version, urlBuilder *url
 		IsBasedOn:    datasetDoc.IsBasedOn,
 		Version:      versionDoc.Version,
 		Type:         datasetDoc.Type,
+		State:        versionDoc.State,
 	}
 
-	// Add relevant metdata links from dataset document
+	// Add relevant metadata links from dataset document
 	if datasetDoc.Links != nil {
 		metaDataDoc.Links.AccessRights = datasetDoc.Links.AccessRights
 	}
 
-	// Add relevant metdata links from version document
+	// Add relevant metadata links from version document
 	if versionDoc.Links != nil {
 		if versionDoc.Links.Version != nil && versionDoc.Links.Version.HRef != "" {
 			metaDataDoc.Links.Self = &LinkObject{
@@ -223,6 +225,7 @@ func CreateCantabularMetaDataDoc(d *Dataset, v *Version) *Metadata {
 		Version:      v.Version,
 		URI:          d.URI,
 		IsBasedOn:    d.IsBasedOn,
+		State:        v.State,
 	}
 
 	m.Distribution = getDistribution(v.Downloads)

--- a/models/metadata_test.go
+++ b/models/metadata_test.go
@@ -142,6 +142,7 @@ func TestCreateMetadata(t *testing.T) {
 				So(metaDataDoc.Dimensions, ShouldResemble, version.Dimensions)
 				So(metaDataDoc.ReleaseDate, ShouldEqual, version.ReleaseDate)
 				So(metaDataDoc.Version, ShouldEqual, version.Version)
+				So(metaDataDoc.State, ShouldEqual, version.State)
 
 				So(metaDataDoc.Downloads.CSV.HRef, ShouldEqual, csvDownload.HRef)
 				So(metaDataDoc.Downloads.CSV.Size, ShouldEqual, csvDownload.Size)
@@ -205,6 +206,10 @@ func TestCreateMetadata(t *testing.T) {
 				So(metaDataDoc.Subtopics, ShouldResemble, dataset.Subtopics)
 				So(metaDataDoc.Topics, ShouldBeNil)
 			})
+
+			Convey("And the state is set from the version", func() {
+				So(metaDataDoc.State, ShouldEqual, version.State)
+			})
 		})
 
 		Convey("When we call CreateMetaDataDoc with a static dataset", func() {
@@ -223,6 +228,10 @@ func TestCreateMetadata(t *testing.T) {
 
 			Convey("Then it returns a metadata object with topics populated", func() {
 				So(metaDataDoc.Topics, ShouldResemble, staticDataset.Topics)
+			})
+
+			Convey("And the state is set from the version", func() {
+				So(metaDataDoc.State, ShouldEqual, version.State)
 			})
 		})
 	})

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2261,6 +2261,8 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/Publisher"
+      state:
+        $ref: "#/definitions/State"
       qmi:
         $ref: "#/definitions/QMILink"
       quality_designation:


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-3930

- Return state when calling `GET /metadata` endpoint
- Swagger spec and models updated
- `Edition` struct not needed in static dataset version test step since it wasn't being used and static types only make use of the `versions` collection
- I have only added the `state` into the metadata struct, it looks like a lot changed there because I've put it in alphabetical order

### How to review

- Test cases covered within component tests
- You will need both an unpublished and published version for both a cantabular and static dataset. Can be done using the steps here: https://officefornationalstatistics.atlassian.net/wiki/spaces/DIS/pages/60787954/Discoverable+Datasets+-+Basic+API+Calls+-+Publish
- Overall should have:
```
1 Cantabular dataset version (published)
1 Cantabular dataset version (unpublished)
1 static dataset version (published)
1 static dataset version (unpublished)
```
- You can switch to web mode by changing env vars in dp-compose for the dataset-api
- Call `GET /metadata` on each version listed above and responses should match with acceptance criteria

### Who can review

Anyone
