### PR TITLE
add is_migration field

### DIFF
--- a/api/editions_test.go
+++ b/api/editions_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -1262,6 +1263,151 @@ func TestGetEditionAuditEventLogsErrorButContinues(t *testing.T) {
 
 			Convey("And the audit service was called", func() {
 				So(len(auditServiceMock.RecordVersionAuditEventCalls()), ShouldEqual, 1)
+			})
+		})
+	})
+}
+
+func TestGetEditionReturnsIsMigration(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a static dataset version with is_migration set to true", t, func() {
+		trueVal := true
+		publishedVersion := &models.Version{
+			DatasetID:   "123-456",
+			Edition:     "678",
+			Version:     1,
+			State:       models.PublishedState,
+			ReleaseDate: "1996-04-01",
+			IsMigration: &trueVal,
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123-456",
+					ID:   "123-456",
+				},
+				Self: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123-456/editions/678/versions/1",
+				},
+				Edition: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123-456/editions/678",
+					ID:   "678",
+				},
+				Version: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123-456/editions/678/versions/1",
+					ID:   "1",
+				},
+			},
+			LastUpdated: time.Date(2025, 3, 11, 0, 0, 0, 0, time.UTC),
+		}
+
+		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678", http.NoBody)
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			IsStaticDatasetFunc: func(ctx context.Context, datasetID string) (bool, error) {
+				return true, nil
+			},
+			GetDatasetTypeFunc: func(context.Context, string, bool) (string, error) {
+				return models.Static.String(), nil
+			},
+			GetLatestVersionStaticFunc: func(ctx context.Context, datasetID, editionID, state string) (*models.Version, error) {
+				return publishedVersion, nil
+			},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return nil, permissionsAPISDK.ErrFailedToParsePermissionsResponse
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{})
+
+		Convey("When we call the GET edition endpoint", func() {
+			api.Router.ServeHTTP(w, r)
+
+			Convey("Then it returns a 200 OK", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+			})
+
+			Convey("And is_migration is present in the response body", func() {
+				var edition models.Edition
+				err := json.Unmarshal(w.Body.Bytes(), &edition)
+				So(err, ShouldBeNil)
+				So(edition.IsMigration, ShouldNotBeNil)
+				So(*edition.IsMigration, ShouldBeTrue)
+			})
+		})
+	})
+
+	Convey("Given a static dataset version without is_migration set", t, func() {
+		publishedVersion := &models.Version{
+			DatasetID:   "123-456",
+			Edition:     "678",
+			Version:     1,
+			State:       models.PublishedState,
+			ReleaseDate: "1996-04-01",
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123-456",
+					ID:   "123-456",
+				},
+				Self: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123-456/editions/678/versions/1",
+				},
+				Edition: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123-456/editions/678",
+					ID:   "678",
+				},
+				Version: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/123-456/editions/678/versions/1",
+					ID:   "1",
+				},
+			},
+			LastUpdated: time.Date(2025, 3, 11, 0, 0, 0, 0, time.UTC),
+		}
+
+		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678", http.NoBody)
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			IsStaticDatasetFunc: func(ctx context.Context, datasetID string) (bool, error) {
+				return true, nil
+			},
+			GetDatasetTypeFunc: func(context.Context, string, bool) (string, error) {
+				return models.Static.String(), nil
+			},
+			GetLatestVersionStaticFunc: func(ctx context.Context, datasetID, editionID, state string) (*models.Version, error) {
+				return publishedVersion, nil
+			},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return nil, permissionsAPISDK.ErrFailedToParsePermissionsResponse
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{})
+
+		Convey("When we call the GET edition endpoint", func() {
+			api.Router.ServeHTTP(w, r)
+
+			Convey("Then it returns a 200 OK", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+			})
+
+			Convey("And is_migration is absent from the response body", func() {
+				var edition models.Edition
+				err := json.Unmarshal(w.Body.Bytes(), &edition)
+				So(err, ShouldBeNil)
+				So(edition.IsMigration, ShouldBeNil)
 			})
 		})
 	})

--- a/api/static_versions_test.go
+++ b/api/static_versions_test.go
@@ -2466,3 +2466,221 @@ func TestCreateVersion_Failure(t *testing.T) {
 		})
 	})
 }
+
+func TestAddDatasetVersionCondensed_IsMigration(t *testing.T) {
+	t.Parallel()
+
+	authorisationMock := &authMock.MiddlewareMock{
+		RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+			return handlerFunc
+		},
+		ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+			return testEntityData, nil
+		},
+	}
+
+	auditServiceMock := &applicationMocks.AuditServiceMock{
+		RecordVersionAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, version *models.Version) error {
+			return nil
+		},
+	}
+
+	Convey("When is_migration is true in the request body, it is stored and returned", t, func() {
+		trueVal := true
+
+		b := `{
+			"release_date": "2025-01-15",
+			"edition_title": "Edition Title 2025",
+			"is_migration": true,
+			"distributions": [{
+				"title": "Full Dataset (CSV)",
+				"download_url": "https://download.ons.gov.uk/my-dataset-download.csv",
+				"byte_size": 4300000,
+				"format": "csv"
+			}]
+		}`
+
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/time-series/versions", bytes.NewBufferString(b))
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			GetLatestVersionStaticFunc: func(context.Context, string, string, string) (*models.Version, error) {
+				return &models.Version{State: models.PublishedState}, nil
+			},
+			AddVersionStaticFunc: func(_ context.Context, v *models.Version) (*models.Version, error) {
+				return v, nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{State: "associated", Links: &models.DatasetLinks{}}}, nil
+			},
+			UpsertDatasetFunc: func(context.Context, string, *models.DatasetUpdate) error {
+				return nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		successResponse, errorResponse := api.addDatasetVersionCondensed(w, r)
+
+		So(errorResponse, ShouldBeNil)
+		So(successResponse.Status, ShouldEqual, http.StatusCreated)
+
+		var version models.Version
+		err := json.Unmarshal(successResponse.Body, &version)
+		So(err, ShouldBeNil)
+		So(version.IsMigration, ShouldNotBeNil)
+		So(*version.IsMigration, ShouldEqual, trueVal)
+	})
+
+	Convey("When is_migration is absent from the request body, it is nil in the response", t, func() {
+		b := `{
+			"release_date": "2025-01-15",
+			"edition_title": "Edition Title 2025",
+			"distributions": [{
+				"title": "Full Dataset (CSV)",
+				"download_url": "https://download.ons.gov.uk/my-dataset-download.csv",
+				"byte_size": 4300000,
+				"format": "csv"
+			}]
+		}`
+
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/time-series/versions", bytes.NewBufferString(b))
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			GetLatestVersionStaticFunc: func(context.Context, string, string, string) (*models.Version, error) {
+				return &models.Version{State: models.PublishedState}, nil
+			},
+			AddVersionStaticFunc: func(_ context.Context, v *models.Version) (*models.Version, error) {
+				return v, nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{State: "associated", Links: &models.DatasetLinks{}}}, nil
+			},
+			UpsertDatasetFunc: func(context.Context, string, *models.DatasetUpdate) error {
+				return nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		successResponse, errorResponse := api.addDatasetVersionCondensed(w, r)
+
+		So(errorResponse, ShouldBeNil)
+		So(successResponse.Status, ShouldEqual, http.StatusCreated)
+
+		var version models.Version
+		err := json.Unmarshal(successResponse.Body, &version)
+		So(err, ShouldBeNil)
+		So(version.IsMigration, ShouldBeNil)
+	})
+}
+
+func TestCreateVersion_IsMigration(t *testing.T) {
+	t.Parallel()
+
+	authorisationMock := &authMock.MiddlewareMock{
+		RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+			return handlerFunc
+		},
+		ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+			return testEntityData, nil
+		},
+	}
+
+	auditServiceMock := &applicationMocks.AuditServiceMock{
+		RecordVersionAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, version *models.Version) error {
+			return nil
+		},
+	}
+
+	Convey("When is_migration is true in the request body, it is stored and returned", t, func() {
+		trueVal := true
+
+		versionInput := &models.Version{
+			EditionTitle: "New edition title",
+			ReleaseDate:  "2025-01-01",
+			Distributions: &[]models.Distribution{
+				{Title: "CSV", Format: "csv", DownloadURL: "path/to/download", ByteSize: 100, MediaType: "text/csv"},
+			},
+			Type:        models.Static.String(),
+			IsMigration: &trueVal,
+		}
+
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
+				return false, nil
+			},
+			AddVersionStaticFunc: func(_ context.Context, v *models.Version) (*models.Version, error) {
+				return v, nil
+			},
+		}
+
+		body, err := json.Marshal(versionInput)
+		So(err, ShouldBeNil)
+
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/edition1/versions/1", bytes.NewBuffer(body))
+		r = mux.SetURLVars(r, map[string]string{"dataset_id": "123", "edition": "edition1", "version": "1"})
+		w := httptest.NewRecorder()
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		successResponse, errorResponse := api.createVersion(w, r)
+
+		So(errorResponse, ShouldBeNil)
+		So(successResponse.Status, ShouldEqual, http.StatusCreated)
+
+		var version models.Version
+		err = json.Unmarshal(successResponse.Body, &version)
+		So(err, ShouldBeNil)
+		So(version.IsMigration, ShouldNotBeNil)
+		So(*version.IsMigration, ShouldEqual, trueVal)
+	})
+
+	Convey("When is_migration is absent from the request body, it is nil in the response", t, func() {
+		versionInput := &models.Version{
+			EditionTitle: "New edition title",
+			ReleaseDate:  "2025-01-01",
+			Distributions: &[]models.Distribution{
+				{Title: "CSV", Format: "csv", DownloadURL: "path/to/download", ByteSize: 100, MediaType: "text/csv"},
+			},
+			Type: models.Static.String(),
+		}
+
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
+				return false, nil
+			},
+			AddVersionStaticFunc: func(_ context.Context, v *models.Version) (*models.Version, error) {
+				return v, nil
+			},
+		}
+
+		body, err := json.Marshal(versionInput)
+		So(err, ShouldBeNil)
+
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/edition1/versions/1", bytes.NewBuffer(body))
+		r = mux.SetURLVars(r, map[string]string{"dataset_id": "123", "edition": "edition1", "version": "1"})
+		w := httptest.NewRecorder()
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		successResponse, errorResponse := api.createVersion(w, r)
+
+		So(errorResponse, ShouldBeNil)
+		So(successResponse.Status, ShouldEqual, http.StatusCreated)
+
+		var version models.Version
+		err = json.Unmarshal(successResponse.Body, &version)
+		So(err, ShouldBeNil)
+		So(version.IsMigration, ShouldBeNil)
+	})
+}

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -5722,3 +5722,202 @@ func TestGetVersionAuditEventLogsErrorButContinues(t *testing.T) {
 		})
 	})
 }
+
+func TestGetVersionReturnsIsMigration(t *testing.T) {
+	t.Parallel()
+	Convey("Given a static version with is_migration set to true", t, func() {
+		trueVal := true
+		version := &models.Version{
+			State:       models.PublishedState,
+			IsMigration: &trueVal,
+			Links: &models.VersionLinks{
+				Self:    &models.LinkObject{},
+				Version: &models.LinkObject{HRef: "href"},
+			},
+		}
+
+		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678/versions/1", http.NoBody)
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			IsStaticDatasetFunc: func(ctx context.Context, datasetID string) (bool, error) {
+				return true, nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{ID: "123-456", Next: &models.Dataset{ID: "123-456", Type: models.Static.String()}}, nil
+			},
+			CheckEditionExistsStaticFunc: func(context.Context, string, string, string) error {
+				return nil
+			},
+			GetVersionStaticFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
+				return version, nil
+			},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			RequireWithAttributesFunc: func(permission string, handlerFunc http.HandlerFunc, getAttributes authorisation.GetAttributesFromRequest) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return nil, errors.New("no token")
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{})
+
+		Convey("When we call the GET version endpoint", func() {
+			api.Router.ServeHTTP(w, r)
+
+			Convey("Then it returns a 200 OK", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+			})
+
+			Convey("And is_migration is present in the response body", func() {
+				var responseVersion models.Version
+				err := json.Unmarshal(w.Body.Bytes(), &responseVersion)
+				So(err, ShouldBeNil)
+				So(responseVersion.IsMigration, ShouldNotBeNil)
+				So(*responseVersion.IsMigration, ShouldBeTrue)
+			})
+		})
+	})
+
+	Convey("Given a static version without is_migration set", t, func() {
+		version := &models.Version{
+			State: models.PublishedState,
+			Links: &models.VersionLinks{
+				Self:    &models.LinkObject{},
+				Version: &models.LinkObject{HRef: "href"},
+			},
+		}
+
+		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678/versions/1", http.NoBody)
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			IsStaticDatasetFunc: func(ctx context.Context, datasetID string) (bool, error) {
+				return true, nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{ID: "123-456", Next: &models.Dataset{ID: "123-456", Type: models.Static.String()}}, nil
+			},
+			CheckEditionExistsStaticFunc: func(context.Context, string, string, string) error {
+				return nil
+			},
+			GetVersionStaticFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
+				return version, nil
+			},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			RequireWithAttributesFunc: func(permission string, handlerFunc http.HandlerFunc, getAttributes authorisation.GetAttributesFromRequest) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return nil, errors.New("no token")
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{})
+
+		Convey("When we call the GET version endpoint", func() {
+			api.Router.ServeHTTP(w, r)
+
+			Convey("Then it returns a 200 OK", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+			})
+
+			Convey("And is_migration is absent from the response body", func() {
+				var responseVersion models.Version
+				err := json.Unmarshal(w.Body.Bytes(), &responseVersion)
+				So(err, ShouldBeNil)
+				So(responseVersion.IsMigration, ShouldBeNil)
+			})
+		})
+	})
+}
+
+func TestPutVersionIsMigration(t *testing.T) {
+	t.Parallel()
+	Convey("When is_migration is included in a PUT version request body", t, func() {
+		trueVal := true
+
+		b := `{"edition_title":"Updated Edition Title","release_date":"2017-04-04","is_migration":true,"type":"static"}`
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
+		w := httptest.NewRecorder()
+
+		var capturedVersionUpdate *models.Version
+
+		mockedDataStore := &storetest.StorerMock{
+			CheckEditionExistsStaticFunc: func(ctx context.Context, datasetID, editionID, state string) error {
+				if editionID == "2017" {
+					return nil
+				}
+				return errs.ErrEditionNotFound
+			},
+			CheckEditionTitleExistsStaticFunc: func(ctx context.Context, datasetID, editionTitle string) error {
+				return nil
+			},
+			GetVersionFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
+				return &models.Version{
+					State: models.AssociatedState,
+					Type:  models.Static.String(),
+				}, nil
+			},
+			GetVersionStaticFunc: func(ctx context.Context, datasetID, editionID string, version int, state string) (*models.Version, error) {
+				return &models.Version{
+					ID:           "789",
+					Edition:      "2017",
+					EditionTitle: "Original Title",
+					State:        models.AssociatedState,
+					Type:         models.Static.String(),
+					ETag:         testETag,
+					Version:      1,
+					IsMigration:  &trueVal,
+				}, nil
+			},
+			UpdateVersionStaticFunc: func(ctx context.Context, currentVersion *models.Version, versionUpdate *models.Version, eTagSelector string) (string, error) {
+				capturedVersionUpdate = versionUpdate
+				return "", nil
+			},
+			AcquireVersionsLockFunc: func(context.Context, string) (string, error) {
+				return testLockID, nil
+			},
+			UnlockVersionsFunc: func(context.Context, string) {},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return testEntityData, nil
+			},
+		}
+
+		auditServiceMock := &applicationMocks.AuditServiceMock{
+			RecordVersionAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, version *models.Version) error {
+				return nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		api.Router.ServeHTTP(w, r)
+
+		Convey("Then it returns a 200 OK", func() {
+			So(w.Code, ShouldEqual, http.StatusOK)
+		})
+
+		Convey("And is_migration is carried through to the update", func() {
+			So(capturedVersionUpdate, ShouldNotBeNil)
+			So(capturedVersionUpdate.IsMigration, ShouldNotBeNil)
+			So(*capturedVersionUpdate.IsMigration, ShouldBeTrue)
+		})
+	})
+}

--- a/application/application.go
+++ b/application/application.go
@@ -282,6 +282,10 @@ func populateNewVersionDoc(currentVersion, originalVersion *models.Version) (*mo
 		version.Distributions = nil
 	}
 
+	if version.IsMigration == nil {
+		version.IsMigration = currentVersion.IsMigration
+	}
+
 	if version.UsageNotes == nil {
 		version.UsageNotes = currentVersion.UsageNotes
 	}

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -1375,6 +1375,89 @@ func TestPopulateNewVersionDocWithDistributions(t *testing.T) {
 	})
 }
 
+func TestPopulateNewVersionDocWithIsMigration(t *testing.T) {
+	t.Parallel()
+	Convey("Given versions with is_migration field", t, func() {
+		trueVal := true
+		falseVal := false
+
+		Convey("When the current version has is_migration true and the update does not set it", func() {
+			currentVersion := &models.Version{
+				Type:        models.Static.String(),
+				IsMigration: &trueVal,
+			}
+
+			originalVersion := &models.Version{
+				Type: models.Static.String(),
+			}
+
+			Convey("Then is_migration is carried forward from the current version", func() {
+				version, err := populateNewVersionDoc(currentVersion, originalVersion)
+				So(err, ShouldBeNil)
+				So(version, ShouldNotBeNil)
+				So(version.IsMigration, ShouldNotBeNil)
+				So(*version.IsMigration, ShouldBeTrue)
+			})
+		})
+
+		Convey("When the update explicitly sets is_migration to false", func() {
+			currentVersion := &models.Version{
+				Type:        models.Static.String(),
+				IsMigration: &trueVal,
+			}
+
+			originalVersion := &models.Version{
+				Type:        models.Static.String(),
+				IsMigration: &falseVal,
+			}
+
+			Convey("Then is_migration is set to false from the update", func() {
+				version, err := populateNewVersionDoc(currentVersion, originalVersion)
+				So(err, ShouldBeNil)
+				So(version, ShouldNotBeNil)
+				So(version.IsMigration, ShouldNotBeNil)
+				So(*version.IsMigration, ShouldBeFalse)
+			})
+		})
+
+		Convey("When neither the current version nor the update sets is_migration", func() {
+			currentVersion := &models.Version{
+				Type: models.Static.String(),
+			}
+
+			originalVersion := &models.Version{
+				Type: models.Static.String(),
+			}
+
+			Convey("Then is_migration is nil", func() {
+				version, err := populateNewVersionDoc(currentVersion, originalVersion)
+				So(err, ShouldBeNil)
+				So(version, ShouldNotBeNil)
+				So(version.IsMigration, ShouldBeNil)
+			})
+		})
+
+		Convey("When the update explicitly sets is_migration to true and current version does not have it", func() {
+			currentVersion := &models.Version{
+				Type: models.Static.String(),
+			}
+
+			originalVersion := &models.Version{
+				Type:        models.Static.String(),
+				IsMigration: &trueVal,
+			}
+
+			Convey("Then is_migration is set to true from the update", func() {
+				version, err := populateNewVersionDoc(currentVersion, originalVersion)
+				So(err, ShouldBeNil)
+				So(version, ShouldNotBeNil)
+				So(version.IsMigration, ShouldNotBeNil)
+				So(*version.IsMigration, ShouldBeTrue)
+			})
+		})
+	})
+}
+
 func TestPublishCMDVersionFailsToPublish(t *testing.T) {
 	t.Parallel()
 	Convey("When a version is set to published from associated and the graph errors", t, func() {

--- a/features/static_versions_get.feature
+++ b/features/static_versions_get.feature
@@ -43,7 +43,7 @@ Feature: Static versions GET /versions
                             "href": "/economy/datasets/test-static/editions/test-edition-static/versions/1"
                         }
                     },
-                    "state": "created",
+                    "state": "associated",
                     "type": "static",
                     "distributions": [
                         {
@@ -53,7 +53,8 @@ Feature: Static versions GET /versions
                             "download_url": "/uuid/filename.csv",
                             "byte_size": 100000
                         }
-                    ]
+                    ],
+                    "is_migration": true
                 },
                 {
                     "id": "test-static-version-approved",
@@ -291,3 +292,45 @@ Feature: Static versions GET /versions
         And I am an admin user
         When I GET "/datasets/test-static"
         Then the HTTP status code should be "200"
+
+    Scenario: GET /datasets/{id}/editions/{edition}/versions/{version} returns is_migration when set
+        Given private endpoints are enabled
+        And I am an admin user
+        When I GET "/datasets/test-static/editions/test-edition-static/versions/1"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "id": "test-static-version",
+                "is_migration": true,
+                "last_updated": "2021-01-01T00:00:00Z",
+                "type": "static",
+                "version": 1,
+                "state": "associated",
+                "links": {
+                    "dataset": {
+                        "id": "test-static"
+                    },
+                    "edition": {
+                        "href": "/datasets/test-static/editions/test-edition-static",
+                        "id": "test-edition-static"
+                    },
+                    "self": {
+                        "href": "/datasets/test-static/editions/test-edition-static/versions/1"
+                    },
+                    "web_page": {
+                        "href": "/economy/datasets/test-static/editions/test-edition-static/versions/1"
+                    }
+                },
+                "edition": "test-edition-static",
+                "edition_title": "Test Edition Static Title",
+                "distributions": [
+                    {
+                        "title": "Distribution 1",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "download_url": "/uuid/filename.csv",
+                        "byte_size": 100000
+                    }
+                ]
+            }
+            """

--- a/features/static_versions_post.feature
+++ b/features/static_versions_post.feature
@@ -448,3 +448,60 @@ Feature: Static Dataset Versions POST API
                 ]
             }
             """
+
+    Scenario: POST creates a static version with is_migration true and it is returned in the response
+        Given private endpoints are enabled
+        And I am an admin user
+        When I POST "/datasets/static-dataset-test/editions/2024/versions"
+            """
+            {
+                "release_date": "2024-12-01T09:00:00.000Z",
+                "edition_title": "2024",
+                "type": "static",
+                "is_migration": true,
+                "distributions": [
+                    {
+                        "title": "Full Dataset CSV",
+                        "format": "csv",
+                        "download_url": "/uuid/filename.csv",
+                        "byte_size": 100000
+                    }
+                ]
+            }
+            """
+        Then I should receive the following JSON response with status "201":
+            """
+            {
+                "dataset_id": "static-dataset-test",
+                "distributions": [
+                    {
+                        "byte_size": 100000,
+                        "download_url": "/uuid/filename.csv",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "title": "Full Dataset CSV"
+                    }
+                ],
+                "edition": "2024",
+                "edition_title": "2024",
+                "is_migration": true,
+                "last_updated": "{{DYNAMIC_RECENT_TIMESTAMP}}",
+                "links": {
+                    "dataset": {
+                        "href": "http://localhost:22000/datasets/static-dataset-test",
+                        "id": "static-dataset-test"
+                    },
+                    "edition": {
+                        "href": "http://localhost:22000/datasets/static-dataset-test/editions/2024",
+                        "id": "2024"
+                    },
+                    "self": {
+                        "href": "http://localhost:22000/datasets/static-dataset-test/editions/2024/versions/1"
+                    }
+                },
+                "release_date": "2024-12-01T09:00:00.000Z",
+                "state": "associated",
+                "type": "static",
+                "version": 1
+            }
+            """

--- a/features/static_versions_post_with_id.feature
+++ b/features/static_versions_post_with_id.feature
@@ -761,3 +761,60 @@ Scenario: Request with an invalid is_latest value returns 400
             ]
         }
         """
+
+Scenario: POST creates a static version with is_migration true and it is returned in the response
+    Given private endpoints are enabled
+    And I am an admin user
+    When I POST "/datasets/static-dataset-1/editions/2024/versions/2"
+        """
+        {
+            "release_date": "2024-12-01T09:00:00.000Z",
+            "edition_title": "2024",
+            "type": "static",
+            "is_migration": true,
+            "distributions": [
+                {
+                    "title": "Full Dataset CSV",
+                    "format": "csv",
+                    "download_url": "/uuid/filename.csv",
+                    "byte_size": 100
+                }
+            ]
+        }
+        """
+    Then I should receive the following JSON response with status "201":
+        """
+        {
+            "dataset_id": "static-dataset-1",
+            "distributions": [
+                {
+                    "byte_size": 100,
+                    "download_url": "/uuid/filename.csv",
+                    "format": "csv",
+                    "media_type": "text/csv",
+                    "title": "Full Dataset CSV"
+                }
+            ],
+            "edition": "2024",
+            "edition_title": "2024",
+            "is_migration": true,
+            "last_updated": "{{DYNAMIC_RECENT_TIMESTAMP}}",
+            "links": {
+                "dataset": {
+                    "href": "http://localhost:22000/datasets/static-dataset-1",
+                    "id": "static-dataset-1"
+                },
+                "edition": {
+                    "href": "http://localhost:22000/datasets/static-dataset-1/editions/2024",
+                    "id": "2024"
+                },
+                "self": {
+                    "href": "http://localhost:22000/datasets/static-dataset-1/editions/2024/versions/2"
+                }
+            },
+            "release_date": "2024-12-01T09:00:00.000Z",
+            "state": "associated",
+            "type": "static",
+            "version": 2
+        }
+        """

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -897,3 +897,48 @@ Feature: Static Dataset Versions PUT API
               """
               canonical topic can't be changed once a series is published
               """
+
+    Scenario: PUT updates static dataset version with is_migration field
+        Given private endpoints are enabled
+        And I am an admin user
+        When I PUT "/datasets/static-dataset-update/editions/2025/versions/1"
+            """
+            {
+                "is_migration": true,
+                "type": "static"
+            }
+            """
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "dataset_id": "static-dataset-update",
+                "distributions": [
+                    {
+                        "byte_size": 125000,
+                        "download_url": "/uuid/filename.csv",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "title": "csv"
+                    }
+                ],
+                "edition": "2025",
+                "id": "static-version-update",
+                "is_migration": true,
+                "last_updated": "{{DYNAMIC_RECENT_TIMESTAMP}}",
+                "links": {
+                    "dataset": {
+                        "id": "static-dataset-update"
+                    },
+                    "edition": {
+                        "href": "/datasets/static-dataset-update/editions/2025",
+                        "id": "2025"
+                    },
+                    "self": {
+                        "href": "/datasets/static-dataset-update/editions/2025/versions/1"
+                    }
+                },
+                "release_date": "2025-01-01T09:00:00.000Z",
+                "state": "associated",
+                "type": "static"
+            }
+            """

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -181,6 +181,7 @@ type Edition struct {
 	Alerts             *[]Alert            `bson:"alerts,omitempty"              json:"alerts,omitempty"`
 	UsageNotes         *[]UsageNote        `bson:"usage_notes,omitempty"         json:"usage_notes,omitempty"`
 	Distributions      *[]Distribution     `bson:"distributions,omitempty"       json:"distributions,omitempty"`
+	IsMigration        *bool               `bson:"is_migration,omitempty"        json:"is_migration,omitempty"`
 	IsBasedOn          *IsBasedOn          `bson:"is_based_on,omitempty"         json:"is_based_on,omitempty"`
 	Type               string              `bson:"type,omitempty"                json:"type,omitempty"`
 	QualityDesignation QualityDesignation  `bson:"quality_designation,omitempty" json:"quality_designation,omitempty"`

--- a/models/version.go
+++ b/models/version.go
@@ -50,6 +50,7 @@ type Version struct {
 	LowestGeography    string               `bson:"lowest_geography,omitempty"      json:"lowest_geography,omitempty"`
 	QualityDesignation QualityDesignation   `bson:"quality_designation,omitempty"   json:"quality_designation,omitempty"`
 	Distributions      *[]Distribution      `bson:"distributions,omitempty"         json:"distributions,omitempty"`
+	IsMigration        *bool                `bson:"is_migration,omitempty"          json:"is_migration,omitempty"`
 }
 
 // Alert represents an object containing information on an alert

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -603,6 +603,10 @@ func createVersionUpdateQuery(version *models.Version, newETag string) bson.M {
 		setUpdates["distributions"] = version.Distributions
 	}
 
+	if version.IsMigration != nil {
+		setUpdates["is_migration"] = version.IsMigration
+	}
+
 	if newETag != "" {
 		setUpdates["e_tag"] = newETag
 	}

--- a/mongo/dataset_test.go
+++ b/mongo/dataset_test.go
@@ -281,6 +281,7 @@ func TestDatasetUpdateQuery(t *testing.T) {
 func TestVersionUpdateQuery(t *testing.T) {
 	t.Parallel()
 	Convey("When all possible fields exist", t, func() {
+		trueVal := true
 		temporal := models.TemporalFrequency{
 			EndDate:   "2017-09-09",
 			Frequency: "monthly",
@@ -325,6 +326,7 @@ func TestVersionUpdateQuery(t *testing.T) {
 			State:         models.PublishedState,
 			Temporal:      &[]models.TemporalFrequency{temporal},
 			Distributions: distributions,
+			IsMigration:   &trueVal,
 		}
 
 		selector := createVersionUpdateQuery(version, "newETag")
@@ -343,6 +345,7 @@ func TestVersionUpdateQuery(t *testing.T) {
 		So(selector["distributions"], ShouldResemble, distributions)
 		So(selector["e_tag"], ShouldEqual, "newETag")
 		So(selector["last_updated"], ShouldNotBeEmpty)
+		So(selector["is_migration"], ShouldResemble, &trueVal)
 	})
 }
 

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -944,3 +944,89 @@ func TestPostVersion(t *testing.T) {
 		})
 	})
 }
+
+func TestVersionIsMigration(t *testing.T) {
+	Convey("Given a version with is_migration set to true", t, func() {
+		trueVal := true
+		versionID := 1
+
+		mockVersion := models.Version{
+			CollectionID: collectionID,
+			DatasetID:    datasetID,
+			Edition:      editionID,
+			Version:      versionID,
+			IsMigration:  &trueVal,
+		}
+
+		Convey("When GetVersion is called and the API returns is_migration: true", func() {
+			httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, mockVersion, map[string]string{}})
+			datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+			returnedVersion, err := datasetAPIClient.GetVersion(ctx, headers, datasetID, editionID, strconv.Itoa(versionID))
+
+			Convey("Then is_migration is deserialised correctly", func() {
+				So(err, ShouldBeNil)
+				So(returnedVersion.IsMigration, ShouldNotBeNil)
+				So(*returnedVersion.IsMigration, ShouldBeTrue)
+			})
+		})
+
+		Convey("When PostVersion is called with is_migration: true in the request body", func() {
+			expectedResponse := mockVersion
+			httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusCreated, expectedResponse, map[string]string{"ETag": etag}})
+			datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+			createdVersion, err := datasetAPIClient.PostVersion(ctx, headers, datasetID, editionID, strconv.Itoa(versionID), mockVersion, false)
+
+			Convey("Then is_migration is serialised in the request body and deserialised in the response", func() {
+				So(err, ShouldBeNil)
+				So(createdVersion.IsMigration, ShouldNotBeNil)
+				So(*createdVersion.IsMigration, ShouldBeTrue)
+
+				var sentVersion models.Version
+				err := json.NewDecoder(httpClient.DoCalls()[0].Req.Body).Decode(&sentVersion)
+				So(err, ShouldBeNil)
+				So(sentVersion.IsMigration, ShouldNotBeNil)
+				So(*sentVersion.IsMigration, ShouldBeTrue)
+			})
+		})
+
+		Convey("When PutVersion is called with is_migration: true in the request body", func() {
+			httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, mockVersion, map[string]string{}})
+			datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+			updatedVersion, err := datasetAPIClient.PutVersion(ctx, headers, datasetID, editionID, strconv.Itoa(versionID), mockVersion)
+
+			Convey("Then is_migration is serialised in the request body and deserialised in the response", func() {
+				So(err, ShouldBeNil)
+				So(updatedVersion.IsMigration, ShouldNotBeNil)
+				So(*updatedVersion.IsMigration, ShouldBeTrue)
+
+				var sentVersion models.Version
+				err := json.NewDecoder(httpClient.DoCalls()[0].Req.Body).Decode(&sentVersion)
+				So(err, ShouldBeNil)
+				So(sentVersion.IsMigration, ShouldNotBeNil)
+				So(*sentVersion.IsMigration, ShouldBeTrue)
+			})
+		})
+	})
+
+	Convey("Given a version without is_migration set", t, func() {
+		versionID := 1
+
+		mockVersion := models.Version{
+			CollectionID: collectionID,
+			DatasetID:    datasetID,
+			Edition:      editionID,
+			Version:      versionID,
+		}
+
+		Convey("When GetVersion is called and the API returns no is_migration field", func() {
+			httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, mockVersion, map[string]string{}})
+			datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+			returnedVersion, err := datasetAPIClient.GetVersion(ctx, headers, datasetID, editionID, strconv.Itoa(versionID))
+
+			Convey("Then is_migration is nil", func() {
+				So(err, ShouldBeNil)
+				So(returnedVersion.IsMigration, ShouldBeNil)
+			})
+		})
+	})
+}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2663,6 +2663,9 @@ definitions:
         example: July to September 2017
       is_based_on:
         $ref: "#/definitions/IsBasedOn"
+      is_migration:
+        description: "Indicates whether this version was created as part of a dataset migration"
+        type: boolean
       last_updated:
         $ref: "#/definitions/LastUpdated"
       latest_changes:

--- a/utils/mapping.go
+++ b/utils/mapping.go
@@ -36,6 +36,7 @@ func MapVersionToEdition(version *models.Version) *models.Edition {
 		UsageNotes:         version.UsageNotes,
 		Distributions:      version.Distributions,
 		QualityDesignation: version.QualityDesignation,
+		IsMigration:        version.IsMigration,
 	}
 
 	return edition

--- a/utils/mapping_test.go
+++ b/utils/mapping_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestMapVersionToEdition(t *testing.T) {
 	Convey("Given a version model", t, func() {
+		trueVal := true
 		version := &models.Version{
 			DatasetID:   "123",
 			Edition:     "2023",
@@ -36,6 +37,7 @@ func TestMapVersionToEdition(t *testing.T) {
 			UsageNotes:         &[]models.UsageNote{{Note: "Test usage note"}},
 			Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
 			QualityDesignation: "Test quality designation",
+			IsMigration:        &trueVal,
 		}
 
 		Convey("When the version is mapped to an edition", func() {
@@ -59,6 +61,7 @@ func TestMapVersionToEdition(t *testing.T) {
 				So(edition.UsageNotes, ShouldResemble, version.UsageNotes)
 				So(edition.Distributions, ShouldResemble, version.Distributions)
 				So(edition.QualityDesignation, ShouldEqual, version.QualityDesignation)
+				So(edition.IsMigration, ShouldResemble, version.IsMigration)
 			})
 		})
 	})
@@ -66,6 +69,8 @@ func TestMapVersionToEdition(t *testing.T) {
 
 func TestMapVersionsToEditions(t *testing.T) {
 	Convey("Given a published and unpublished version", t, func() {
+		trueVal := true
+		falseVal := false
 		publishedVersion := &models.Version{
 			DatasetID:   "123",
 			Edition:     "2023",
@@ -91,6 +96,7 @@ func TestMapVersionsToEditions(t *testing.T) {
 			Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
 			QualityDesignation: "Test quality designation",
 			State:              models.PublishedState,
+			IsMigration:        &trueVal,
 		}
 
 		unpublishedVersion := &models.Version{
@@ -118,6 +124,7 @@ func TestMapVersionsToEditions(t *testing.T) {
 			Distributions:      &[]models.Distribution{{Title: "Test distribution"}},
 			QualityDesignation: "Test quality designation",
 			State:              models.AssociatedState,
+			IsMigration:        &falseVal,
 		}
 
 		Convey("When both versions are available", func() {
@@ -142,6 +149,7 @@ func TestMapVersionsToEditions(t *testing.T) {
 				So(edition.Current.Distributions, ShouldResemble, publishedVersion.Distributions)
 				So(edition.Current.QualityDesignation, ShouldEqual, publishedVersion.QualityDesignation)
 				So(edition.Current.State, ShouldEqual, publishedVersion.State)
+				So(edition.Current.IsMigration, ShouldResemble, publishedVersion.IsMigration)
 			})
 
 			Convey("And the unpublished version should be mapped to the 'Next' field", func() {
@@ -162,6 +170,7 @@ func TestMapVersionsToEditions(t *testing.T) {
 				So(edition.Next.Distributions, ShouldResemble, unpublishedVersion.Distributions)
 				So(edition.Next.QualityDesignation, ShouldEqual, unpublishedVersion.QualityDesignation)
 				So(edition.Next.State, ShouldEqual, unpublishedVersion.State)
+				So(edition.Next.IsMigration, ShouldResemble, unpublishedVersion.IsMigration)
 			})
 		})
 
@@ -187,6 +196,7 @@ func TestMapVersionsToEditions(t *testing.T) {
 				So(edition.Current.Distributions, ShouldResemble, publishedVersion.Distributions)
 				So(edition.Current.QualityDesignation, ShouldEqual, publishedVersion.QualityDesignation)
 				So(edition.Current.State, ShouldEqual, publishedVersion.State)
+				So(edition.Current.IsMigration, ShouldResemble, publishedVersion.IsMigration)
 
 				So(edition.Next.DatasetID, ShouldEqual, publishedVersion.DatasetID)
 				So(edition.Next.Edition, ShouldEqual, publishedVersion.Edition)
@@ -205,6 +215,7 @@ func TestMapVersionsToEditions(t *testing.T) {
 				So(edition.Next.Distributions, ShouldResemble, publishedVersion.Distributions)
 				So(edition.Next.QualityDesignation, ShouldEqual, publishedVersion.QualityDesignation)
 				So(edition.Next.State, ShouldEqual, publishedVersion.State)
+				So(edition.Next.IsMigration, ShouldResemble, publishedVersion.IsMigration)
 			})
 		})
 
@@ -231,6 +242,7 @@ func TestMapVersionsToEditions(t *testing.T) {
 				So(edition.Next.Distributions, ShouldResemble, unpublishedVersion.Distributions)
 				So(edition.Next.QualityDesignation, ShouldEqual, unpublishedVersion.QualityDesignation)
 				So(edition.Next.State, ShouldEqual, unpublishedVersion.State)
+				So(edition.Next.IsMigration, ShouldResemble, unpublishedVersion.IsMigration)
 			})
 		})
 
@@ -243,6 +255,52 @@ func TestMapVersionsToEditions(t *testing.T) {
 
 			Convey("And a version not found error should be returned", func() {
 				So(err, ShouldEqual, errs.ErrVersionNotFound)
+			})
+		})
+	})
+}
+
+func TestMapVersionToEditionIsMigration(t *testing.T) {
+	Convey("Given a version with is_migration set", t, func() {
+		trueVal := true
+
+		version := &models.Version{
+			DatasetID: "123",
+			Edition:   "2023",
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{HRef: "http://localhost:22000/datasets/123", ID: "123"},
+				Version: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023/versions/1", ID: "1"},
+				Edition: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023", ID: "2023"},
+			},
+			IsMigration: &trueVal,
+		}
+
+		Convey("When the version is mapped to an edition", func() {
+			edition := MapVersionToEdition(version)
+
+			Convey("Then is_migration should be carried through to the edition", func() {
+				So(edition.IsMigration, ShouldNotBeNil)
+				So(*edition.IsMigration, ShouldBeTrue)
+			})
+		})
+	})
+
+	Convey("Given a version without is_migration set", t, func() {
+		version := &models.Version{
+			DatasetID: "123",
+			Edition:   "2023",
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{HRef: "http://localhost:22000/datasets/123", ID: "123"},
+				Version: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023/versions/1", ID: "1"},
+				Edition: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2023", ID: "2023"},
+			},
+		}
+
+		Convey("When the version is mapped to an edition", func() {
+			edition := MapVersionToEdition(version)
+
+			Convey("Then is_migration should be nil on the edition", func() {
+				So(edition.IsMigration, ShouldBeNil)
 			})
 		})
 	})


### PR DESCRIPTION
### What

Add `is_migration` field to data model for a version
Jira - https://officefornationalstatistics.atlassian.net/browse/DIS-4787

### How to review

To test locally -

- send a POST request with `is_migration: true` in the request body to create a new static version via the following endpoints - 

`/datasets/{dataset_id}/editions/{edition}/versions`
`/datasets/{dataset_id}/editions/{edition}/versions/{version}`

 and confirm the field is returned in the 201 response

- send a PUT request to an existing static version with `is_migration: true` and confirm the field is returned in the 200 response

- send a GET request to the version just created and confirm `is_migration: true` is present in the response

- create a version without `is_migration` and confirm the field is not present in any responses

Confirm changes make sense, tests pass

### Who can review

Anyone
