### PR TITLE
add web_page link into VersionLinks

### DIFF
--- a/models/version.go
+++ b/models/version.go
@@ -128,6 +128,7 @@ type VersionLinks struct {
 	Self       *LinkObject `bson:"self,omitempty"        json:"self,omitempty"`
 	Spatial    *LinkObject `bson:"spatial,omitempty"     json:"spatial,omitempty"`
 	Version    *LinkObject `bson:"version,omitempty"     json:"-"`
+	WebPage    *LinkObject `bson:"web_page,omitempty"    json:"web_page,omitempty"`
 }
 
 func (vl *VersionLinks) DeepCopy() *VersionLinks {
@@ -166,6 +167,12 @@ func (vl *VersionLinks) DeepCopy() *VersionLinks {
 		dst.Version = &LinkObject{
 			ID:   vl.Version.ID,
 			HRef: vl.Version.HRef,
+		}
+	}
+	if vl.WebPage != nil {
+		dst.WebPage = &LinkObject{
+			ID:   vl.WebPage.ID,
+			HRef: vl.WebPage.HRef,
 		}
 	}
 	return dst

--- a/models/version_test.go
+++ b/models/version_test.go
@@ -412,6 +412,10 @@ func TestVersionLinksDeepCopy(t *testing.T) {
 				ID:   "versionID",
 				HRef: "versionHRef",
 			},
+			WebPage: &LinkObject{
+				ID:   "webPageID",
+				HRef: "webPageHRef",
+			},
 		}
 
 		Convey("Then doing a deep copy of it results in a new fully populated VersionLinks", func() {
@@ -441,6 +445,10 @@ func TestVersionLinksDeepCopy(t *testing.T) {
 					ID:   "versionID",
 					HRef: "versionHRef",
 				},
+				WebPage: &LinkObject{
+					ID:   "webPageID",
+					HRef: "webPageHRef",
+				},
 			})
 
 			So(vl2, ShouldNotPointTo, vl)
@@ -450,6 +458,7 @@ func TestVersionLinksDeepCopy(t *testing.T) {
 			So(vl2.Self, ShouldNotPointTo, vl.Self)
 			So(vl2.Spatial, ShouldNotPointTo, vl.Spatial)
 			So(vl2.Version, ShouldNotPointTo, vl.Version)
+			So(vl2.WebPage, ShouldNotPointTo, vl.WebPage)
 		})
 	})
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2916,13 +2916,22 @@ definitions:
             description: "A URL to this resource"
             type: string
             example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/july-september-2017/versions/5"
+      web_page:
+        description: "A link to the location of this version of the dataset on the web"
+        readOnly: true
+        type: object
+        properties:
+          href:
+            description: "The uri to the location of this version of the dataset on the web"
+            type: string
+            example: "https://www.ons.gov.uk/businessindustryandtrade/datasets/my-dataset/editions/july-september-2017/versions/5"
       versions:
         type: object
         readOnly: true
         properties:
           href:
             description: "A URL to all versions for an edition of a dataset"
-            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/edition/july-september-2017/versions"
+            example: "https://api.beta.ons.gov.uk/v1/datasets/my-dataset/editions/july-september-2017/versions"
             type: string
   DatasetLink:
     description: "An object containing the dataset id and link"


### PR DESCRIPTION
### What

Linked to https://officefornationalstatistics.atlassian.net/browse/DIS-4794

- Update version model and swagger spec so `web_page` link exists within `VersionLinks`. This shouldn't cause any issues as the field is not in use yet.
- This is being done first as there are 3 tickets which require this model so it's being updated in advance

### How to review

- Check changes are ok

### Who can review

- Anyone
