### PR TITLE
Feature/rewrite web page url

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -161,8 +161,9 @@ func (api *DatasetAPI) getVersions(w http.ResponseWriter, r *http.Request, limit
 	if api.enableURLRewriting {
 		datasetLinksBuilder := links.FromHeadersOrDefault(&r.Header, api.urlBuilder.GetDatasetAPIURL())
 		codeListLinksBuilder := links.FromHeadersOrDefault(&r.Header, api.urlBuilder.GetCodeListAPIURL())
+		websiteLinksBuilder := &links.Builder{URL: api.urlBuilder.GetWebsiteURL()}
 
-		list, err = utils.RewriteVersions(ctx, list, datasetLinksBuilder, codeListLinksBuilder, api.urlBuilder.GetDownloadServiceURL())
+		list, err = utils.RewriteVersions(ctx, list, datasetLinksBuilder, codeListLinksBuilder, websiteLinksBuilder, api.urlBuilder.GetDownloadServiceURL())
 		if err != nil {
 			log.Error(ctx, "getVersions endpoint: error rewriting dimension, version, download or distribution links", err)
 			handleVersionAPIErr(ctx, err, w, logData)
@@ -288,10 +289,11 @@ func (api *DatasetAPI) getVersion(w http.ResponseWriter, r *http.Request) (*mode
 	if api.enableURLRewriting {
 		datasetLinksBuilder := links.FromHeadersOrDefault(&r.Header, api.urlBuilder.GetDatasetAPIURL())
 		codeListLinksBuilder := links.FromHeadersOrDefault(&r.Header, api.urlBuilder.GetCodeListAPIURL())
+		websiteLinksBuilder := &links.Builder{URL: api.urlBuilder.GetWebsiteURL()}
 
 		var err error
 
-		err = utils.RewriteVersionLinks(ctx, v.Links, datasetLinksBuilder)
+		err = utils.RewriteVersionLinks(ctx, v.Links, datasetLinksBuilder, websiteLinksBuilder)
 		if err != nil {
 			log.Error(ctx, "getVersion endpoint: failed to rewrite version links", err, logData)
 			return nil, models.NewErrorResponse(getVersionAPIErrStatusCode(err), nil, models.NewError(err, "failed to rewrite version links", "internal error"))

--- a/features/static_versions_get.feature
+++ b/features/static_versions_get.feature
@@ -38,6 +38,9 @@ Feature: Static versions GET /versions
                         },
                         "self": {
                             "href": "/datasets/test-static/editions/test-edition-static/versions/1"
+                        },
+                        "web_page": {
+                            "href": "/economy/datasets/test-static/editions/test-edition-static/versions/1"
                         }
                     },
                     "state": "created",
@@ -67,6 +70,9 @@ Feature: Static versions GET /versions
                         },
                         "self": {
                             "href": "/datasets/test-static/editions/test-edition-static-approved/versions/1"
+                        },
+                        "web_page": {
+                            "href": "/economy/datasets/test-static/editions/test-edition-static-approved/versions/1"
                         }
                     },
                     "state": "approved",
@@ -96,6 +102,9 @@ Feature: Static versions GET /versions
                         },
                         "self": {
                             "href": "/datasets/test-static/editions/test-edition-published/versions/1"
+                        },
+                        "web_page": {
+                            "href": "/economy/datasets/test-static/editions/test-edition-published/versions/1"
                         }
                     },
                     "state": "published",
@@ -139,6 +148,9 @@ Feature: Static versions GET /versions
                             },
                             "self": {
                                 "href": "/datasets/test-static/editions/test-edition-static-approved/versions/1"
+                            },
+                            "web_page": {
+                                "href": "/economy/datasets/test-static/editions/test-edition-static-approved/versions/1"
                             }
                         },
                         "edition": "test-edition-static-approved",
@@ -157,6 +169,103 @@ Feature: Static versions GET /versions
                 "limit": 20,
                 "offset": 0,
                 "total_count": 1
+            }
+            """
+
+    Scenario: GET /datasets/test-static/editions/test-edition-static-approved/versions in private mode rewrites all links when URL rewriting is enabled
+        Given private endpoints are enabled
+        And URL rewriting is enabled
+        And I set the "X-Forwarded-Host" header to "api.example.com"
+        And I set the "X-Forwarded-Path-Prefix" header to "v1"
+        And I am an admin user
+        When I GET "/datasets/test-static/editions/test-edition-static-approved/versions"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "count": 1,
+                "items": [
+                    {
+                        "dataset_id": "test-static",
+                        "id": "test-static-version-approved",
+                        "last_updated":"2021-01-01T00:00:01Z",
+                        "type":"static",
+                        "version": 1,
+                        "state": "approved",
+                        "links": {
+                            "dataset": {
+                                "id": "test-static"
+                            },
+                            "edition": {
+                                "href": "https://api.example.com/v1/datasets/test-static/editions/test-edition-static-approved",
+                                "id": "test-edition-static-approved"
+                            },
+                            "self": {
+                                "href": "https://api.example.com/v1/datasets/test-static/editions/test-edition-static-approved/versions/1"
+                            },
+                            "web_page": {
+                                "href": "http://localhost:20000/economy/datasets/test-static/editions/test-edition-static-approved/versions/1"
+                            }
+                        },
+                        "edition": "test-edition-static-approved",
+                        "edition_title": "Test Edition Static Approved Title",
+                        "distributions": [
+                            {
+                                "title": "Distribution 1",
+                                "format": "csv",
+                                "media_type": "text/csv",
+                                "download_url": "http://localhost:23600/downloads/files/uuid/filename.csv",
+                                "byte_size": 100000
+                            }
+                        ]
+                    }
+                ],
+                "limit": 20,
+                "offset": 0,
+                "total_count": 1
+            }
+            """
+
+    Scenario: GET /datasets/test-static/editions/test-edition-static-approved/versions/1 in private mode rewrites all links when URL rewriting is enabled
+        Given private endpoints are enabled
+        And URL rewriting is enabled
+        And I set the "X-Forwarded-Host" header to "api.example.com"
+        And I set the "X-Forwarded-Path-Prefix" header to "v1"
+        And I am an admin user
+        When I GET "/datasets/test-static/editions/test-edition-static-approved/versions/1"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "id": "test-static-version-approved",
+                "last_updated":"2021-01-01T00:00:01Z",
+                "type":"static",
+                "version": 1,
+                "state": "approved",
+                "links": {
+                    "dataset": {
+                        "id": "test-static"
+                    },
+                    "edition": {
+                        "href": "https://api.example.com/v1/datasets/test-static/editions/test-edition-static-approved",
+                        "id": "test-edition-static-approved"
+                    },
+                    "self": {
+                        "href": "https://api.example.com/v1/datasets/test-static/editions/test-edition-static-approved/versions/1"
+                    },
+                    "web_page": {
+                        "href": "http://localhost:20000/economy/datasets/test-static/editions/test-edition-static-approved/versions/1"
+                    }
+                },
+                "edition": "test-edition-static-approved",
+                "edition_title": "Test Edition Static Approved Title",
+                "distributions": [
+                    {
+                        "title": "Distribution 1",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "download_url": "http://localhost:23600/downloads/files/uuid/filename.csv",
+                        "byte_size": 100000
+                    }
+                ]
             }
             """
 

--- a/utils/rewriting.go
+++ b/utils/rewriting.go
@@ -474,7 +474,7 @@ func RewriteMetadataLinks(ctx context.Context, oldLinks *models.MetadataLinks, d
 	return nil
 }
 
-func RewriteVersions(ctx context.Context, results []models.Version, datasetLinksBuilder, codeListLinksBuilder *links.Builder, downloadServiceURL *url.URL) ([]models.Version, error) {
+func RewriteVersions(ctx context.Context, results []models.Version, datasetLinksBuilder, codeListLinksBuilder, websiteLinksBuilder *links.Builder, downloadServiceURL *url.URL) ([]models.Version, error) {
 	if len(results) == 0 {
 		return results, nil
 	}
@@ -491,7 +491,7 @@ func RewriteVersions(ctx context.Context, results []models.Version, datasetLinks
 			return nil, err
 		}
 
-		err = RewriteVersionLinks(ctx, item.Links, datasetLinksBuilder)
+		err = RewriteVersionLinks(ctx, item.Links, datasetLinksBuilder, websiteLinksBuilder)
 		if err != nil {
 			log.Error(ctx, "failed to rewrite version links", err)
 			return nil, err
@@ -515,7 +515,7 @@ func RewriteVersions(ctx context.Context, results []models.Version, datasetLinks
 	return items, nil
 }
 
-func RewriteVersionLinks(ctx context.Context, oldLinks *models.VersionLinks, datasetLinksBuilder *links.Builder) error {
+func RewriteVersionLinks(ctx context.Context, oldLinks *models.VersionLinks, datasetLinksBuilder, websiteLinksBuilder *links.Builder) error {
 	if oldLinks == nil {
 		return nil
 	}
@@ -537,6 +537,14 @@ func RewriteVersionLinks(ctx context.Context, oldLinks *models.VersionLinks, dat
 				log.Error(ctx, "failed to rewrite link", err, log.Data{"link": link.HRef})
 				return err
 			}
+		}
+	}
+
+	if oldLinks.WebPage != nil && oldLinks.WebPage.HRef != "" {
+		oldLinks.WebPage.HRef, err = websiteLinksBuilder.BuildLink(oldLinks.WebPage.HRef)
+		if err != nil {
+			log.Error(ctx, "failed to rewrite web page link", err, log.Data{"link": oldLinks.WebPage.HRef})
+			return err
 		}
 	}
 

--- a/utils/rewriting_test.go
+++ b/utils/rewriting_test.go
@@ -15,6 +15,7 @@ import (
 var (
 	codeListAPIURL     = &neturl.URL{Scheme: "http", Host: "localhost:22400"}
 	datasetAPIURL      = &neturl.URL{Scheme: "http", Host: "localhost:22000"}
+	websiteURL         = &neturl.URL{Scheme: "http", Host: "localhost:20000"}
 	downloadServiceURL = &neturl.URL{Scheme: "http", Host: "localhost:23600"}
 	importAPIURL       = &neturl.URL{Scheme: "http", Host: "localhost:21800"}
 )
@@ -3923,6 +3924,7 @@ func TestRewriteVersions_Success(t *testing.T) {
 	Convey("Given a list of versions", t, func() {
 		codeListLinksBuilder := links.FromHeadersOrDefault(&http.Header{}, codeListAPIURL)
 		datasetLinksBuilder := links.FromHeadersOrDefault(&http.Header{}, datasetAPIURL)
+		websiteLinksBuilder := links.FromHeadersOrDefault(&http.Header{}, websiteURL)
 
 		Convey("When the version, dimension, download and distribution links need rewriting", func() {
 			results := []models.Version{
@@ -3942,6 +3944,9 @@ func TestRewriteVersions_Success(t *testing.T) {
 						},
 						Self: &models.LinkObject{
 							HRef: "https://oldhost:1000/datasets/cpih01/editions/time-series/versions/53",
+						},
+						WebPage: &models.LinkObject{
+							HRef: "https://oldhost:1000/economy/datasets/cpih01/editions/time-series/versions/53",
 						},
 					},
 					Dimensions: []models.Dimension{
@@ -4036,6 +4041,9 @@ func TestRewriteVersions_Success(t *testing.T) {
 						Self: &models.LinkObject{
 							HRef: "https://oldhost:1000/datasets/cpih01/editions/time-series/versions/52",
 						},
+						WebPage: &models.LinkObject{
+							HRef: "https://oldhost:1000/economy/datasets/cpih01/editions/time-series/versions/52",
+						},
 					},
 					Dimensions: []models.Dimension{
 						{
@@ -4114,7 +4122,7 @@ func TestRewriteVersions_Success(t *testing.T) {
 				},
 			}
 
-			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, downloadServiceURL)
+			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, websiteLinksBuilder, downloadServiceURL)
 
 			Convey("Then the links should be rewritten correctly", func() {
 				So(err, ShouldBeNil)
@@ -4126,6 +4134,7 @@ func TestRewriteVersions_Success(t *testing.T) {
 				So(items[0].Links.Dataset.HRef, ShouldEqual, "http://localhost:22000/datasets/cpih01")
 				So(items[0].Links.Edition.HRef, ShouldEqual, "http://localhost:22000/datasets/cpih01/editions/time-series")
 				So(items[0].Links.Self.HRef, ShouldEqual, "http://localhost:22000/datasets/cpih01/editions/time-series/versions/53")
+				So(items[0].Links.WebPage.HRef, ShouldEqual, "http://localhost:20000/economy/datasets/cpih01/editions/time-series/versions/53")
 				So(items[0].Dimensions[0].Links.CodeList.HRef, ShouldEqual, "http://localhost:22400/code-lists/cpih1dim1aggid")
 				So(items[0].Dimensions[0].Links.Options.HRef, ShouldEqual, "http://localhost:22000/datasets/cpih01/editions/time-series/versions/1/dimensions/aggregate/options")
 				So(items[0].Dimensions[0].Links.Version.HRef, ShouldEqual, "http://localhost:22000/datasets/cpih01/editions/time-series/versions/1")
@@ -4152,6 +4161,7 @@ func TestRewriteVersions_Success(t *testing.T) {
 				So(items[1].Links.Dataset.HRef, ShouldEqual, "http://localhost:22000/datasets/cpih01")
 				So(items[1].Links.Edition.HRef, ShouldEqual, "http://localhost:22000/datasets/cpih01/editions/time-series")
 				So(items[1].Links.Self.HRef, ShouldEqual, "http://localhost:22000/datasets/cpih01/editions/time-series/versions/52")
+				So(items[1].Links.WebPage.HRef, ShouldEqual, "http://localhost:20000/economy/datasets/cpih01/editions/time-series/versions/52")
 				So(items[1].Dimensions[0].Links.CodeList.HRef, ShouldEqual, "http://localhost:22400/code-lists/cpih1dim1aggid")
 				So(items[1].Dimensions[0].Links.Options.HRef, ShouldEqual, "http://localhost:22000/datasets/cpih01/editions/time-series/versions/1/dimensions/aggregate/options")
 				So(items[1].Dimensions[0].Links.Version.HRef, ShouldEqual, "http://localhost:22000/datasets/cpih01/editions/time-series/versions/1")
@@ -4191,6 +4201,9 @@ func TestRewriteVersions_Success(t *testing.T) {
 						},
 						Self: &models.LinkObject{
 							HRef: "http://localhost:22000/datasets/cpih01/editions/time-series/versions/53",
+						},
+						WebPage: &models.LinkObject{
+							HRef: "http://localhost:20000/economy/datasets/cpih01/editions/time-series/versions/53",
 						},
 					},
 					Dimensions: []models.Dimension{
@@ -4285,6 +4298,9 @@ func TestRewriteVersions_Success(t *testing.T) {
 						Self: &models.LinkObject{
 							HRef: "http://localhost:22000/datasets/cpih01/editions/time-series/versions/52",
 						},
+						WebPage: &models.LinkObject{
+							HRef: "http://localhost:20000/economy/datasets/cpih01/editions/time-series/versions/52",
+						},
 					},
 					Dimensions: []models.Dimension{
 						{
@@ -4363,7 +4379,7 @@ func TestRewriteVersions_Success(t *testing.T) {
 				},
 			}
 
-			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, downloadServiceURL)
+			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, websiteLinksBuilder, downloadServiceURL)
 
 			Convey("Then the links should remain the same", func() {
 				So(err, ShouldBeNil)
@@ -4375,6 +4391,7 @@ func TestRewriteVersions_Success(t *testing.T) {
 				So(items[0].Links.Dataset.HRef, ShouldEqual, results[0].Links.Dataset.HRef)
 				So(items[0].Links.Edition.HRef, ShouldEqual, results[0].Links.Edition.HRef)
 				So(items[0].Links.Self.HRef, ShouldEqual, results[0].Links.Self.HRef)
+				So(items[0].Links.WebPage.HRef, ShouldEqual, results[0].Links.WebPage.HRef)
 				So(items[0].Dimensions[0].Links.CodeList.HRef, ShouldEqual, results[0].Dimensions[0].Links.CodeList.HRef)
 				So(items[0].Dimensions[0].Links.Options.HRef, ShouldEqual, results[0].Dimensions[0].Links.Options.HRef)
 				So(items[0].Dimensions[0].Links.Version.HRef, ShouldEqual, results[0].Dimensions[0].Links.Version.HRef)
@@ -4401,6 +4418,7 @@ func TestRewriteVersions_Success(t *testing.T) {
 				So(items[1].Links.Dataset.HRef, ShouldEqual, results[1].Links.Dataset.HRef)
 				So(items[1].Links.Edition.HRef, ShouldEqual, results[1].Links.Edition.HRef)
 				So(items[1].Links.Self.HRef, ShouldEqual, results[1].Links.Self.HRef)
+				So(items[1].Links.WebPage.HRef, ShouldEqual, results[1].Links.WebPage.HRef)
 				So(items[1].Dimensions[0].Links.CodeList.HRef, ShouldEqual, results[1].Dimensions[0].Links.CodeList.HRef)
 				So(items[1].Dimensions[0].Links.Options.HRef, ShouldEqual, results[1].Dimensions[0].Links.Options.HRef)
 				So(items[1].Dimensions[0].Links.Version.HRef, ShouldEqual, results[1].Dimensions[0].Links.Version.HRef)
@@ -4446,7 +4464,7 @@ func TestRewriteVersions_Success(t *testing.T) {
 				},
 			}
 
-			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, downloadServiceURL)
+			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, websiteLinksBuilder, downloadServiceURL)
 
 			Convey("Then the links should remain empty", func() {
 				So(err, ShouldBeNil)
@@ -4495,7 +4513,7 @@ func TestRewriteVersions_Success(t *testing.T) {
 				},
 			}
 
-			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, downloadServiceURL)
+			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, websiteLinksBuilder, downloadServiceURL)
 
 			Convey("Then the links should remain nil", func() {
 				So(err, ShouldBeNil)
@@ -4523,7 +4541,7 @@ func TestRewriteVersions_Success(t *testing.T) {
 		Convey("When the versions are empty", func() {
 			results := []models.Version{}
 
-			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, downloadServiceURL)
+			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, websiteLinksBuilder, downloadServiceURL)
 
 			Convey("Then the versions should remain empty", func() {
 				So(err, ShouldBeNil)
@@ -4538,6 +4556,7 @@ func TestRewriteVersions_Error(t *testing.T) {
 	Convey("Given a list of versions", t, func() {
 		datasetLinksBuilder := links.FromHeadersOrDefault(&http.Header{}, datasetAPIURL)
 		codeListLinksBuilder := links.FromHeadersOrDefault(&http.Header{}, codeListAPIURL)
+		websiteLinksBuilder := links.FromHeadersOrDefault(&http.Header{}, websiteURL)
 		Convey("When the version links are unable to be parsed", func() {
 			results := []models.Version{
 				{
@@ -4580,7 +4599,7 @@ func TestRewriteVersions_Error(t *testing.T) {
 				},
 			}
 
-			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, downloadServiceURL)
+			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, websiteLinksBuilder, downloadServiceURL)
 
 			Convey("Then a parsing error should be returned", func() {
 				So(err, ShouldNotBeNil)
@@ -4618,7 +4637,7 @@ func TestRewriteVersions_Error(t *testing.T) {
 				},
 			}
 
-			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, downloadServiceURL)
+			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, websiteLinksBuilder, downloadServiceURL)
 
 			Convey("Then a parsing error should be returned", func() {
 				So(err, ShouldNotBeNil)
@@ -4642,7 +4661,7 @@ func TestRewriteVersions_Error(t *testing.T) {
 				},
 			}
 
-			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, downloadServiceURL)
+			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, websiteLinksBuilder, downloadServiceURL)
 
 			Convey("Then a parsing error should be returned", func() {
 				So(err, ShouldNotBeNil)
@@ -4666,7 +4685,7 @@ func TestRewriteVersions_Error(t *testing.T) {
 				},
 			}
 
-			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, downloadServiceURL)
+			items, err := RewriteVersions(ctx, results, datasetLinksBuilder, codeListLinksBuilder, websiteLinksBuilder, downloadServiceURL)
 
 			Convey("Then a parsing error should be returned", func() {
 				So(err, ShouldNotBeNil)
@@ -4681,6 +4700,7 @@ func TestRewriteVersionLinks_Success(t *testing.T) {
 	ctx := context.Background()
 	Convey("Given a set of version links", t, func() {
 		datasetLinksBuilder := links.FromHeadersOrDefault(&http.Header{}, datasetAPIURL)
+		websiteLinksBuilder := links.FromHeadersOrDefault(&http.Header{}, websiteURL)
 		Convey("When the version links need rewriting", func() {
 			versionLinks := &models.VersionLinks{
 				Dataset: &models.LinkObject{
@@ -4704,9 +4724,12 @@ func TestRewriteVersionLinks_Success(t *testing.T) {
 					HRef: "https://oldhost:1000/datasets/cpih01/editions/time-series/versions/1",
 					ID:   "1",
 				},
+				WebPage: &models.LinkObject{
+					HRef: "https://oldhost:1000/economy/datasets/cpih01/editions/time-series/versions/1",
+				},
 			}
 
-			err := RewriteVersionLinks(ctx, versionLinks, datasetLinksBuilder)
+			err := RewriteVersionLinks(ctx, versionLinks, datasetLinksBuilder, websiteLinksBuilder)
 
 			Convey("Then the links should be rewritten correctly", func() {
 				So(err, ShouldBeNil)
@@ -4717,6 +4740,7 @@ func TestRewriteVersionLinks_Success(t *testing.T) {
 				So(versionLinks.Spatial.HRef, ShouldEqual, "https://oldhost:1000/spatial")
 				So(versionLinks.Version.HRef, ShouldEqual, "http://localhost:22000/datasets/cpih01/editions/time-series/versions/1")
 				So(versionLinks.Version.ID, ShouldEqual, "1")
+				So(versionLinks.WebPage.HRef, ShouldEqual, "http://localhost:20000/economy/datasets/cpih01/editions/time-series/versions/1")
 			})
 		})
 
@@ -4743,9 +4767,12 @@ func TestRewriteVersionLinks_Success(t *testing.T) {
 					HRef: "http://localhost:22000/datasets/cpih01/editions/time-series/versions/1",
 					ID:   "1",
 				},
+				WebPage: &models.LinkObject{
+					HRef: "http://localhost:20000/economy/datasets/cpih01/editions/time-series/versions/1",
+				},
 			}
 
-			err := RewriteVersionLinks(ctx, versionLinks, datasetLinksBuilder)
+			err := RewriteVersionLinks(ctx, versionLinks, datasetLinksBuilder, websiteLinksBuilder)
 
 			Convey("Then the links should remain the same", func() {
 				So(err, ShouldBeNil)
@@ -4756,13 +4783,14 @@ func TestRewriteVersionLinks_Success(t *testing.T) {
 				So(versionLinks.Spatial.HRef, ShouldEqual, "http://oldhost:1000/spatial")
 				So(versionLinks.Version.HRef, ShouldEqual, "http://localhost:22000/datasets/cpih01/editions/time-series/versions/1")
 				So(versionLinks.Version.ID, ShouldEqual, "1")
+				So(versionLinks.WebPage.HRef, ShouldEqual, "http://localhost:20000/economy/datasets/cpih01/editions/time-series/versions/1")
 			})
 		})
 
 		Convey("When the version links are empty", func() {
 			versionLinks := &models.VersionLinks{}
 
-			err := RewriteVersionLinks(ctx, versionLinks, datasetLinksBuilder)
+			err := RewriteVersionLinks(ctx, versionLinks, datasetLinksBuilder, websiteLinksBuilder)
 
 			Convey("Then the links should remain empty", func() {
 				So(err, ShouldBeNil)
@@ -4771,7 +4799,7 @@ func TestRewriteVersionLinks_Success(t *testing.T) {
 		})
 
 		Convey("When the version links are nil", func() {
-			err := RewriteVersionLinks(ctx, nil, datasetLinksBuilder)
+			err := RewriteVersionLinks(ctx, nil, datasetLinksBuilder, websiteLinksBuilder)
 
 			Convey("Then the links should remain nil", func() {
 				So(err, ShouldBeNil)
@@ -4789,26 +4817,9 @@ func TestRewriteVersionLinks_Error(t *testing.T) {
 					HRef: "://oldhost:1000/datasets/cpih01",
 					ID:   "cpih01",
 				},
-				Dimensions: &models.LinkObject{
-					HRef: "://oldhost:1000/datasets/cpih01/editions/time-series/versions/1/dimensions",
-				},
-				Edition: &models.LinkObject{
-					HRef: "://oldhost:1000/datasets/cpih01/editions/time-series",
-					ID:   "time-series",
-				},
-				Self: &models.LinkObject{
-					HRef: "://oldhost:1000/datasets/cpih01/editions/time-series/versions/1",
-				},
-				Spatial: &models.LinkObject{
-					HRef: "://oldhost:1000/spatial",
-				},
-				Version: &models.LinkObject{
-					HRef: "://oldhost:1000/datasets/cpih01/editions/time-series/versions/1",
-					ID:   "1",
-				},
 			}
 
-			err := RewriteVersionLinks(ctx, versionLinks, nil)
+			err := RewriteVersionLinks(ctx, versionLinks, nil, nil)
 
 			Convey("Then a parsing error should be returned", func() {
 				So(err, ShouldNotBeNil)


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-4794

- Add URL rewriting for `web_page` links and updated tests

**Notes**:
- The website links builder is intentionally defined without using `links.FromHeadersOrDefault` as we always want the rewritten link to be external (not an IP host)
- There are no additional unit tests in the handler. I decided not to add any as the API layer does not have any existing URL rewriting tests, instead all rewriting tests are done within `utils/rewriting.go` and in component tests.

### How to review

- Check changes are ok
- Create a dataset version and then manually go into Mongo to add a `web_page` link. (This is the only way to test it as the `POST` endpoint updates have not been implemented yet)
- Try call either version endpoint from the api-router and dataset-api. The `web_page` URL should be rewritten correctly. (When calling from the api-router, other links will have the `/v1` path prefix but the `web_page` link shouldn't)

### Who can review

- Anyone
