### PR TITLE
Feature/order editions by oldest version release date

### DIFF
--- a/api/editions.go
+++ b/api/editions.go
@@ -61,52 +61,15 @@ func (api *DatasetAPI) getEditions(w http.ResponseWriter, r *http.Request, limit
 	var totalCount int
 
 	if datasetType == models.Static.String() {
-		var versionResults []*models.Version
-		var unpublishedVersion *models.Version
-
-		versionResults, totalCount, err = api.dataStore.Backend.GetAllStaticVersions(ctx, datasetID, state, offset, limit)
+		results, totalCount, err = api.dataStore.Backend.GetEditionsStatic(ctx, datasetID, state, offset, limit)
 		if err != nil {
-			log.Error(ctx, "getEditions endpoint: unable to find versions for dataset", err, logData)
-			if err == errs.ErrVersionsNotFound {
-				http.Error(w, errs.ErrEditionsNotFound.Error(), http.StatusNotFound)
+			log.Error(ctx, "getEditions endpoint: unable to find editions for dataset", err, logData)
+			if err == errs.ErrEditionsNotFound {
+				http.Error(w, err.Error(), http.StatusNotFound)
 			} else {
 				http.Error(w, errs.ErrInternalServer.Error(), http.StatusInternalServerError)
 			}
 			return nil, 0, err
-		}
-
-		editionMap := make(map[string][]*models.Version)
-		editionOrder := make([]string, 0) // maps are unordered, so a separate slice is needed to maintain the order returned from MongoDB
-
-		for _, version := range versionResults {
-			if _, exists := editionMap[version.Edition]; !exists {
-				editionOrder = append(editionOrder, version.Edition)
-			}
-			editionMap[version.Edition] = append(editionMap[version.Edition], version)
-		}
-
-		for _, editionID := range editionOrder {
-			publishedVersion, err := api.dataStore.Backend.GetLatestVersionStatic(ctx, datasetID, editionID, models.PublishedState)
-			if err != nil && err != errs.ErrVersionNotFound {
-				log.Error(ctx, "getEdition endpoint: unable to find latest published static version", err, logData)
-				return nil, 0, err
-			}
-
-			if authorised {
-				unpublishedVersion, err = api.dataStore.Backend.GetLatestVersionStatic(ctx, datasetID, editionID, "")
-				if err != nil && err != errs.ErrVersionNotFound {
-					log.Error(ctx, "getEdition endpoint: unable to find latest unpublished static version", err, logData)
-					return nil, 0, err
-				}
-			}
-
-			edition, err := utils.MapVersionsToEditionUpdate(publishedVersion, unpublishedVersion)
-			if err != nil {
-				log.Error(ctx, "getEditions endpoint: failed to map versions to edition", err, logData)
-				return nil, 0, err
-			}
-
-			results = append(results, edition)
 		}
 	} else {
 		results, totalCount, err = api.dataStore.Backend.GetEditions(ctx, datasetID, state, offset, limit, authorised)

--- a/api/editions_test.go
+++ b/api/editions_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/mocks"
 	"github.com/ONSdigital/dp-dataset-api/models"
 	storetest "github.com/ONSdigital/dp-dataset-api/store/datastoretest"
-	"github.com/ONSdigital/dp-dataset-api/utils"
 	permissionsAPISDK "github.com/ONSdigital/dp-permissions-api/sdk"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
@@ -259,86 +258,6 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 			},
 		}
 
-		versions := []*models.Version{
-			{
-				DatasetID:   "123",
-				Edition:     "2023",
-				ReleaseDate: "2023-10-01",
-				Links: &models.VersionLinks{
-					Dataset: &models.LinkObject{
-						HRef: "http://localhost:22000/datasets/123",
-						ID:   "123",
-					},
-					Version: &models.LinkObject{
-						HRef: "http://localhost:22000/datasets/123/editions/2023/versions/1",
-						ID:   "1",
-					},
-					Edition: &models.LinkObject{
-						HRef: "http://localhost:22000/datasets/123/editions/2023",
-						ID:   "2023",
-					},
-				},
-				Version:            1,
-				LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
-				Alerts:             &[]models.Alert{{Description: "Test alert"}},
-				UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
-				Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
-				QualityDesignation: "Test quality designation",
-				State:              "published",
-			},
-			{
-				DatasetID:   "123",
-				Edition:     "2023",
-				ReleaseDate: "2023-10-01",
-				Links: &models.VersionLinks{
-					Dataset: &models.LinkObject{
-						HRef: "http://localhost:22000/datasets/123",
-						ID:   "123",
-					},
-					Version: &models.LinkObject{
-						HRef: "http://localhost:22000/datasets/123/editions/2023/versions/2",
-						ID:   "2",
-					},
-					Edition: &models.LinkObject{
-						HRef: "http://localhost:22000/datasets/123/editions/2023",
-						ID:   "2023",
-					},
-				},
-				Version:            2,
-				LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
-				Alerts:             &[]models.Alert{{Description: "Test alert"}},
-				UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
-				Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
-				QualityDesignation: "Test quality designation",
-				State:              "published",
-			},
-		}
-		publishedLatestVersion := &models.Version{
-			DatasetID:   "123",
-			Edition:     "2023",
-			ReleaseDate: "2023-10-01",
-			Links: &models.VersionLinks{
-				Dataset: &models.LinkObject{
-					HRef: "http://localhost:22000/datasets/123",
-					ID:   "123",
-				},
-				Version: &models.LinkObject{
-					HRef: "http://localhost:22000/datasets/123/editions/2023/versions/2",
-					ID:   "2",
-				},
-				Edition: &models.LinkObject{
-					HRef: "http://localhost:22000/datasets/123/editions/2023",
-					ID:   "2023",
-				},
-			},
-			Version:            2,
-			LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
-			Alerts:             &[]models.Alert{{Description: "Test alert"}},
-			UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
-			Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
-			QualityDesignation: "Test quality designation",
-			State:              "published",
-		}
 		mockedDataStore := &storetest.StorerMock{
 			IsStaticDatasetFunc: func(ctx context.Context, datasetID string) (bool, error) {
 				return true, nil
@@ -346,11 +265,8 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 			GetDatasetTypeFunc: func(_ context.Context, _ string, authorised bool) (string, error) {
 				return models.Static.String(), nil
 			},
-			GetAllStaticVersionsFunc: func(ctx context.Context, ID, state string, offset, limit int) ([]*models.Version, int, error) {
-				return versions, 2, nil
-			},
-			GetLatestVersionStaticFunc: func(ctx context.Context, datasetID, editionID, state string) (*models.Version, error) {
-				return publishedLatestVersion, nil
+			GetEditionsStaticFunc: func(context.Context, string, string, int, int) ([]*models.EditionUpdate, int, error) {
+				return editionsList, 1, nil
 			},
 		}
 
@@ -364,14 +280,12 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 		}
 
 		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{})
-		_, totalCount, _ := api.getEditions(w, r, 20, 0)
-
-		editions, err := utils.MapVersionsToEditionUpdate(publishedLatestVersion, nil)
+		list, totalCount, err := api.getEditions(w, r, 20, 0)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
-		So(len(mockedDataStore.GetAllStaticVersionsCalls()), ShouldEqual, 1)
-		So([]*models.EditionUpdate{editions}, ShouldEqual, editionsList)
-		So(totalCount, ShouldEqual, 2)
+		So(len(mockedDataStore.GetEditionsStaticCalls()), ShouldEqual, 1)
+		So(list, ShouldEqual, editionsList)
+		So(totalCount, ShouldEqual, 1)
 		So(err, ShouldEqual, nil)
 	})
 
@@ -461,112 +375,6 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 			},
 		}
 
-		versions := []*models.Version{
-			{
-				DatasetID:   "123",
-				Edition:     "2023",
-				ReleaseDate: "2023-10-01",
-				Links: &models.VersionLinks{
-					Dataset: &models.LinkObject{
-						HRef: "http://localhost:22000/datasets/123",
-						ID:   "123",
-					},
-					Version: &models.LinkObject{
-						HRef: "http://localhost:22000/datasets/123/editions/2023/versions/1",
-						ID:   "1",
-					},
-					Edition: &models.LinkObject{
-						HRef: "http://localhost:22000/datasets/123/editions/2023",
-						ID:   "2023",
-					},
-				},
-				Version:            1,
-				LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
-				Alerts:             &[]models.Alert{{Description: "Test alert"}},
-				UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
-				Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
-				QualityDesignation: "Test quality designation",
-				State:              "published",
-			},
-			{
-				DatasetID:   "123",
-				Edition:     "2023",
-				ReleaseDate: "2023-10-01",
-				Links: &models.VersionLinks{
-					Dataset: &models.LinkObject{
-						HRef: "http://localhost:22000/datasets/123",
-						ID:   "123",
-					},
-					Version: &models.LinkObject{
-						HRef: "http://localhost:22000/datasets/123/editions/2023/versions/2",
-						ID:   "2",
-					},
-					Edition: &models.LinkObject{
-						HRef: "http://localhost:22000/datasets/123/editions/2023",
-						ID:   "2023",
-					},
-				},
-				Version:            2,
-				LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
-				Alerts:             &[]models.Alert{{Description: "Test alert"}},
-				UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
-				Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
-				QualityDesignation: "Test quality designation",
-				State:              "associated",
-			},
-		}
-		publishedLatestVersion := &models.Version{
-			DatasetID:   "123",
-			Edition:     "2023",
-			ReleaseDate: "2023-10-01",
-			Links: &models.VersionLinks{
-				Dataset: &models.LinkObject{
-					HRef: "http://localhost:22000/datasets/123",
-					ID:   "123",
-				},
-				Version: &models.LinkObject{
-					HRef: "http://localhost:22000/datasets/123/editions/2023/versions/1",
-					ID:   "1",
-				},
-				Edition: &models.LinkObject{
-					HRef: "http://localhost:22000/datasets/123/editions/2023",
-					ID:   "2023",
-				},
-			},
-			Version:            1,
-			LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
-			Alerts:             &[]models.Alert{{Description: "Test alert"}},
-			UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
-			Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
-			QualityDesignation: "Test quality designation",
-			State:              "published",
-		}
-		unpublishedLatestVersion := &models.Version{
-			DatasetID:   "123",
-			Edition:     "2023",
-			ReleaseDate: "2023-10-01",
-			Links: &models.VersionLinks{
-				Dataset: &models.LinkObject{
-					HRef: "http://localhost:22000/datasets/123",
-					ID:   "123",
-				},
-				Version: &models.LinkObject{
-					HRef: "http://localhost:22000/datasets/123/editions/2023/versions/2",
-					ID:   "2",
-				},
-				Edition: &models.LinkObject{
-					HRef: "http://localhost:22000/datasets/123/editions/2023",
-					ID:   "2023",
-				},
-			},
-			Version:            2,
-			LastUpdated:        time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC),
-			Alerts:             &[]models.Alert{{Description: "Test alert"}},
-			UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
-			Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
-			QualityDesignation: "Test quality designation",
-			State:              "associated",
-		}
 		mockedDataStore := &storetest.StorerMock{
 			IsStaticDatasetFunc: func(ctx context.Context, datasetID string) (bool, error) {
 				return true, nil
@@ -574,11 +382,8 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 			GetDatasetTypeFunc: func(_ context.Context, _ string, authorised bool) (string, error) {
 				return models.Static.String(), nil
 			},
-			GetAllStaticVersionsFunc: func(ctx context.Context, ID, state string, offset, limit int) ([]*models.Version, int, error) {
-				return versions, 2, nil
-			},
-			GetLatestVersionStaticFunc: func(ctx context.Context, datasetID, editionID, state string) (*models.Version, error) {
-				return publishedLatestVersion, nil
+			GetEditionsStaticFunc: func(context.Context, string, string, int, int) ([]*models.EditionUpdate, int, error) {
+				return editionsList, 1, nil
 			},
 		}
 
@@ -592,14 +397,12 @@ func TestGetEditionsReturnsOK(t *testing.T) {
 		}
 
 		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{})
-		_, totalCount, _ := api.getEditions(w, r, 20, 0)
-
-		editions, err := utils.MapVersionsToEditionUpdate(publishedLatestVersion, unpublishedLatestVersion)
+		list, totalCount, err := api.getEditions(w, r, 20, 0)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(len(mockedDataStore.GetEditionsCalls()), ShouldEqual, 0)
-		So(len(mockedDataStore.GetAllStaticVersionsCalls()), ShouldEqual, 1)
-		So([]*models.EditionUpdate{editions}, ShouldEqual, editionsList)
-		So(totalCount, ShouldEqual, 2)
+		So(len(mockedDataStore.GetEditionsStaticCalls()), ShouldEqual, 1)
+		So(list, ShouldEqual, editionsList)
+		So(totalCount, ShouldEqual, 1)
 		So(err, ShouldEqual, nil)
 	})
 }
@@ -749,8 +552,8 @@ func TestGetEditionsReturnsError(t *testing.T) {
 			GetDatasetTypeFunc: func(_ context.Context, _ string, authorised bool) (string, error) {
 				return models.Static.String(), nil
 			},
-			GetAllStaticVersionsFunc: func(ctx context.Context, ID, state string, offset, limit int) ([]*models.Version, int, error) {
-				return nil, 0, errs.ErrVersionsNotFound
+			GetEditionsStaticFunc: func(context.Context, string, string, int, int) ([]*models.EditionUpdate, int, error) {
+				return nil, 0, errs.ErrEditionsNotFound
 			},
 		}
 
@@ -768,7 +571,7 @@ func TestGetEditionsReturnsError(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrEditionsNotFound.Error())
-		So(len(mockedDataStore.GetAllStaticVersionsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetEditionsStaticCalls()), ShouldEqual, 1)
 	})
 }
 

--- a/features/editions_static.feature
+++ b/features/editions_static.feature
@@ -15,7 +15,7 @@ Feature: GET editions static
             """
             [
                 {
-                    "id": "static-version-1",
+                    "id": "2024-version-1",
                     "edition": "2024",
                     "state": "published",
                     "version": 1,
@@ -42,7 +42,34 @@ Feature: GET editions static
                     "release_date": "2024-01-01T07:00:00.000Z"
                 },
                 {
-                    "id": "static-version-2",
+                    "id": "2024-version-2",
+                    "edition": "2024",
+                    "state": "published",
+                    "version": 2,
+                    "links": {
+                        "dataset": {
+                            "href": "/datasets/static-dataset",
+                            "id": "static-dataset"
+                        },
+                        "edition": {
+                            "href": "/datasets/static-dataset/editions/2024",
+                            "id": "2024"
+                        }
+                    },
+                    "type": "static",
+                    "distributions": [
+                        {
+                            "title": "Distribution 1",
+                            "format": "csv",
+                            "media_type": "text/csv",
+                            "download_url": "/uuid/filename.csv",
+                            "byte_size": 100000
+                        }
+                    ],
+                    "release_date": "2026-01-01T07:00:00.000Z"
+                },
+                {
+                    "id": "2025-version-1",
                     "edition": "2025",
                     "state": "published",
                     "version": 1,
@@ -71,7 +98,7 @@ Feature: GET editions static
             ]
             """
 
-    Scenario: GET /datasets/{id}/editions returns editions ordered by release_date
+    Scenario: GET /datasets/{id}/editions returns editions ordered by version 1 release_date
         When I GET "/datasets/static-dataset/editions"
         Then I should receive the following JSON response with status "200":
             """
@@ -112,7 +139,7 @@ Feature: GET editions static
                     },
                     {
                         "edition": "2024",
-                        "version": 1,
+                        "version": 2,
                         "state": "published",
                         "links": {
                             "dataset": {
@@ -120,8 +147,8 @@ Feature: GET editions static
                                 "id": "static-dataset"
                             },
                             "latest_version": {
-                                "href": "/datasets/static-dataset/editions/2024/versions/1",
-                                "id": "1"
+                                "href": "/datasets/static-dataset/editions/2024/versions/2",
+                                "id": "2"
                             },
                             "self": {
                                 "href": "/datasets/static-dataset/editions/2024",
@@ -140,11 +167,58 @@ Feature: GET editions static
                                 "byte_size": 100000
                             }
                         ],
-                        "release_date": "2024-01-01T07:00:00.000Z"
+                        "release_date": "2026-01-01T07:00:00.000Z"
                     }
                 ],
                 "limit": 20,
                 "offset": 0,
+                "total_count": 2
+            }
+            """
+        And the total number of audit events should be 0
+
+    Scenario: GET /datasets/{id}/editions returns paginated static editions
+        When I GET "/datasets/static-dataset/editions?limit=1&offset=1"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "count": 1,
+                "items": [
+                    {
+                        "edition": "2024",
+                        "version": 2,
+                        "state": "published",
+                        "links": {
+                            "dataset": {
+                                "href": "/datasets/static-dataset",
+                                "id": "static-dataset"
+                            },
+                            "latest_version": {
+                                "href": "/datasets/static-dataset/editions/2024/versions/2",
+                                "id": "2"
+                            },
+                            "self": {
+                                "href": "/datasets/static-dataset/editions/2024",
+                                "id": "2024"
+                            },
+                            "versions": {
+                                "href": "/datasets/static-dataset/editions/2024/versions"
+                            }
+                        },
+                        "distributions": [
+                            {
+                                "title": "Distribution 1",
+                                "format": "csv",
+                                "media_type": "text/csv",
+                                "download_url": "/uuid/filename.csv",
+                                "byte_size": 100000
+                            }
+                        ],
+                        "release_date": "2026-01-01T07:00:00.000Z"
+                    }
+                ],
+                "limit": 1,
+                "offset": 1,
                 "total_count": 2
             }
             """
@@ -188,7 +262,7 @@ Feature: GET editions static
             }
             """
         And the total number of audit events should be 0
-    
+
     Scenario: GET /datasets/{id}/editions/{edition} records audit event with authorised user
         Given private endpoints are enabled
         And I am a publisher user

--- a/features/editions_static_with_permissions.feature
+++ b/features/editions_static_with_permissions.feature
@@ -26,7 +26,7 @@ Feature: Dataset API - Static Editions Permissions
             """
             [
                 {
-                    "id": "test-version-population-1",
+                    "id": "January-version-1",
                     "edition": "January",
                     "edition_title": "January Edition Title",
                     "links": {
@@ -44,7 +44,25 @@ Feature: Dataset API - Static Editions Permissions
                     "type": "static"
                 },
                 {
-                    "id": "test-version-population-2",
+                    "id": "January-version-2",
+                    "edition": "January",
+                    "edition_title": "January Edition Title",
+                    "links": {
+                        "dataset": {
+                            "id": "population-estimates"
+                        },
+                        "edition": {
+                            "href": "/datasets/population-estimates/editions/January",
+                            "id": "January"
+                        }
+                    },
+                    "version": 2,
+                    "release_date": "2025-03-01T07:00:00.000Z",
+                    "state": "associated",
+                    "type": "static"
+                },
+                {
+                    "id": "February-version-1",
                     "edition": "February",
                     "edition_title": "February Edition Title",
                     "links": {
@@ -130,6 +148,47 @@ Feature: Dataset API - Static Editions Permissions
                                     "id": "population-estimates"
                                 },
                                 "latest_version": {
+                                    "href": "/datasets/population-estimates/editions/January/versions/2",
+                                    "id": "2"
+                                },
+                                "self": {
+                                    "href": "/datasets/population-estimates/editions/January",
+                                    "id": "January"
+                                },
+                                "versions": {
+                                    "href": "/datasets/population-estimates/editions/January/versions"
+                                }
+                            },
+                            "release_date": "2025-03-01T07:00:00.000Z",
+                            "state": "associated",
+                            "version": 2
+                        }
+                    }
+                ],
+                "limit": 20,
+                "offset": 0,
+                "total_count": 2
+            }
+            """
+
+    Scenario: GET /datasets/{id}/editions returns paginated results for Admin
+        Given private endpoints are enabled
+        And I am an admin user
+        When I GET "/datasets/population-estimates/editions?limit=1&offset=1"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "count": 1,
+                "items": [
+                    {
+                        "current": {
+                            "edition": "January",
+                            "edition_title": "January Edition Title",
+                            "links": {
+                                "dataset": {
+                                    "id": "population-estimates"
+                                },
+                                "latest_version": {
                                     "href": "/datasets/population-estimates/editions/January/versions/1",
                                     "id": "1"
                                 },
@@ -144,11 +203,34 @@ Feature: Dataset API - Static Editions Permissions
                             "release_date": "2025-01-01T07:00:00.000Z",
                             "state": "published",
                             "version": 1
+                        },
+                        "next": {
+                            "edition": "January",
+                            "edition_title": "January Edition Title",
+                            "links": {
+                                "dataset": {
+                                    "id": "population-estimates"
+                                },
+                                "latest_version": {
+                                    "href": "/datasets/population-estimates/editions/January/versions/2",
+                                    "id": "2"
+                                },
+                                "self": {
+                                    "href": "/datasets/population-estimates/editions/January",
+                                    "id": "January"
+                                },
+                                "versions": {
+                                    "href": "/datasets/population-estimates/editions/January/versions"
+                                }
+                            },
+                            "release_date": "2025-03-01T07:00:00.000Z",
+                            "state": "associated",
+                            "version": 2
                         }
                     }
                 ],
-                "limit": 20,
-                "offset": 0,
+                "limit": 1,
+                "offset": 1,
                 "total_count": 2
             }
             """
@@ -220,8 +302,8 @@ Feature: Dataset API - Static Editions Permissions
                                     "id": "population-estimates"
                                 },
                                 "latest_version": {
-                                    "href": "/datasets/population-estimates/editions/January/versions/1",
-                                    "id": "1"
+                                    "href": "/datasets/population-estimates/editions/January/versions/2",
+                                    "id": "2"
                                 },
                                 "self": {
                                     "href": "/datasets/population-estimates/editions/January",
@@ -231,9 +313,9 @@ Feature: Dataset API - Static Editions Permissions
                                     "href": "/datasets/population-estimates/editions/January/versions"
                                 }
                             },
-                            "release_date": "2025-01-01T07:00:00.000Z",
-                            "state": "published",
-                            "version": 1
+                            "release_date": "2025-03-01T07:00:00.000Z",
+                            "state": "associated",
+                            "version": 2
                         }
                     }
                 ],

--- a/mongo/mongo_test_helpers.go
+++ b/mongo/mongo_test_helpers.go
@@ -100,6 +100,22 @@ func setupVersionsTestData(ctx context.Context, mongoStore *Mongo) ([]*models.Ve
 			ReleaseDate: "2025-02-02T07:00:00.000Z",
 		},
 		{
+			ID:           "edition2-version1",
+			Edition:      "edition2",
+			EditionTitle: "Second Edition",
+			LastUpdated:  now.Add(-time.Hour),
+			Version:      1,
+			State:        models.AssociatedState,
+			Type:         "static",
+			ETag:         "edition2Version1ETag",
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{ID: staticDatasetID},
+				Edition: &models.LinkObject{ID: "edition2"},
+				Version: &models.LinkObject{ID: "1"},
+			},
+			ReleaseDate: "2024-02-02T07:00:00.000Z",
+		},
+		{
 			ID:           "version1",
 			Edition:      "edition1",
 			EditionTitle: "First Edition",

--- a/mongo/version_store.go
+++ b/mongo/version_store.go
@@ -10,6 +10,7 @@ import (
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
 	"github.com/ONSdigital/dp-dataset-api/config"
 	"github.com/ONSdigital/dp-dataset-api/models"
+	"github.com/ONSdigital/dp-dataset-api/utils"
 	mongodriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -274,6 +275,107 @@ func (m *Mongo) GetAllStaticVersions(ctx context.Context, datasetID, state strin
 	}
 
 	return results, totalCount, nil
+}
+
+// GetEditionsStatic retrieves a paginated list of editions for a given dataset.
+// Response is ordered by the release date of the oldest version for each edition.
+// Each Version record is mapped to an EditionUpdate with Current and Next set depending on the state.
+func (m *Mongo) GetEditionsStatic(ctx context.Context, datasetID, state string, offset, limit int) ([]*models.EditionUpdate, int, error) {
+	selector := bson.M{"links.dataset.id": datasetID}
+	if state != "" {
+		selector["state"] = state
+	}
+
+	pipeline := []bson.M{
+		{"$match": selector},
+		{"$sort": bson.M{
+			"edition": 1,
+			"version": 1,
+		}},
+		{"$group": bson.M{
+			"_id": "$edition",
+			"oldest_version_release_date": bson.M{
+				"$first": "$release_date",
+			},
+		}},
+		{"$sort": bson.M{
+			"oldest_version_release_date": -1,
+			"_id":                         1,
+		}},
+	}
+
+	if offset > 0 {
+		pipeline = append(pipeline, bson.M{"$skip": offset})
+	}
+	if limit > 0 {
+		pipeline = append(pipeline, bson.M{"$limit": limit})
+	}
+
+	pipeline = append(pipeline, bson.M{
+		"$project": bson.M{
+			"_id":        0,
+			"edition_id": "$_id",
+		},
+	})
+
+	var editionResults []struct {
+		EditionID string `bson:"edition_id"`
+	}
+
+	if err := m.Connection.Collection(m.ActualCollectionName(config.VersionsCollection)).Aggregate(ctx, pipeline, &editionResults); err != nil {
+		return nil, 0, err
+	}
+
+	sortedEditionIDs := make([]string, 0, len(editionResults))
+	for _, result := range editionResults {
+		sortedEditionIDs = append(sortedEditionIDs, result.EditionID)
+	}
+
+	countPipeline := []bson.M{
+		{"$match": selector},
+		{"$group": bson.M{
+			"_id": "$edition",
+		}},
+		{"$count": "total_count"},
+	}
+
+	var countResults []struct {
+		TotalCount int `bson:"total_count"`
+	}
+
+	if err := m.Connection.Collection(m.ActualCollectionName(config.VersionsCollection)).Aggregate(ctx, countPipeline, &countResults); err != nil {
+		return nil, 0, err
+	}
+
+	if len(countResults) == 0 {
+		return nil, 0, errs.ErrEditionsNotFound
+	}
+
+	totalCount := countResults[0].TotalCount
+
+	editions := make([]*models.EditionUpdate, 0, len(sortedEditionIDs))
+	for _, editionID := range sortedEditionIDs {
+		publishedVersion, err := m.GetLatestVersionStatic(ctx, datasetID, editionID, models.PublishedState)
+		if err != nil && !errors.Is(err, errs.ErrVersionNotFound) {
+			return nil, 0, err
+		}
+
+		var unpublishedVersion *models.Version
+		if state != models.PublishedState {
+			unpublishedVersion, err = m.GetLatestVersionStatic(ctx, datasetID, editionID, "")
+			if err != nil && !errors.Is(err, errs.ErrVersionNotFound) {
+				return nil, 0, err
+			}
+		}
+
+		edition, err := utils.MapVersionsToEditionUpdate(publishedVersion, unpublishedVersion)
+		if err != nil {
+			return nil, 0, err
+		}
+		editions = append(editions, edition)
+	}
+
+	return editions, totalCount, nil
 }
 
 func (m *Mongo) DeleteStaticDatasetVersion(ctx context.Context, datasetID, editionID string, versionNumber int) (err error) {

--- a/mongo/version_store_test.go
+++ b/mongo/version_store_test.go
@@ -68,7 +68,7 @@ func TestGetStaticVersionsByState(t *testing.T) {
 			Convey("Then the version is retrieved successfully", func() {
 				So(err, ShouldBeNil)
 				So(version, ShouldNotBeNil)
-				So(count, ShouldEqual, 2)
+				So(count, ShouldEqual, 3)
 				So(version[0].State, ShouldNotEqual, models.PublishedState)
 			})
 		})
@@ -121,7 +121,7 @@ func TestGetAllStaticVersions(t *testing.T) {
 			retrievedVersions, count, err := mongoStore.GetAllStaticVersions(ctx, staticDatasetID, "", 0, 0)
 
 			So(err, ShouldBeNil)
-			So(count, ShouldEqual, 2)
+			So(count, ShouldEqual, 3)
 			So(retrievedVersions, ShouldHaveLength, 0)
 		})
 
@@ -129,7 +129,7 @@ func TestGetAllStaticVersions(t *testing.T) {
 			retrievedVersions, count, err := mongoStore.GetAllStaticVersions(ctx, staticDatasetID, "", 1, 1)
 
 			So(err, ShouldBeNil)
-			So(count, ShouldEqual, 2)
+			So(count, ShouldEqual, 3)
 			So(retrievedVersions, ShouldHaveLength, 1)
 			So(retrievedVersions[0].ID, ShouldEqual, "version1")
 		})
@@ -138,7 +138,7 @@ func TestGetAllStaticVersions(t *testing.T) {
 			retrievedVersions, count, err := mongoStore.GetAllStaticVersions(ctx, staticDatasetID, "", 0, 1)
 
 			So(err, ShouldBeNil)
-			So(count, ShouldEqual, 2)
+			So(count, ShouldEqual, 3)
 			So(retrievedVersions, ShouldHaveLength, 1)
 
 			So(retrievedVersions[0].ID, ShouldEqual, "version2")
@@ -150,6 +150,81 @@ func TestGetAllStaticVersions(t *testing.T) {
 			So(err, ShouldEqual, errs.ErrVersionsNotFound)
 			So(count, ShouldEqual, 0)
 			So(retrievedVersions, ShouldBeNil)
+		})
+	})
+}
+
+func TestGetEditionsStatic(t *testing.T) {
+	Convey("Given MongoDB is running and populated with static versions", t, func() {
+		ctx := context.Background()
+		mongoStore, err := getTestMongoDB(ctx, t)
+		So(err, ShouldBeNil)
+
+		versions, err := setupVersionsTestData(ctx, mongoStore)
+		So(err, ShouldBeNil)
+		So(versions, ShouldNotBeEmpty)
+
+		Convey("When GetEditionsStatic is called with no state filter", func() {
+			retrievedEditions, count, err := mongoStore.GetEditionsStatic(ctx, staticDatasetID, "", 0, 20)
+
+			Convey("Then it returns the expected total number of unique editions", func() {
+				So(err, ShouldBeNil)
+				So(count, ShouldEqual, 2)
+				So(retrievedEditions, ShouldHaveLength, 2)
+			})
+
+			Convey("And the editions are ordered by version 1 release date in descending order", func() {
+				So(retrievedEditions[0].Next.Edition, ShouldEqual, "edition1")
+				So(retrievedEditions[1].Next.Edition, ShouldEqual, "edition2")
+			})
+
+			Convey("And each edition is mapped to the latest published and unpublished versions correctly", func() {
+				So(retrievedEditions[0].Current.Edition, ShouldEqual, "edition1")
+				So(retrievedEditions[0].Current.Version, ShouldEqual, 1)
+				So(retrievedEditions[0].Next.Edition, ShouldEqual, "edition1")
+				So(retrievedEditions[0].Next.Version, ShouldEqual, 1)
+
+				So(retrievedEditions[1].Current, ShouldBeNil)
+				So(retrievedEditions[1].Next.Edition, ShouldEqual, "edition2")
+				So(retrievedEditions[1].Next.Version, ShouldEqual, 2)
+			})
+		})
+
+		Convey("When GetEditionsStatic is called with pagination", func() {
+			retrievedEditions, count, err := mongoStore.GetEditionsStatic(ctx, staticDatasetID, "", 1, 1)
+
+			Convey("Then it returns a paginated subset while preserving the total edition count", func() {
+				So(err, ShouldBeNil)
+				So(count, ShouldEqual, 2)
+				So(retrievedEditions, ShouldHaveLength, 1)
+				So(retrievedEditions[0].Current, ShouldBeNil)
+				So(retrievedEditions[0].Next.Edition, ShouldEqual, "edition2")
+				So(retrievedEditions[0].Next.Version, ShouldEqual, 2)
+			})
+		})
+
+		Convey("When GetEditionsStatic is called with the published state", func() {
+			retrievedEditions, count, err := mongoStore.GetEditionsStatic(ctx, staticDatasetID, models.PublishedState, 0, 20)
+
+			Convey("Then it only returns editions that have published versions", func() {
+				So(err, ShouldBeNil)
+				So(count, ShouldEqual, 1)
+				So(retrievedEditions, ShouldHaveLength, 1)
+				So(retrievedEditions[0].Current.Edition, ShouldEqual, "edition1")
+				So(retrievedEditions[0].Current.Version, ShouldEqual, 1)
+				So(retrievedEditions[0].Next.Edition, ShouldEqual, "edition1")
+				So(retrievedEditions[0].Next.Version, ShouldEqual, 1)
+			})
+		})
+
+		Convey("When GetEditionsStatic is called with a non-existent datasetID", func() {
+			retrievedEditions, count, err := mongoStore.GetEditionsStatic(ctx, nonExistentDatasetID, "", 0, 20)
+
+			Convey("Then ErrEditionsNotFound is returned", func() {
+				So(err, ShouldEqual, errs.ErrEditionsNotFound)
+				So(count, ShouldEqual, 0)
+				So(retrievedEditions, ShouldBeNil)
+			})
 		})
 	})
 }
@@ -203,7 +278,7 @@ func TestDeleteStaticDatasetVersion(t *testing.T) {
 
 			versions, err := setupVersionsTestData(ctx, mongoStore)
 			So(err, ShouldBeNil)
-			So(versions, ShouldHaveLength, 4)
+			So(versions, ShouldHaveLength, 5)
 
 			datasetToDelete := staticDatasetID
 			editionToDelete := "edition2"
@@ -214,7 +289,7 @@ func TestDeleteStaticDatasetVersion(t *testing.T) {
 			selector := bson.M{"links.dataset.id": staticDatasetID}
 			totalCount, err := mongoStore.Connection.Collection(mongoStore.ActualCollectionName(config.VersionsCollection)).Count(ctx, selector)
 			So(err, ShouldBeNil)
-			So(totalCount, ShouldEqual, 1)
+			So(totalCount, ShouldEqual, 2)
 		})
 	})
 }

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -39,6 +39,7 @@ type dataMongoDB interface {
 	GetDimensionOptionsFromIDs(ctx context.Context, version *models.Version, dimension string, ids []string) ([]*models.PublicDimensionOption, int, error)
 	GetEdition(ctx context.Context, ID, editionID, state string) (*models.EditionUpdate, error)
 	GetEditions(ctx context.Context, ID, state string, offset, limit int, authorised bool) ([]*models.EditionUpdate, int, error)
+	GetEditionsStatic(ctx context.Context, datasetID, state string, offset, limit int) ([]*models.EditionUpdate, int, error)
 	GetStaticVersionsByState(ctx context.Context, state, publishedOnly string, offset, limit int) ([]*models.Version, int, error)
 	GetAllStaticVersions(ctx context.Context, ID, state string, offset, limit int) ([]*models.Version, int, error)
 	GetInstances(ctx context.Context, states []string, datasets []string, offset, limit int) ([]*models.Instance, int, error)

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -102,6 +102,9 @@ var _ store.Storer = &StorerMock{}
 //			GetEditionsFunc: func(ctx context.Context, ID string, state string, offset int, limit int, authorised bool) ([]*models.EditionUpdate, int, error) {
 //				panic("mock out the GetEditions method")
 //			},
+//			GetEditionsStaticFunc: func(ctx context.Context, datasetID string, state string, offset int, limit int) ([]*models.EditionUpdate, int, error) {
+//				panic("mock out the GetEditionsStatic method")
+//			},
 //			GetInstanceFunc: func(ctx context.Context, ID string, eTagSelector string) (*models.Instance, error) {
 //				panic("mock out the GetInstance method")
 //			},
@@ -288,6 +291,9 @@ type StorerMock struct {
 
 	// GetEditionsFunc mocks the GetEditions method.
 	GetEditionsFunc func(ctx context.Context, ID string, state string, offset int, limit int, authorised bool) ([]*models.EditionUpdate, int, error)
+
+	// GetEditionsStaticFunc mocks the GetEditionsStatic method.
+	GetEditionsStaticFunc func(ctx context.Context, datasetID string, state string, offset int, limit int) ([]*models.EditionUpdate, int, error)
 
 	// GetInstanceFunc mocks the GetInstance method.
 	GetInstanceFunc func(ctx context.Context, ID string, eTagSelector string) (*models.Instance, error)
@@ -658,6 +664,19 @@ type StorerMock struct {
 			Limit int
 			// Authorised is the authorised argument value.
 			Authorised bool
+		}
+		// GetEditionsStatic holds details about calls to the GetEditionsStatic method.
+		GetEditionsStatic []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// DatasetID is the datasetID argument value.
+			DatasetID string
+			// State is the state argument value.
+			State string
+			// Offset is the offset argument value.
+			Offset int
+			// Limit is the limit argument value.
+			Limit int
 		}
 		// GetInstance holds details about calls to the GetInstance method.
 		GetInstance []struct {
@@ -1032,6 +1051,7 @@ type StorerMock struct {
 	lockGetDimensionsFromInstance           sync.RWMutex
 	lockGetEdition                          sync.RWMutex
 	lockGetEditions                         sync.RWMutex
+	lockGetEditionsStatic                   sync.RWMutex
 	lockGetInstance                         sync.RWMutex
 	lockGetInstances                        sync.RWMutex
 	lockGetLatestVersionStatic              sync.RWMutex
@@ -2196,6 +2216,54 @@ func (mock *StorerMock) GetEditionsCalls() []struct {
 	mock.lockGetEditions.RLock()
 	calls = mock.calls.GetEditions
 	mock.lockGetEditions.RUnlock()
+	return calls
+}
+
+// GetEditionsStatic calls GetEditionsStaticFunc.
+func (mock *StorerMock) GetEditionsStatic(ctx context.Context, datasetID string, state string, offset int, limit int) ([]*models.EditionUpdate, int, error) {
+	if mock.GetEditionsStaticFunc == nil {
+		panic("StorerMock.GetEditionsStaticFunc: method is nil but Storer.GetEditionsStatic was just called")
+	}
+	callInfo := struct {
+		Ctx       context.Context
+		DatasetID string
+		State     string
+		Offset    int
+		Limit     int
+	}{
+		Ctx:       ctx,
+		DatasetID: datasetID,
+		State:     state,
+		Offset:    offset,
+		Limit:     limit,
+	}
+	mock.lockGetEditionsStatic.Lock()
+	mock.calls.GetEditionsStatic = append(mock.calls.GetEditionsStatic, callInfo)
+	mock.lockGetEditionsStatic.Unlock()
+	return mock.GetEditionsStaticFunc(ctx, datasetID, state, offset, limit)
+}
+
+// GetEditionsStaticCalls gets all the calls that were made to GetEditionsStatic.
+// Check the length with:
+//
+//	len(mockedStorer.GetEditionsStaticCalls())
+func (mock *StorerMock) GetEditionsStaticCalls() []struct {
+	Ctx       context.Context
+	DatasetID string
+	State     string
+	Offset    int
+	Limit     int
+} {
+	var calls []struct {
+		Ctx       context.Context
+		DatasetID string
+		State     string
+		Offset    int
+		Limit     int
+	}
+	mock.lockGetEditionsStatic.RLock()
+	calls = mock.calls.GetEditionsStatic
+	mock.lockGetEditionsStatic.RUnlock()
 	return calls
 }
 

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -106,6 +106,9 @@ var _ store.MongoDB = &MongoDBMock{}
 //			GetEditionsFunc: func(ctx context.Context, ID string, state string, offset int, limit int, authorised bool) ([]*models.EditionUpdate, int, error) {
 //				panic("mock out the GetEditions method")
 //			},
+//			GetEditionsStaticFunc: func(ctx context.Context, datasetID string, state string, offset int, limit int) ([]*models.EditionUpdate, int, error) {
+//				panic("mock out the GetEditionsStatic method")
+//			},
 //			GetInstanceFunc: func(ctx context.Context, ID string, eTagSelector string) (*models.Instance, error) {
 //				panic("mock out the GetInstance method")
 //			},
@@ -292,6 +295,9 @@ type MongoDBMock struct {
 
 	// GetEditionsFunc mocks the GetEditions method.
 	GetEditionsFunc func(ctx context.Context, ID string, state string, offset int, limit int, authorised bool) ([]*models.EditionUpdate, int, error)
+
+	// GetEditionsStaticFunc mocks the GetEditionsStatic method.
+	GetEditionsStaticFunc func(ctx context.Context, datasetID string, state string, offset int, limit int) ([]*models.EditionUpdate, int, error)
 
 	// GetInstanceFunc mocks the GetInstance method.
 	GetInstanceFunc func(ctx context.Context, ID string, eTagSelector string) (*models.Instance, error)
@@ -658,6 +664,19 @@ type MongoDBMock struct {
 			Limit int
 			// Authorised is the authorised argument value.
 			Authorised bool
+		}
+		// GetEditionsStatic holds details about calls to the GetEditionsStatic method.
+		GetEditionsStatic []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// DatasetID is the datasetID argument value.
+			DatasetID string
+			// State is the state argument value.
+			State string
+			// Offset is the offset argument value.
+			Offset int
+			// Limit is the limit argument value.
+			Limit int
 		}
 		// GetInstance holds details about calls to the GetInstance method.
 		GetInstance []struct {
@@ -1026,6 +1045,7 @@ type MongoDBMock struct {
 	lockGetDimensionsFromInstance           sync.RWMutex
 	lockGetEdition                          sync.RWMutex
 	lockGetEditions                         sync.RWMutex
+	lockGetEditionsStatic                   sync.RWMutex
 	lockGetInstance                         sync.RWMutex
 	lockGetInstances                        sync.RWMutex
 	lockGetLatestVersionStatic              sync.RWMutex
@@ -2209,6 +2229,54 @@ func (mock *MongoDBMock) GetEditionsCalls() []struct {
 	mock.lockGetEditions.RLock()
 	calls = mock.calls.GetEditions
 	mock.lockGetEditions.RUnlock()
+	return calls
+}
+
+// GetEditionsStatic calls GetEditionsStaticFunc.
+func (mock *MongoDBMock) GetEditionsStatic(ctx context.Context, datasetID string, state string, offset int, limit int) ([]*models.EditionUpdate, int, error) {
+	if mock.GetEditionsStaticFunc == nil {
+		panic("MongoDBMock.GetEditionsStaticFunc: method is nil but MongoDB.GetEditionsStatic was just called")
+	}
+	callInfo := struct {
+		Ctx       context.Context
+		DatasetID string
+		State     string
+		Offset    int
+		Limit     int
+	}{
+		Ctx:       ctx,
+		DatasetID: datasetID,
+		State:     state,
+		Offset:    offset,
+		Limit:     limit,
+	}
+	mock.lockGetEditionsStatic.Lock()
+	mock.calls.GetEditionsStatic = append(mock.calls.GetEditionsStatic, callInfo)
+	mock.lockGetEditionsStatic.Unlock()
+	return mock.GetEditionsStaticFunc(ctx, datasetID, state, offset, limit)
+}
+
+// GetEditionsStaticCalls gets all the calls that were made to GetEditionsStatic.
+// Check the length with:
+//
+//	len(mockedMongoDB.GetEditionsStaticCalls())
+func (mock *MongoDBMock) GetEditionsStaticCalls() []struct {
+	Ctx       context.Context
+	DatasetID string
+	State     string
+	Offset    int
+	Limit     int
+} {
+	var calls []struct {
+		Ctx       context.Context
+		DatasetID string
+		State     string
+		Offset    int
+		Limit     int
+	}
+	mock.lockGetEditionsStatic.RLock()
+	calls = mock.calls.GetEditionsStatic
+	mock.lockGetEditionsStatic.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
### What

Tickets:
https://officefornationalstatistics.atlassian.net/browse/DIS-3478
https://officefornationalstatistics.atlassian.net/browse/DIS-4798

- Fix pagination for `GET /editions` for static datasets
- Order editions by release date of version 1 of each edition

**Notes:**
- The ordering uses the oldest version release date. (Just in case version 1 doesn't exists as an edge case which shouldn't happen)
- Moved `version` to `EditonUpdate` mapping into mongo function to make handler code cleaner. The other option was to return the list of ordered EditionIDs and then fetch each edition in the handler but it made more sense to have the mongo layer do the mapping in case we call the function elsewhere

### How to review

- Create multiple editions and versions (published and unpublished)
- `GET /editions` should return unique editions ordered by the release date of version 1
- Example data with the issue can be seen within the pagination bug ticket
- Pagination should work correctly. Total count should be correct with limit and offset being applied correctly

### Who can review

- Anyone
