### PR TITLE
prevent is_migration being surfaced in web

### DIFF
--- a/api/editions.go
+++ b/api/editions.go
@@ -113,6 +113,9 @@ func (api *DatasetAPI) getEditions(w http.ResponseWriter, r *http.Request, limit
 
 	publicResults := make([]*models.Edition, 0, len(results))
 	for i := range results {
+		if results[i].Current != nil {
+			results[i].Current.IsMigration = nil
+		}
 		publicResults = append(publicResults, results[i].Current)
 	}
 	log.Info(ctx, "getEditions endpoint: get all edition without auth", logData)
@@ -235,6 +238,9 @@ func (api *DatasetAPI) getEdition(w http.ResponseWriter, r *http.Request) {
 				log.Info(ctx, "getEdition endpoint: get edition with auth", logData)
 			} else {
 				// User is not authenticated and hence has only access to current sub document
+				if edition.Current != nil {
+					edition.Current.IsMigration = nil
+				}
 				b, err = json.Marshal(edition.Current)
 				if err != nil {
 					log.Error(ctx, "getEdition endpoint: failed to marshal edition resource into bytes", err, logData)

--- a/api/editions_test.go
+++ b/api/editions_test.go
@@ -1300,9 +1300,6 @@ func TestGetEditionReturnsIsMigration(t *testing.T) {
 			LastUpdated: time.Date(2025, 3, 11, 0, 0, 0, 0, time.UTC),
 		}
 
-		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678", http.NoBody)
-		w := httptest.NewRecorder()
-
 		mockedDataStore := &storetest.StorerMock{
 			IsStaticDatasetFunc: func(ctx context.Context, datasetID string) (bool, error) {
 				return true, nil
@@ -1315,18 +1312,57 @@ func TestGetEditionReturnsIsMigration(t *testing.T) {
 			},
 		}
 
-		authorisationMock := &authMock.MiddlewareMock{
-			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
-				return handlerFunc
-			},
-			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
-				return nil, permissionsAPISDK.ErrFailedToParsePermissionsResponse
-			},
-		}
+		Convey("When an unauthenticated user calls the GET edition endpoint", func() {
+			r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678", http.NoBody)
+			w := httptest.NewRecorder()
 
-		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{})
+			authorisationMock := &authMock.MiddlewareMock{
+				RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+					return handlerFunc
+				},
+				ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+					return nil, permissionsAPISDK.ErrFailedToParsePermissionsResponse
+				},
+			}
 
-		Convey("When we call the GET edition endpoint", func() {
+			api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{})
+			api.Router.ServeHTTP(w, r)
+
+			Convey("Then it returns a 200 OK", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+			})
+
+			Convey("And is_migration is absent from the response body", func() {
+				var edition models.Edition
+				err := json.Unmarshal(w.Body.Bytes(), &edition)
+				So(err, ShouldBeNil)
+				So(edition.IsMigration, ShouldBeNil)
+			})
+		})
+
+		Convey("When an authenticated user calls the GET edition endpoint", func() {
+			r := createRequestWithAuth("GET", "http://localhost:22000/datasets/123-456/editions/678", nil)
+			w := httptest.NewRecorder()
+
+			authorisationMock := &authMock.MiddlewareMock{
+				RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+					return handlerFunc
+				},
+				RequireWithAttributesFunc: func(permission string, handlerFunc http.HandlerFunc, getAttributes authorisation.GetAttributesFromRequest) http.HandlerFunc {
+					return handlerFunc
+				},
+				ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+					return &permissionsAPISDK.EntityData{UserID: "test-user-id"}, nil
+				},
+			}
+
+			auditServiceMock := &applicationMocks.AuditServiceMock{
+				RecordVersionAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, versionDoc *models.Version) error {
+					return nil
+				},
+			}
+
+			api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
 			api.Router.ServeHTTP(w, r)
 
 			Convey("Then it returns a 200 OK", func() {
@@ -1334,11 +1370,12 @@ func TestGetEditionReturnsIsMigration(t *testing.T) {
 			})
 
 			Convey("And is_migration is present in the response body", func() {
-				var edition models.Edition
-				err := json.Unmarshal(w.Body.Bytes(), &edition)
+				var editionUpdate models.EditionUpdate
+				err := json.Unmarshal(w.Body.Bytes(), &editionUpdate)
 				So(err, ShouldBeNil)
-				So(edition.IsMigration, ShouldNotBeNil)
-				So(*edition.IsMigration, ShouldBeTrue)
+				So(editionUpdate.Current, ShouldNotBeNil)
+				So(editionUpdate.Current.IsMigration, ShouldNotBeNil)
+				So(*editionUpdate.Current.IsMigration, ShouldBeTrue)
 			})
 		})
 	})

--- a/api/versions.go
+++ b/api/versions.go
@@ -144,6 +144,10 @@ func (api *DatasetAPI) getVersions(w http.ResponseWriter, r *http.Request, limit
 					}
 				}
 			}
+
+			if !authorised {
+				item.IsMigration = nil
+			}
 		}
 
 		if hasInvalidState {
@@ -285,6 +289,11 @@ func (api *DatasetAPI) getVersion(w http.ResponseWriter, r *http.Request) (*mode
 				}
 			}
 		}
+
+		if !authorised {
+			version.IsMigration = nil
+		}
+
 		return version, nil
 	}()
 	if getVersionErr != nil {

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -5736,9 +5736,6 @@ func TestGetVersionReturnsIsMigration(t *testing.T) {
 			},
 		}
 
-		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678/versions/1", http.NoBody)
-		w := httptest.NewRecorder()
-
 		mockedDataStore := &storetest.StorerMock{
 			IsStaticDatasetFunc: func(ctx context.Context, datasetID string) (bool, error) {
 				return true, nil
@@ -5754,21 +5751,61 @@ func TestGetVersionReturnsIsMigration(t *testing.T) {
 			},
 		}
 
-		authorisationMock := &authMock.MiddlewareMock{
-			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
-				return handlerFunc
-			},
-			RequireWithAttributesFunc: func(permission string, handlerFunc http.HandlerFunc, getAttributes authorisation.GetAttributesFromRequest) http.HandlerFunc {
-				return handlerFunc
-			},
-			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
-				return nil, errors.New("no token")
-			},
-		}
+		Convey("When an unauthenticated user calls the GET version endpoint", func() {
+			r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678/versions/1", http.NoBody)
+			w := httptest.NewRecorder()
 
-		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{})
+			authorisationMock := &authMock.MiddlewareMock{
+				RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+					return handlerFunc
+				},
+				RequireWithAttributesFunc: func(permission string, handlerFunc http.HandlerFunc, getAttributes authorisation.GetAttributesFromRequest) http.HandlerFunc {
+					return handlerFunc
+				},
+				ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+					return nil, errors.New("no token")
+				},
+			}
 
-		Convey("When we call the GET version endpoint", func() {
+			api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{})
+			api.Router.ServeHTTP(w, r)
+
+			Convey("Then it returns a 200 OK", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+			})
+
+			Convey("And is_migration is absent from the response body", func() {
+				var responseVersion models.Version
+				err := json.Unmarshal(w.Body.Bytes(), &responseVersion)
+				So(err, ShouldBeNil)
+				So(responseVersion.IsMigration, ShouldBeNil)
+			})
+		})
+
+		Convey("When an authenticated user calls the GET version endpoint", func() {
+			r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123-456/editions/678/versions/1", http.NoBody)
+			r.Header.Set("Authorization", "Bearer "+testAuthToken)
+			w := httptest.NewRecorder()
+
+			authorisationMock := &authMock.MiddlewareMock{
+				RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+					return handlerFunc
+				},
+				RequireWithAttributesFunc: func(permission string, handlerFunc http.HandlerFunc, getAttributes authorisation.GetAttributesFromRequest) http.HandlerFunc {
+					return handlerFunc
+				},
+				ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+					return &permissionsAPISDK.EntityData{UserID: "test-user-id"}, nil
+				},
+			}
+
+			auditServiceMock := &applicationMocks.AuditServiceMock{
+				RecordVersionAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, versionDoc *models.Version) error {
+					return nil
+				},
+			}
+
+			api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
 			api.Router.ServeHTTP(w, r)
 
 			Convey("Then it returns a 200 OK", func() {

--- a/utils/rewriting.go
+++ b/utils/rewriting.go
@@ -340,6 +340,8 @@ func RewriteEditionsWithoutAuth(ctx context.Context, results []*models.EditionUp
 			continue
 		}
 
+		item.Current.IsMigration = nil
+
 		err := RewriteEditionLinks(ctx, item.Current.Links, datasetLinksBuilder)
 		if err != nil {
 			log.Error(ctx, "failed to rewrite 'current' links", err)
@@ -407,6 +409,7 @@ func RewriteEditionWithoutAuth(ctx context.Context, edition *models.EditionUpdat
 	log.Info(ctx, "getEdition endpoint: caller not authorised returning edition", log.Data{"edition_id": edition.ID})
 
 	edition.Current.ID = edition.ID
+	edition.Current.IsMigration = nil
 	editionResponse = edition.Current
 	err := RewriteEditionLinks(ctx, editionResponse.Links, datasetLinksBuilder)
 	if err != nil {


### PR DESCRIPTION
### What

Prevent `is_migration` field being surfaced in web (this is an addition to the original PR - https://github.com/ONSdigital/dp-dataset-api/pull/710)

### How to review

To test locally, follow the steps in this PR - https://github.com/ONSdigital/dp-dataset-api/pull/710
Then switch to web mode, and make a GET request to each of the `/versions` and `/editions` endpoints and confirm that the `is_migration` field is not included in the response body

### Who can review

Anyone
