### PR TITLE
add is_latest param

### DIFF
--- a/api/static_versions.go
+++ b/api/static_versions.go
@@ -483,8 +483,6 @@ func (api *DatasetAPI) createVersion(w http.ResponseWriter, r *http.Request) (*m
 			datasetDoc.Next.Links = &models.DatasetLinks{}
 		}
 
-		datasetDoc.Next.LastUpdated = createdVersion.LastUpdated
-		datasetDoc.Next.State = models.AssociatedState
 		datasetDoc.Next.Links.LatestVersion = &models.LinkObject{
 			HRef: fmt.Sprintf("/datasets/%s/editions/%s/versions/%d", datasetID, edition, versionNumber),
 			ID:   strconv.Itoa(versionNumber),

--- a/api/static_versions.go
+++ b/api/static_versions.go
@@ -390,6 +390,18 @@ func (api *DatasetAPI) createVersion(w http.ResponseWriter, r *http.Request) (*m
 		return nil, models.NewErrorResponse(http.StatusBadRequest, nil, models.NewError(err, models.ErrInvalidQueryParameter, models.ErrInvalidQueryParameterDescription+": version"))
 	}
 
+	var isLatest bool
+	if isLatestParam := r.URL.Query().Get("is_latest"); isLatestParam != "" {
+		isLatest, err = strconv.ParseBool(isLatestParam)
+		if err != nil {
+			log.Error(ctx, "createVersion endpoint: invalid is_latest parameter", err, logData)
+			return nil, models.NewErrorResponse(
+				http.StatusBadRequest, nil,
+				models.NewError(err, models.ErrInvalidQueryParameter, models.ErrInvalidQueryParameterDescription+": is_latest"),
+			)
+		}
+	}
+
 	if newVersion.Type != models.Static.String() {
 		log.Error(ctx, "createVersion endpoint: only allowed to create static type versions", errs.ErrInvalidBody, logData)
 		return nil, models.NewErrorResponse(http.StatusBadRequest, nil, models.NewValidationError(models.ErrInvalidTypeError, models.ErrTypeNotStaticDescription))
@@ -457,6 +469,32 @@ func (api *DatasetAPI) createVersion(w http.ResponseWriter, r *http.Request) (*m
 	if err != nil {
 		log.Error(ctx, "createVersion endpoint: failed to create version", err, logData)
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewError(err, models.InternalError, models.InternalErrorDescription))
+	}
+
+	if isLatest {
+		datasetDoc, err := api.dataStore.Backend.GetDataset(ctx, datasetID)
+		if err != nil {
+			log.Error(ctx, "createVersion endpoint: failed to get dataset", err, logData)
+			return nil, models.NewErrorResponse(http.StatusInternalServerError, nil,
+				models.NewError(err, "failed to get dataset", models.InternalErrorDescription))
+		}
+
+		if datasetDoc.Next.Links == nil {
+			datasetDoc.Next.Links = &models.DatasetLinks{}
+		}
+
+		datasetDoc.Next.LastUpdated = createdVersion.LastUpdated
+		datasetDoc.Next.State = models.AssociatedState
+		datasetDoc.Next.Links.LatestVersion = &models.LinkObject{
+			HRef: fmt.Sprintf("/datasets/%s/editions/%s/versions/%d", datasetID, edition, versionNumber),
+			ID:   strconv.Itoa(versionNumber),
+		}
+
+		if err := api.dataStore.Backend.UpsertDataset(ctx, datasetID, datasetDoc); err != nil {
+			log.Error(ctx, "createVersion endpoint: failed to update dataset", err, logData)
+			return nil, models.NewErrorResponse(http.StatusInternalServerError, nil,
+				models.NewError(err, "failed to update dataset", models.InternalErrorDescription))
+		}
 	}
 
 	createdVersionJSON, err := json.Marshal(createdVersion)

--- a/api/static_versions_test.go
+++ b/api/static_versions_test.go
@@ -1675,6 +1675,162 @@ func TestCreateVersion_Success(t *testing.T) {
 			})
 		})
 	})
+
+	Convey("When is_latest=true, dataset is updated with latest_version link", t, func() {
+		validVersionJSON, err := json.Marshal(validVersion)
+		So(err, ShouldBeNil)
+
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
+				return false, nil
+			},
+			AddVersionStaticFunc: func(context.Context, *models.Version) (*models.Version, error) {
+				return expectedVersion, nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{
+					Next: &models.Dataset{
+						State: models.AssociatedState,
+						Links: &models.DatasetLinks{},
+					},
+				}, nil
+			},
+			UpsertDatasetFunc: func(context.Context, string, *models.DatasetUpdate) error {
+				return nil
+			},
+		}
+
+		auditServiceMock := &applicationMocks.AuditServiceMock{
+			RecordVersionAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, version *models.Version) error {
+				return nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/edition1/versions/1?is_latest=true", bytes.NewBuffer(validVersionJSON))
+		vars := map[string]string{
+			"dataset_id": "123",
+			"edition":    "edition1",
+			"version":    "1",
+		}
+		r = mux.SetURLVars(r, vars)
+		w := httptest.NewRecorder()
+
+		Convey("When createVersion is called", func() {
+			successResponse, errorResponse := api.createVersion(w, r)
+
+			Convey("Then it should return a 201 status code", func() {
+				So(errorResponse, ShouldBeNil)
+				So(successResponse.Status, ShouldEqual, http.StatusCreated)
+			})
+
+			Convey("And GetDataset and UpsertDataset should have been called to update latest_version", func() {
+				So(mockedDataStore.GetDatasetCalls(), ShouldHaveLength, 1)
+				So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 1)
+
+				upsertCall := mockedDataStore.UpsertDatasetCalls()[0]
+				So(upsertCall.DatasetDoc.Next.Links.LatestVersion.ID, ShouldEqual, "1")
+				So(upsertCall.DatasetDoc.Next.Links.LatestVersion.HRef, ShouldEqual, "/datasets/123/editions/edition1/versions/1")
+			})
+		})
+	})
+
+	Convey("When is_latest=false, dataset is not updated", t, func() {
+		validVersionJSON, err := json.Marshal(validVersion)
+		So(err, ShouldBeNil)
+
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
+				return false, nil
+			},
+			AddVersionStaticFunc: func(context.Context, *models.Version) (*models.Version, error) {
+				return expectedVersion, nil
+			},
+		}
+
+		auditServiceMock := &applicationMocks.AuditServiceMock{
+			RecordVersionAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, version *models.Version) error {
+				return nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/edition1/versions/1?is_latest=false", bytes.NewBuffer(validVersionJSON))
+		vars := map[string]string{
+			"dataset_id": "123",
+			"edition":    "edition1",
+			"version":    "1",
+		}
+		r = mux.SetURLVars(r, vars)
+		w := httptest.NewRecorder()
+
+		Convey("When createVersion is called", func() {
+			successResponse, errorResponse := api.createVersion(w, r)
+
+			Convey("Then it should return a 201 status code", func() {
+				So(errorResponse, ShouldBeNil)
+				So(successResponse.Status, ShouldEqual, http.StatusCreated)
+			})
+
+			Convey("And GetDataset and UpsertDataset should not have been called", func() {
+				So(mockedDataStore.GetDatasetCalls(), ShouldHaveLength, 0)
+				So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 0)
+			})
+		})
+	})
+
+	Convey("When is_latest is absent, dataset is not updated", t, func() {
+		validVersionJSON, err := json.Marshal(validVersion)
+		So(err, ShouldBeNil)
+
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
+				return false, nil
+			},
+			AddVersionStaticFunc: func(context.Context, *models.Version) (*models.Version, error) {
+				return expectedVersion, nil
+			},
+		}
+
+		auditServiceMock := &applicationMocks.AuditServiceMock{
+			RecordVersionAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, version *models.Version) error {
+				return nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/edition1/versions/1", bytes.NewBuffer(validVersionJSON))
+		vars := map[string]string{
+			"dataset_id": "123",
+			"edition":    "edition1",
+			"version":    "1",
+		}
+		r = mux.SetURLVars(r, vars)
+		w := httptest.NewRecorder()
+
+		Convey("When createVersion is called", func() {
+			successResponse, errorResponse := api.createVersion(w, r)
+
+			Convey("Then it should return a 201 status code", func() {
+				So(errorResponse, ShouldBeNil)
+				So(successResponse.Status, ShouldEqual, http.StatusCreated)
+			})
+
+			Convey("And GetDataset and UpsertDataset should not have been called", func() {
+				So(mockedDataStore.GetDatasetCalls(), ShouldHaveLength, 0)
+				So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 0)
+			})
+		})
+	})
 }
 
 func TestCreateVersion_Failure(t *testing.T) {
@@ -2282,5 +2438,31 @@ func TestCreateVersion_Failure(t *testing.T) {
 		So(errResp.Status, ShouldEqual, http.StatusBadRequest)
 		So(errResp.Errors[0].Code, ShouldEqual, models.ErrNoSpacesAllowedError)
 		So(errResp.Errors[0].Description, ShouldEqual, errs.ErrSpacesNotAllowedInID.Error())
+	})
+
+	Convey("When is_latest is not a valid boolean", t, func() {
+		validVersionJSON, err := json.Marshal(validVersion)
+		So(err, ShouldBeNil)
+
+		api := GetAPIWithCMDMocks(&storetest.StorerMock{}, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{})
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/edition1/versions/1?is_latest=ghgk", bytes.NewBuffer(validVersionJSON))
+		vars := map[string]string{
+			"dataset_id": "123",
+			"edition":    "edition1",
+			"version":    "1",
+		}
+		r = mux.SetURLVars(r, vars)
+		w := httptest.NewRecorder()
+
+		Convey("When createVersion is called", func() {
+			successResponse, errorResponse := api.createVersion(w, r)
+
+			Convey("Then it should return a 400 status code with an error message", func() {
+				So(successResponse, ShouldBeNil)
+				So(errorResponse.Status, ShouldEqual, http.StatusBadRequest)
+				So(errorResponse.Errors[0].Code, ShouldEqual, models.ErrInvalidQueryParameter)
+				So(errorResponse.Errors[0].Description, ShouldEqual, models.ErrInvalidQueryParameterDescription+": is_latest")
+			})
+		})
 	})
 }

--- a/features/static_versions_post_with_id.feature
+++ b/features/static_versions_post_with_id.feature
@@ -8,7 +8,13 @@ Feature: POST /datasets/{dataset_id}/editions/{edition}/versions/{version}
                     "id": "static-dataset-1",
                     "title": "static dataset with published version",
                     "state": "published",
-                    "type": "static"
+                    "type": "static",
+                    "links": {
+                        "latest_version": {
+                            "href": "/datasets/static-dataset-1/editions/2024/versions/1",
+                            "id": "1"
+                        }
+                    }
                 }
             ]
             """
@@ -609,3 +615,81 @@ Scenario: POST Creating an edition with spaces in the edition ID should return 4
                 ]
             }
             """
+
+Scenario: Request with is_latest=true updates the dataset latest_version link
+    Given private endpoints are enabled
+    And I am an admin user
+    When I POST "/datasets/static-dataset-1/editions/2024/versions/2?is_latest=true"
+        """
+        {
+            "release_date": "2024-12-01T09:00:00.000Z",
+            "edition_title": "2024",
+            "distributions": [
+                {
+                    "title": "Full Dataset CSV",
+                    "format": "csv",
+                    "media_type": "text/csv",
+                    "download_url": "/uuid/filename.csv",
+                    "byte_size": 100
+                }
+            ],
+            "type": "static"
+        }
+        """
+    Then the HTTP status code should be "201"
+    And the dataset "static-dataset-1" should have latest_version href "/datasets/static-dataset-1/editions/2024/versions/2"
+
+Scenario: Request with is_latest=false does not update the dataset latest_version link
+    Given private endpoints are enabled
+    And I am an admin user
+    When I POST "/datasets/static-dataset-1/editions/2024/versions/2?is_latest=false"
+        """
+        {
+            "release_date": "2024-12-01T09:00:00.000Z",
+            "edition_title": "2024",
+            "distributions": [
+                {
+                    "title": "Full Dataset CSV",
+                    "format": "csv",
+                    "media_type": "text/csv",
+                    "download_url": "/uuid/filename.csv",
+                    "byte_size": 100
+                }
+            ],
+            "type": "static"
+        }
+        """
+    Then the HTTP status code should be "201"
+    And the dataset "static-dataset-1" should have latest_version href "/datasets/static-dataset-1/editions/2024/versions/1"
+
+Scenario: Request with an invalid is_latest value returns 400
+    Given private endpoints are enabled
+    And I am an admin user
+    When I POST "/datasets/static-dataset-1/editions/2024/versions/2?is_latest=notabool"
+        """
+        {
+            "release_date": "2024-12-01T09:00:00.000Z",
+            "edition_title": "2024",
+            "distributions": [
+                {
+                    "title": "Full Dataset CSV",
+                    "format": "csv",
+                    "media_type": "text/csv",
+                    "download_url": "/uuid/filename.csv",
+                    "byte_size": 100
+                }
+            ],
+            "type": "static"
+        }
+        """
+    Then I should receive the following JSON response with status "400":
+        """
+        {
+            "errors": [
+                {
+                    "code": "ErrInvalidQueryParameter",
+                    "description": "invalid query parameter: is_latest"
+                }
+            ]
+        }
+        """

--- a/features/static_versions_post_with_id.feature
+++ b/features/static_versions_post_with_id.feature
@@ -636,7 +636,41 @@ Scenario: Request with is_latest=true updates the dataset latest_version link
             "type": "static"
         }
         """
-    Then the HTTP status code should be "201"
+    Then I should receive the following JSON response with status "201":
+        """
+        {
+            "dataset_id": "static-dataset-1",
+            "distributions": [
+                {
+                    "byte_size": 100,
+                    "download_url": "/uuid/filename.csv",
+                    "format": "csv",
+                    "media_type": "text/csv",
+                    "title": "Full Dataset CSV"
+                }
+            ],
+            "edition": "2024",
+            "edition_title": "2024",
+            "last_updated": "{{DYNAMIC_RECENT_TIMESTAMP}}",
+            "links": {
+                "dataset": {
+                    "href": "http://localhost:22000/datasets/static-dataset-1",
+                    "id": "static-dataset-1"
+                },
+                "edition": {
+                    "href": "http://localhost:22000/datasets/static-dataset-1/editions/2024",
+                    "id": "2024"
+                },
+                "self": {
+                    "href": "http://localhost:22000/datasets/static-dataset-1/editions/2024/versions/2"
+                }
+            },
+            "release_date": "2024-12-01T09:00:00.000Z",
+            "state": "associated",
+            "type": "static",
+            "version": 2
+        }
+        """
     And the dataset "static-dataset-1" should have latest_version href "/datasets/static-dataset-1/editions/2024/versions/2"
 
 Scenario: Request with is_latest=false does not update the dataset latest_version link
@@ -659,7 +693,41 @@ Scenario: Request with is_latest=false does not update the dataset latest_versio
             "type": "static"
         }
         """
-    Then the HTTP status code should be "201"
+    Then I should receive the following JSON response with status "201":
+        """
+        {
+            "dataset_id": "static-dataset-1",
+            "distributions": [
+                {
+                    "byte_size": 100,
+                    "download_url": "/uuid/filename.csv",
+                    "format": "csv",
+                    "media_type": "text/csv",
+                    "title": "Full Dataset CSV"
+                }
+            ],
+            "edition": "2024",
+            "edition_title": "2024",
+            "last_updated": "{{DYNAMIC_RECENT_TIMESTAMP}}",
+            "links": {
+                "dataset": {
+                    "href": "http://localhost:22000/datasets/static-dataset-1",
+                    "id": "static-dataset-1"
+                },
+                "edition": {
+                    "href": "http://localhost:22000/datasets/static-dataset-1/editions/2024",
+                    "id": "2024"
+                },
+                "self": {
+                    "href": "http://localhost:22000/datasets/static-dataset-1/editions/2024/versions/2"
+                }
+            },
+            "release_date": "2024-12-01T09:00:00.000Z",
+            "state": "associated",
+            "type": "static",
+            "version": 2
+        }
+        """
     And the dataset "static-dataset-1" should have latest_version href "/datasets/static-dataset-1/editions/2024/versions/1"
 
 Scenario: Request with an invalid is_latest value returns 400

--- a/features/steps/dataset_component.go
+++ b/features/steps/dataset_component.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	permissionsSDK "github.com/ONSdigital/dp-permissions-api/sdk"
+	"go.mongodb.org/mongo-driver/bson"
 
 	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
 	"github.com/ONSdigital/dp-authorisation/v2/authorisationtest"
@@ -17,6 +18,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/cloudflare"
 	cloudflareMocks "github.com/ONSdigital/dp-dataset-api/cloudflare/mocks"
 	"github.com/ONSdigital/dp-dataset-api/config"
+	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/mongo"
 	"github.com/ONSdigital/dp-dataset-api/service"
 	serviceMock "github.com/ONSdigital/dp-dataset-api/service/mock"
@@ -538,4 +540,23 @@ func (c *DatasetComponent) updateViewerPreviewPolicies(values []string) error {
 	ensure(permissionDatasetEditionsVersionsRead) // "dataset-editions-versions:read" (for /editions, /versions and metadata)
 	c.fakePermissionsAPI.Reset()
 	return c.fakePermissionsAPI.UpdatePermissionsBundleResponse(&bundle)
+}
+
+func (c *DatasetComponent) theDatasetShouldHaveLatestVersionHref(datasetID, expectedHref string) error {
+	collectionName := c.MongoClient.ActualCollectionName(config.DatasetsCollection)
+	var dataset models.DatasetUpdate
+
+	if err := c.MongoClient.Connection.Collection(collectionName).FindOne(context.Background(), bson.M{"_id": datasetID}, &dataset); err != nil {
+		return fmt.Errorf("failed to find dataset %s: %w", datasetID, err)
+	}
+
+	if dataset.Next == nil || dataset.Next.Links == nil || dataset.Next.Links.LatestVersion == nil {
+		return fmt.Errorf("dataset %s has no latest_version link", datasetID)
+	}
+
+	if dataset.Next.Links.LatestVersion.HRef != expectedHref {
+		return fmt.Errorf("expected latest_version href %q but got %q", expectedHref, dataset.Next.Links.LatestVersion.HRef)
+	}
+
+	return nil
 }

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -70,6 +70,7 @@ func (c *DatasetComponent) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`the total number of audit events should be (\d+)`, c.theTotalNumberOfAuditEventsShouldBe)
 	ctx.Step(`the number of events with action "([^"]*)" and resource "([^"]*)" should be (\d+)`, c.theNumberOfEventsWithActionAndResourceShouldBe)
 	ctx.Step(`I have realistic datasets`, c.iHaveRealisticDatasets)
+	ctx.Step(`^the dataset "([^"]*)" should have latest_version href "([^"]*)"$`, c.theDatasetShouldHaveLatestVersionHref)
 }
 
 func (c *DatasetComponent) viewerHasPreviewAccessToDataset(datasetID string) error {

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -494,9 +494,6 @@ versionToCreate := models.Version{
 createdVersion, err := client.PostVersion(ctx, headers, "dataset-id", "edition-id", "1", versionToCreate, true)
 ```
 
-createdVersion, err := client.PostVersion(ctx, headers, "dataset-id", "edition-id", "1", versionToCreate)
-```
-
 ## Additional Information
 
 ### Errors

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -490,6 +490,10 @@ versionToCreate := models.Version{
     // populate other required fields as required
 }
 
+// Pass true to set this version as the latest version at series level
+createdVersion, err := client.PostVersion(ctx, headers, "dataset-id", "edition-id", "1", versionToCreate, true)
+```
+
 createdVersion, err := client.PostVersion(ctx, headers, "dataset-id", "edition-id", "1", versionToCreate)
 ```
 

--- a/sdk/interface.go
+++ b/sdk/interface.go
@@ -33,7 +33,7 @@ type Clienter interface {
 	GetVersionWithResponse(ctx context.Context, headers Headers, datasetID, edition, versionID string) (v models.Version, resp *http.Response, err error)
 	GetVersions(ctx context.Context, headers Headers, datasetID, editionID string, queryParams *QueryParams) (versionsList VersionsList, err error)
 	GetVersionsInBatches(ctx context.Context, headers Headers, datasetID, edition string, batchSize, maxWorkers int) (versions VersionsList, err error)
-	PostVersion(ctx context.Context, headers Headers, datasetID, editionID, versionID string, version models.Version) (createdVersion *models.Version, err error)
+	PostVersion(ctx context.Context, headers Headers, datasetID, editionID, versionID string, version models.Version, isLatest bool) (createdVersion *models.Version, err error)
 	PutDataset(ctx context.Context, headers Headers, datasetID string, d models.Dataset) error
 	PutInstance(ctx context.Context, headers Headers, instanceID string, i UpdateInstance) (eTag string, err error)
 	PutMetadata(ctx context.Context, headers Headers, datasetID, edition, version string, metadata models.EditableMetadata) error

--- a/sdk/mocks/client.go
+++ b/sdk/mocks/client.go
@@ -80,7 +80,7 @@ var _ sdk.Clienter = &ClienterMock{}
 //			HealthFunc: func() *health.Client {
 //				panic("mock out the Health method")
 //			},
-//			PostVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID string, editionID string, versionID string, version models.Version) (*models.Version, error) {
+//			PostVersionFunc: func(ctx context.Context, headers sdk.Headers, datasetID string, editionID string, versionID string, version models.Version, isLatest bool) (*models.Version, error) {
 //				panic("mock out the PostVersion method")
 //			},
 //			PutDatasetFunc: func(ctx context.Context, headers sdk.Headers, datasetID string, d models.Dataset) error {
@@ -166,7 +166,7 @@ type ClienterMock struct {
 	HealthFunc func() *health.Client
 
 	// PostVersionFunc mocks the PostVersion method.
-	PostVersionFunc func(ctx context.Context, headers sdk.Headers, datasetID string, editionID string, versionID string, version models.Version) (*models.Version, error)
+	PostVersionFunc func(ctx context.Context, headers sdk.Headers, datasetID string, editionID string, versionID string, version models.Version, isLatest bool) (*models.Version, error)
 
 	// PutDatasetFunc mocks the PutDataset method.
 	PutDatasetFunc func(ctx context.Context, headers sdk.Headers, datasetID string, d models.Dataset) error
@@ -409,6 +409,8 @@ type ClienterMock struct {
 			VersionID string
 			// Version is the version argument value.
 			Version models.Version
+			// IsLatest is the isLatest argument value.
+			IsLatest bool
 		}
 		// PutDataset holds details about calls to the PutDataset method.
 		PutDataset []struct {
@@ -1341,7 +1343,7 @@ func (mock *ClienterMock) HealthCalls() []struct {
 }
 
 // PostVersion calls PostVersionFunc.
-func (mock *ClienterMock) PostVersion(ctx context.Context, headers sdk.Headers, datasetID string, editionID string, versionID string, version models.Version) (*models.Version, error) {
+func (mock *ClienterMock) PostVersion(ctx context.Context, headers sdk.Headers, datasetID string, editionID string, versionID string, version models.Version, isLatest bool) (*models.Version, error) {
 	if mock.PostVersionFunc == nil {
 		panic("ClienterMock.PostVersionFunc: method is nil but Clienter.PostVersion was just called")
 	}
@@ -1352,6 +1354,7 @@ func (mock *ClienterMock) PostVersion(ctx context.Context, headers sdk.Headers, 
 		EditionID string
 		VersionID string
 		Version   models.Version
+		IsLatest  bool
 	}{
 		Ctx:       ctx,
 		Headers:   headers,
@@ -1359,11 +1362,12 @@ func (mock *ClienterMock) PostVersion(ctx context.Context, headers sdk.Headers, 
 		EditionID: editionID,
 		VersionID: versionID,
 		Version:   version,
+		IsLatest:  isLatest,
 	}
 	mock.lockPostVersion.Lock()
 	mock.calls.PostVersion = append(mock.calls.PostVersion, callInfo)
 	mock.lockPostVersion.Unlock()
-	return mock.PostVersionFunc(ctx, headers, datasetID, editionID, versionID, version)
+	return mock.PostVersionFunc(ctx, headers, datasetID, editionID, versionID, version, isLatest)
 }
 
 // PostVersionCalls gets all the calls that were made to PostVersion.
@@ -1377,6 +1381,7 @@ func (mock *ClienterMock) PostVersionCalls() []struct {
 	EditionID string
 	VersionID string
 	Version   models.Version
+	IsLatest  bool
 } {
 	var calls []struct {
 		Ctx       context.Context
@@ -1385,6 +1390,7 @@ func (mock *ClienterMock) PostVersionCalls() []struct {
 		EditionID string
 		VersionID string
 		Version   models.Version
+		IsLatest  bool
 	}
 	mock.lockPostVersion.RLock()
 	calls = mock.calls.PostVersion

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -463,7 +463,7 @@ func (c *Client) PutVersionState(ctx context.Context, headers Headers, datasetID
 }
 
 // PostVersion creates a specific version for a dataset series
-func (c *Client) PostVersion(ctx context.Context, headers Headers, datasetID, editionID, versionID string, version models.Version, isLatest ...bool) (createdVersion *models.Version, err error) {
+func (c *Client) PostVersion(ctx context.Context, headers Headers, datasetID, editionID, versionID string, version models.Version, isLatest bool) (createdVersion *models.Version, err error) {
 	if err := validateRequiredParams(map[string]string{
 		"datasetID": datasetID,
 		"editionID": editionID,
@@ -478,9 +478,9 @@ func (c *Client) PostVersion(ctx context.Context, headers Headers, datasetID, ed
 		return createdVersion, err
 	}
 
-	if len(isLatest) > 0 {
+	if isLatest {
 		query := uri.Query()
-		query.Set("is_latest", strconv.FormatBool(isLatest[0]))
+		query.Set("is_latest", "true")
 		uri.RawQuery = query.Encode()
 	}
 

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -463,7 +463,7 @@ func (c *Client) PutVersionState(ctx context.Context, headers Headers, datasetID
 }
 
 // PostVersion creates a specific version for a dataset series
-func (c *Client) PostVersion(ctx context.Context, headers Headers, datasetID, editionID, versionID string, version models.Version) (createdVersion *models.Version, err error) {
+func (c *Client) PostVersion(ctx context.Context, headers Headers, datasetID, editionID, versionID string, version models.Version, isLatest ...bool) (createdVersion *models.Version, err error) {
 	if err := validateRequiredParams(map[string]string{
 		"datasetID": datasetID,
 		"editionID": editionID,
@@ -476,6 +476,12 @@ func (c *Client) PostVersion(ctx context.Context, headers Headers, datasetID, ed
 	uri.Path, err = url.JoinPath(c.hcCli.URL, "datasets", datasetID, "editions", editionID, "versions", versionID)
 	if err != nil {
 		return createdVersion, err
+	}
+
+	if len(isLatest) > 0 {
+		query := uri.Query()
+		query.Set("is_latest", strconv.FormatBool(isLatest[0]))
+		uri.RawQuery = query.Encode()
 	}
 
 	requestBody, err := json.Marshal(version)

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -846,7 +846,7 @@ func TestPostVersion(t *testing.T) {
 		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
 
 		Convey("And the parameters are valid", func() {
-			createdVersion, err := datasetAPIClient.PostVersion(ctx, headers, datasetID, editionID, versionID, exampleVersion)
+			createdVersion, err := datasetAPIClient.PostVersion(ctx, headers, datasetID, editionID, versionID, exampleVersion, false)
 
 			Convey("Then the request is successful", func() {
 				So(err, ShouldBeNil)
@@ -868,7 +868,7 @@ func TestPostVersion(t *testing.T) {
 		})
 
 		Convey("When all required parameters are not provided", func() {
-			createdVersion, err := datasetAPIClient.PostVersion(ctx, headers, "", "", "", exampleVersion)
+			createdVersion, err := datasetAPIClient.PostVersion(ctx, headers, "", "", "", exampleVersion, false)
 
 			Convey("Then an error is returned", func() {
 				So(err, ShouldNotBeNil)
@@ -897,7 +897,7 @@ func TestPostVersion(t *testing.T) {
 			httpClient = createHTTPClientMock(MockedHTTPResponse{http.StatusInternalServerError, expectedErrorResponse, map[string]string{}})
 			datasetAPIClient = newDatasetAPIHealthcheckClient(t, httpClient)
 
-			createdVersion, err := datasetAPIClient.PostVersion(ctx, headers, datasetID, editionID, versionID, exampleVersion)
+			createdVersion, err := datasetAPIClient.PostVersion(ctx, headers, datasetID, editionID, versionID, exampleVersion, false)
 
 			Convey("Then an error is returned", func() {
 				So(err, ShouldNotBeNil)
@@ -927,24 +927,8 @@ func TestPostVersion(t *testing.T) {
 			})
 		})
 
-		Convey("When is_latest=false is passed, the URI includes the query parameter", func() {
+		Convey("When is_latest=false is passed, the URI does not include the query parameter", func() {
 			createdVersion, err := datasetAPIClient.PostVersion(ctx, headers, datasetID, editionID, versionID, exampleVersion, false)
-
-			Convey("Then the request is successful", func() {
-				So(err, ShouldBeNil)
-				So(*createdVersion, ShouldResemble, expectedVersionResponse)
-			})
-
-			Convey("And the request URI includes is_latest=false", func() {
-				So(len(httpClient.DoCalls()), ShouldEqual, 1)
-				call := httpClient.DoCalls()[0]
-				So(call.Req.Method, ShouldEqual, http.MethodPost)
-				So(call.Req.URL.RequestURI(), ShouldEqual, fmt.Sprintf("/datasets/%s/editions/%s/versions/%s?is_latest=false", datasetID, editionID, versionID))
-			})
-		})
-
-		Convey("When is_latest is not passed, the URI does not include the query parameter", func() {
-			createdVersion, err := datasetAPIClient.PostVersion(ctx, headers, datasetID, editionID, versionID, exampleVersion)
 
 			Convey("Then the request is successful", func() {
 				So(err, ShouldBeNil)

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -910,5 +910,53 @@ func TestPostVersion(t *testing.T) {
 				So(createdVersion, ShouldBeNil)
 			})
 		})
+
+		Convey("When is_latest=true is passed, the URI includes the query parameter", func() {
+			createdVersion, err := datasetAPIClient.PostVersion(ctx, headers, datasetID, editionID, versionID, exampleVersion, true)
+
+			Convey("Then the request is successful", func() {
+				So(err, ShouldBeNil)
+				So(*createdVersion, ShouldResemble, expectedVersionResponse)
+			})
+
+			Convey("And the request URI includes is_latest=true", func() {
+				So(len(httpClient.DoCalls()), ShouldEqual, 1)
+				call := httpClient.DoCalls()[0]
+				So(call.Req.Method, ShouldEqual, http.MethodPost)
+				So(call.Req.URL.RequestURI(), ShouldEqual, fmt.Sprintf("/datasets/%s/editions/%s/versions/%s?is_latest=true", datasetID, editionID, versionID))
+			})
+		})
+
+		Convey("When is_latest=false is passed, the URI includes the query parameter", func() {
+			createdVersion, err := datasetAPIClient.PostVersion(ctx, headers, datasetID, editionID, versionID, exampleVersion, false)
+
+			Convey("Then the request is successful", func() {
+				So(err, ShouldBeNil)
+				So(*createdVersion, ShouldResemble, expectedVersionResponse)
+			})
+
+			Convey("And the request URI includes is_latest=false", func() {
+				So(len(httpClient.DoCalls()), ShouldEqual, 1)
+				call := httpClient.DoCalls()[0]
+				So(call.Req.Method, ShouldEqual, http.MethodPost)
+				So(call.Req.URL.RequestURI(), ShouldEqual, fmt.Sprintf("/datasets/%s/editions/%s/versions/%s?is_latest=false", datasetID, editionID, versionID))
+			})
+		})
+
+		Convey("When is_latest is not passed, the URI does not include the query parameter", func() {
+			createdVersion, err := datasetAPIClient.PostVersion(ctx, headers, datasetID, editionID, versionID, exampleVersion)
+
+			Convey("Then the request is successful", func() {
+				So(err, ShouldBeNil)
+				So(*createdVersion, ShouldResemble, expectedVersionResponse)
+			})
+
+			Convey("And the request URI does not include is_latest", func() {
+				So(len(httpClient.DoCalls()), ShouldEqual, 1)
+				call := httpClient.DoCalls()[0]
+				So(call.Req.Method, ShouldEqual, http.MethodPost)
+				So(call.Req.URL.RequestURI(), ShouldEqual, fmt.Sprintf("/datasets/%s/editions/%s/versions/%s", datasetID, editionID, versionID))
+			})
+		})
 	})
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -192,6 +192,12 @@ parameters:
             downloads:
               allOf:
                 - readOnly: false
+  is_latest:
+    name: is_latest
+    description: "A boolean value which, when true, sets the latest_version information at series level using the version number and edition provided in the path"
+    in: query
+    required: false
+    type: boolean
   limit:
     name: limit
     description: "Maximum number of items that will be returned. A value of zero will return zero items."
@@ -633,6 +639,7 @@ paths:
         - $ref: "#/parameters/edition"
         - $ref: "#/parameters/version"
         - $ref: "#/parameters/new_version"
+        - $ref: "#/parameters/is_latest"  
       security:
         - {}
         - Authorization: []
@@ -648,6 +655,7 @@ paths:
               * dataset id was incorrect
               * edition was incorrect
               * an unpublished version of the dataset already exists
+              * is_latest parameter is not a valid boolean
         401:
           description: "Unauthorised to update version of dataset"
         404:


### PR DESCRIPTION
### What

Add `is_latest` parameter to POST /versions/{number} endpoint, and update sdk
Jira - https://officefornationalstatistics.atlassian.net/browse/DIS-4756

### How to review

To test locally - 

- create a new version of a dataset with `is_latest=true` - POST `/datasets/{dataset_id}/editions/{edition}/versions/{version}?is_latest=true`
- in mongo, check the datasets collection for the dataset and confirm that `next.links.latest_version.href` and `next.links.latest_version.id` point to the version number just created
- create another version with `is_latest=false`, then check the same dataset document in mongo and confirm that `next.links.latest_version` is unchanged from what it was after the first step
- test an invalid `is_latest` param and confirm that the error response is something like this - 

```
{
    "errors": [
        {
            "code": "ErrInvalidQueryParameter",
            "description": "invalid query parameter: is_latest"
        }
    ]
}
```
Confirm changes make sense, tests pass

### Who can review

Anyone
