### PR TITLE
update web links

### DIFF
--- a/api/static_versions.go
+++ b/api/static_versions.go
@@ -260,7 +260,7 @@ func (api *DatasetAPI) addDatasetVersionCondensed(w http.ResponseWriter, r *http
 		topic, err := api.topicAPIClient.GetTopicPrivate(ctx, topicSDKHeaders, datasetDoc.Next.Topics[0])
 		if err != nil {
 			log.Error(ctx, "addDatasetVersionCondensed endpoint: failed to get topic from Topic API", err, logData)
-			return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewError(err, models.InternalError, models.InternalErrorDescription))
+			return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewError(err, models.ErrTopicAPIFailure, models.ErrTopicAPIFailureDescription))
 		}
 		versionRequest.Links.WebPage = &models.LinkObject{
 			HRef: fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d", topic.Next.Slug, datasetID, edition, nextVersion),
@@ -469,7 +469,7 @@ func (api *DatasetAPI) createVersion(w http.ResponseWriter, r *http.Request) (*m
 		topic, err := api.topicAPIClient.GetTopicPrivate(ctx, topicSDKHeaders, datasetDoc.Next.Topics[0])
 		if err != nil {
 			log.Error(ctx, "createVersion endpoint: failed to get topic from Topic API", err, logData)
-			return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewError(err, models.InternalError, models.InternalErrorDescription))
+			return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewError(err, models.ErrTopicAPIFailure, models.ErrTopicAPIFailureDescription))
 		}
 		newVersion.Links.WebPage = &models.LinkObject{
 			HRef: fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d", topic.Next.Slug, datasetID, edition, versionNumber),

--- a/api/static_versions.go
+++ b/api/static_versions.go
@@ -260,10 +260,10 @@ func (api *DatasetAPI) addDatasetVersionCondensed(w http.ResponseWriter, r *http
 		topic, err := api.topicAPIClient.GetTopicPrivate(ctx, topicSDKHeaders, datasetDoc.Next.Topics[0])
 		if err != nil {
 			log.Error(ctx, "addDatasetVersionCondensed endpoint: failed to get topic from Topic API", err, logData)
-		} else {
-			versionRequest.Links.WebPage = &models.LinkObject{
-				HRef: fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d", topic.Next.Slug, datasetID, edition, nextVersion),
-			}
+			return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewError(err, models.InternalError, models.InternalErrorDescription))
+		}
+		versionRequest.Links.WebPage = &models.LinkObject{
+			HRef: fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d", topic.Next.Slug, datasetID, edition, nextVersion),
 		}
 	}
 
@@ -469,10 +469,10 @@ func (api *DatasetAPI) createVersion(w http.ResponseWriter, r *http.Request) (*m
 		topic, err := api.topicAPIClient.GetTopicPrivate(ctx, topicSDKHeaders, datasetDoc.Next.Topics[0])
 		if err != nil {
 			log.Error(ctx, "createVersion endpoint: failed to get topic from Topic API", err, logData)
-		} else {
-			newVersion.Links.WebPage = &models.LinkObject{
-				HRef: fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d", topic.Next.Slug, datasetID, edition, versionNumber),
-			}
+			return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewError(err, models.InternalError, models.InternalErrorDescription))
+		}
+		newVersion.Links.WebPage = &models.LinkObject{
+			HRef: fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d", topic.Next.Slug, datasetID, edition, versionNumber),
 		}
 	}
 

--- a/api/static_versions.go
+++ b/api/static_versions.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/utils"
 	dpresponse "github.com/ONSdigital/dp-net/v3/handlers/response"
 	dphttp "github.com/ONSdigital/dp-net/v3/http"
+	topicAPISDK "github.com/ONSdigital/dp-topic-api/sdk"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -246,6 +247,26 @@ func (api *DatasetAPI) addDatasetVersionCondensed(w http.ResponseWriter, r *http
 	versionRequest.Links = api.generateVersionLinks(datasetID, edition, nextVersion, versionRequest.Links)
 	versionRequest.Type = models.Static.String()
 
+	datasetDoc, err := api.dataStore.Backend.GetDataset(ctx, datasetID)
+	if err != nil {
+		log.Error(ctx, "failed to get dataset", err, logData)
+		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewError(err, "failed to get dataset", "internal error"))
+	}
+
+	if api.topicAPIClient != nil && len(datasetDoc.Next.Topics) > 0 {
+		topicSDKHeaders := topicAPISDK.Headers{
+			ServiceAuthToken: fetchAccessTokenFromHeader(r),
+		}
+		topic, err := api.topicAPIClient.GetTopicPrivate(ctx, topicSDKHeaders, datasetDoc.Next.Topics[0])
+		if err != nil {
+			log.Error(ctx, "addDatasetVersionCondensed endpoint: failed to get topic from Topic API", err, logData)
+		} else {
+			versionRequest.Links.WebPage = &models.LinkObject{
+				HRef: fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d", topic.Next.Slug, datasetID, edition, nextVersion),
+			}
+		}
+	}
+
 	// ID and Email are the same as auth middleware can only provide userID
 	if err := api.auditService.RecordVersionAuditEvent(ctx, models.RequestedBy{ID: authEntityData.EntityData.UserID, Email: authEntityData.EntityData.UserID}, models.ActionCreate, "/datasets/"+datasetID+"/editions/"+edition+"/versions/"+strconv.Itoa(nextVersion), versionRequest); err != nil {
 		log.Info(ctx, "failed to create version audit event", log.Classification(log.ProtectiveMonitoring), logAuthOption, log.Data{
@@ -270,14 +291,11 @@ func (api *DatasetAPI) addDatasetVersionCondensed(w http.ResponseWriter, r *http
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewError(err, "failed to add version", "internal error"))
 	}
 
-	datasetDoc, err := api.dataStore.Backend.GetDataset(ctx, datasetID)
-	if err != nil {
-		log.Error(ctx, "failed to get dataset", err, logData)
-		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewError(err, "failed to get dataset", "internal error"))
-	}
-
 	datasetDoc.Next.LastUpdated = newVersion.LastUpdated
 	datasetDoc.Next.State = models.AssociatedState
+	if datasetDoc.Next.Links == nil {
+		datasetDoc.Next.Links = &models.DatasetLinks{}
+	}
 	datasetDoc.Next.Links.LatestVersion = &models.LinkObject{
 		HRef: fmt.Sprintf("/datasets/%s/editions/%s/versions/%d", datasetID, edition, nextVersion),
 		ID:   strconv.Itoa(nextVersion),
@@ -304,7 +322,7 @@ func (api *DatasetAPI) addDatasetVersionCondensed(w http.ResponseWriter, r *http
 	return models.NewSuccessResponse(response, http.StatusCreated, headers), nil
 }
 
-//nolint:gocyclo // high cyclomatic complexity not in scope for maintenance
+//nolint:gocyclo,gocognit // high cyclomatic complexity not in scope for maintenance
 func (api *DatasetAPI) createVersion(w http.ResponseWriter, r *http.Request) (*models.SuccessResponse, *models.ErrorResponse) {
 	ctx := r.Context()
 
@@ -438,6 +456,26 @@ func (api *DatasetAPI) createVersion(w http.ResponseWriter, r *http.Request) (*m
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewError(err, models.InternalError, models.InternalErrorDescription))
 	}
 
+	datasetDoc, err := api.dataStore.Backend.GetDataset(ctx, datasetID)
+	if err != nil {
+		log.Error(ctx, "createVersion endpoint: failed to get dataset", err, logData)
+		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewError(err, models.InternalError, models.InternalErrorDescription))
+	}
+
+	if api.topicAPIClient != nil && len(datasetDoc.Next.Topics) > 0 {
+		topicSDKHeaders := topicAPISDK.Headers{
+			ServiceAuthToken: fetchAccessTokenFromHeader(r),
+		}
+		topic, err := api.topicAPIClient.GetTopicPrivate(ctx, topicSDKHeaders, datasetDoc.Next.Topics[0])
+		if err != nil {
+			log.Error(ctx, "createVersion endpoint: failed to get topic from Topic API", err, logData)
+		} else {
+			newVersion.Links.WebPage = &models.LinkObject{
+				HRef: fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d", topic.Next.Slug, datasetID, edition, versionNumber),
+			}
+		}
+	}
+
 	versionExists, err := api.dataStore.Backend.CheckVersionExistsStatic(ctx, datasetID, edition, versionNumber)
 	if err != nil {
 		log.Error(ctx, "createVersion endpoint: failed to check version existence", err, logData)
@@ -472,13 +510,6 @@ func (api *DatasetAPI) createVersion(w http.ResponseWriter, r *http.Request) (*m
 	}
 
 	if isLatest {
-		datasetDoc, err := api.dataStore.Backend.GetDataset(ctx, datasetID)
-		if err != nil {
-			log.Error(ctx, "createVersion endpoint: failed to get dataset", err, logData)
-			return nil, models.NewErrorResponse(http.StatusInternalServerError, nil,
-				models.NewError(err, "failed to get dataset", models.InternalErrorDescription))
-		}
-
 		if datasetDoc.Next.Links == nil {
 			datasetDoc.Next.Links = &models.DatasetLinks{}
 		}

--- a/api/static_versions_test.go
+++ b/api/static_versions_test.go
@@ -2802,7 +2802,7 @@ func TestCreateVersion_WebPageLink(t *testing.T) {
 		So(topicClientMock.GetTopicPrivateCalls()[0].ID, ShouldEqual, "topic-0")
 	})
 
-	Convey("When topic API call fails, version is still created successfully without a web_page link", t, func() {
+	Convey("When topic API call fails, version creation returns a 500 error", t, func() {
 		validVersionJSON, err := json.Marshal(validVersion)
 		So(err, ShouldBeNil)
 
@@ -2840,14 +2840,10 @@ func TestCreateVersion_WebPageLink(t *testing.T) {
 
 		successResponse, errorResponse := api.createVersion(w, r)
 
-		So(errorResponse, ShouldBeNil)
-		So(successResponse.Status, ShouldEqual, http.StatusCreated)
-
-		var version models.Version
-		err = json.Unmarshal(successResponse.Body, &version)
-		So(err, ShouldBeNil)
-		So(version.Links, ShouldNotBeNil)
-		So(version.Links.WebPage, ShouldBeNil)
+		So(successResponse, ShouldBeNil)
+		So(errorResponse.Status, ShouldEqual, http.StatusInternalServerError)
+		So(errorResponse.Errors[0].Code, ShouldEqual, models.InternalError)
+		So(errorResponse.Errors[0].Description, ShouldEqual, models.InternalErrorDescription)
 
 		So(topicClientMock.GetTopicPrivateCalls(), ShouldHaveLength, 1)
 	})
@@ -2982,7 +2978,7 @@ func TestAddDatasetVersionCondensed_WebPageLink(t *testing.T) {
 		So(topicClientMock.GetTopicPrivateCalls()[0].ID, ShouldEqual, "topic-0")
 	})
 
-	Convey("When topic API call fails, version is still created successfully without a web_page link", t, func() {
+	Convey("When topic API call fails, version creation returns a 500 error", t, func() {
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
@@ -3022,62 +3018,11 @@ func TestAddDatasetVersionCondensed_WebPageLink(t *testing.T) {
 
 		successResponse, errorResponse := api.addDatasetVersionCondensed(w, r)
 
-		So(errorResponse, ShouldBeNil)
-		So(successResponse.Status, ShouldEqual, http.StatusCreated)
-
-		var version models.Version
-		err := json.Unmarshal(successResponse.Body, &version)
-		So(err, ShouldBeNil)
-		So(version.Links, ShouldNotBeNil)
-		So(version.Links.WebPage, ShouldBeNil)
+		So(successResponse, ShouldBeNil)
+		So(errorResponse.Status, ShouldEqual, http.StatusInternalServerError)
+		So(errorResponse.Errors[0].Code, ShouldEqual, models.InternalError)
+		So(errorResponse.Errors[0].Description, ShouldEqual, models.InternalErrorDescription)
 
 		So(topicClientMock.GetTopicPrivateCalls(), ShouldHaveLength, 1)
-	})
-
-	Convey("When dataset has no topics, topic API is not called and version is created without a web_page link", t, func() {
-		mockedDataStore := &storetest.StorerMock{
-			CheckDatasetExistsFunc: func(context.Context, string, string) error {
-				return nil
-			},
-			GetLatestVersionStaticFunc: func(context.Context, string, string, string) (*models.Version, error) {
-				return &models.Version{State: models.PublishedState}, nil
-			},
-			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
-				return &models.DatasetUpdate{
-					Next: &models.Dataset{
-						State: models.AssociatedState,
-						Links: &models.DatasetLinks{},
-					},
-				}, nil
-			},
-			AddVersionStaticFunc: func(_ context.Context, v *models.Version) (*models.Version, error) {
-				return v, nil
-			},
-			UpsertDatasetFunc: func(context.Context, string, *models.DatasetUpdate) error {
-				return nil
-			},
-		}
-
-		topicClientMock := &topicMocks.ClienterMock{}
-
-		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/time-series/versions", bytes.NewBufferString(body))
-		r = mux.SetURLVars(r, map[string]string{"dataset_id": "123", "edition": "time-series"})
-		w := httptest.NewRecorder()
-
-		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
-		api.SetTopicAPIClient(topicClientMock)
-
-		successResponse, errorResponse := api.addDatasetVersionCondensed(w, r)
-
-		So(errorResponse, ShouldBeNil)
-		So(successResponse.Status, ShouldEqual, http.StatusCreated)
-
-		var version models.Version
-		err := json.Unmarshal(successResponse.Body, &version)
-		So(err, ShouldBeNil)
-		So(version.Links, ShouldNotBeNil)
-		So(version.Links.WebPage, ShouldBeNil)
-
-		So(topicClientMock.GetTopicPrivateCalls(), ShouldHaveLength, 0)
 	})
 }

--- a/api/static_versions_test.go
+++ b/api/static_versions_test.go
@@ -2842,52 +2842,10 @@ func TestCreateVersion_WebPageLink(t *testing.T) {
 
 		So(successResponse, ShouldBeNil)
 		So(errorResponse.Status, ShouldEqual, http.StatusInternalServerError)
-		So(errorResponse.Errors[0].Code, ShouldEqual, models.InternalError)
-		So(errorResponse.Errors[0].Description, ShouldEqual, models.InternalErrorDescription)
+		So(errorResponse.Errors[0].Code, ShouldEqual, models.ErrTopicAPIFailure)
+		So(errorResponse.Errors[0].Description, ShouldEqual, models.ErrTopicAPIFailureDescription)
 
 		So(topicClientMock.GetTopicPrivateCalls(), ShouldHaveLength, 1)
-	})
-
-	Convey("When dataset has no topics, topic API is not called and version is created without a web_page link", t, func() {
-		validVersionJSON, err := json.Marshal(validVersion)
-		So(err, ShouldBeNil)
-
-		mockedDataStore := &storetest.StorerMock{
-			CheckDatasetExistsFunc: func(context.Context, string, string) error {
-				return nil
-			},
-			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
-				return &models.DatasetUpdate{Next: &models.Dataset{}}, nil
-			},
-			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
-				return false, nil
-			},
-			AddVersionStaticFunc: func(_ context.Context, v *models.Version) (*models.Version, error) {
-				return v, nil
-			},
-		}
-
-		topicClientMock := &topicMocks.ClienterMock{}
-
-		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
-		api.SetTopicAPIClient(topicClientMock)
-
-		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/edition1/versions/1", bytes.NewBuffer(validVersionJSON))
-		r = mux.SetURLVars(r, map[string]string{"dataset_id": "123", "edition": "edition1", "version": "1"})
-		w := httptest.NewRecorder()
-
-		successResponse, errorResponse := api.createVersion(w, r)
-
-		So(errorResponse, ShouldBeNil)
-		So(successResponse.Status, ShouldEqual, http.StatusCreated)
-
-		var version models.Version
-		err = json.Unmarshal(successResponse.Body, &version)
-		So(err, ShouldBeNil)
-		So(version.Links, ShouldNotBeNil)
-		So(version.Links.WebPage, ShouldBeNil)
-
-		So(topicClientMock.GetTopicPrivateCalls(), ShouldHaveLength, 0)
 	})
 }
 
@@ -3020,8 +2978,8 @@ func TestAddDatasetVersionCondensed_WebPageLink(t *testing.T) {
 
 		So(successResponse, ShouldBeNil)
 		So(errorResponse.Status, ShouldEqual, http.StatusInternalServerError)
-		So(errorResponse.Errors[0].Code, ShouldEqual, models.InternalError)
-		So(errorResponse.Errors[0].Description, ShouldEqual, models.InternalErrorDescription)
+		So(errorResponse.Errors[0].Code, ShouldEqual, models.ErrTopicAPIFailure)
+		So(errorResponse.Errors[0].Description, ShouldEqual, models.ErrTopicAPIFailureDescription)
 
 		So(topicClientMock.GetTopicPrivateCalls(), ShouldHaveLength, 1)
 	})

--- a/api/static_versions_test.go
+++ b/api/static_versions_test.go
@@ -17,6 +17,10 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/models"
 	storetest "github.com/ONSdigital/dp-dataset-api/store/datastoretest"
 	permissionsAPISDK "github.com/ONSdigital/dp-permissions-api/sdk"
+	topicModels "github.com/ONSdigital/dp-topic-api/models"
+	topicSDK "github.com/ONSdigital/dp-topic-api/sdk"
+	apiError "github.com/ONSdigital/dp-topic-api/sdk/errors"
+	topicMocks "github.com/ONSdigital/dp-topic-api/sdk/mocks"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -1442,6 +1446,9 @@ func TestAddDatasetVersionCondensed_Failure(t *testing.T) {
 					State: models.PublishedState,
 				}, nil
 			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{}}, nil
+			},
 		}
 
 		authorisationMock := &authMock.MiddlewareMock{
@@ -1594,6 +1601,9 @@ func TestCreateVersion_Success(t *testing.T) {
 		},
 		AddVersionStaticFunc: func(context.Context, *models.Version) (*models.Version, error) {
 			return expectedVersion, nil
+		},
+		GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+			return &models.DatasetUpdate{Next: &models.Dataset{}}, nil
 		},
 	}
 
@@ -1752,6 +1762,9 @@ func TestCreateVersion_Success(t *testing.T) {
 			AddVersionStaticFunc: func(context.Context, *models.Version) (*models.Version, error) {
 				return expectedVersion, nil
 			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{}}, nil
+			},
 		}
 
 		auditServiceMock := &applicationMocks.AuditServiceMock{
@@ -1779,7 +1792,7 @@ func TestCreateVersion_Success(t *testing.T) {
 			})
 
 			Convey("And GetDataset and UpsertDataset should not have been called", func() {
-				So(mockedDataStore.GetDatasetCalls(), ShouldHaveLength, 0)
+				So(mockedDataStore.GetDatasetCalls(), ShouldHaveLength, 1)
 				So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 0)
 			})
 		})
@@ -1798,6 +1811,9 @@ func TestCreateVersion_Success(t *testing.T) {
 			},
 			AddVersionStaticFunc: func(context.Context, *models.Version) (*models.Version, error) {
 				return expectedVersion, nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{}}, nil
 			},
 		}
 
@@ -1825,8 +1841,8 @@ func TestCreateVersion_Success(t *testing.T) {
 				So(successResponse.Status, ShouldEqual, http.StatusCreated)
 			})
 
-			Convey("And GetDataset and UpsertDataset should not have been called", func() {
-				So(mockedDataStore.GetDatasetCalls(), ShouldHaveLength, 0)
+			Convey("And GetDataset should have been called once for topic lookup, UpsertDataset should not have been called", func() {
+				So(mockedDataStore.GetDatasetCalls(), ShouldHaveLength, 1)
 				So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 0)
 			})
 		})
@@ -2106,6 +2122,9 @@ func TestCreateVersion_Failure(t *testing.T) {
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
 			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{}}, nil
+			},
 			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
 				return true, nil
 			},
@@ -2141,6 +2160,9 @@ func TestCreateVersion_Failure(t *testing.T) {
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
 			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{}}, nil
+			},
 			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
 				return false, errs.ErrInternalServer
 			},
@@ -2175,6 +2197,9 @@ func TestCreateVersion_Failure(t *testing.T) {
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{}}, nil
 			},
 			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
 				return false, nil
@@ -2219,6 +2244,9 @@ func TestCreateVersion_Failure(t *testing.T) {
 		mockedDataStore := &storetest.StorerMock{
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{}}, nil
 			},
 			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
 				return false, nil
@@ -2615,6 +2643,9 @@ func TestCreateVersion_IsMigration(t *testing.T) {
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
 			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{}}, nil
+			},
 			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
 				return false, nil
 			},
@@ -2657,6 +2688,9 @@ func TestCreateVersion_IsMigration(t *testing.T) {
 			CheckDatasetExistsFunc: func(context.Context, string, string) error {
 				return nil
 			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{}}, nil
+			},
 			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
 				return false, nil
 			},
@@ -2682,5 +2716,368 @@ func TestCreateVersion_IsMigration(t *testing.T) {
 		err = json.Unmarshal(successResponse.Body, &version)
 		So(err, ShouldBeNil)
 		So(version.IsMigration, ShouldBeNil)
+	})
+}
+
+func TestCreateVersion_WebPageLink(t *testing.T) {
+	t.Parallel()
+
+	authorisationMock := &authMock.MiddlewareMock{
+		RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+			return handlerFunc
+		},
+		ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+			return testEntityData, nil
+		},
+	}
+
+	auditServiceMock := &applicationMocks.AuditServiceMock{
+		RecordVersionAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, version *models.Version) error {
+			return nil
+		},
+	}
+
+	validVersion := &models.Version{
+		EditionTitle: "New edition title",
+		ReleaseDate:  "2025-01-01",
+		Distributions: &[]models.Distribution{
+			{Title: "CSV", Format: "csv", DownloadURL: "path/to/download", ByteSize: 100, MediaType: "text/csv"},
+		},
+		Type: models.Static.String(),
+	}
+
+	Convey("When topic API client is set and returns a valid slug, web_page link is set on the version", t, func() {
+		validVersionJSON, err := json.Marshal(validVersion)
+		So(err, ShouldBeNil)
+
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{
+					Next: &models.Dataset{
+						Topics: []string{"topic-0"},
+					},
+				}, nil
+			},
+			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
+				return false, nil
+			},
+			AddVersionStaticFunc: func(_ context.Context, v *models.Version) (*models.Version, error) {
+				return v, nil
+			},
+		}
+
+		topicClientMock := &topicMocks.ClienterMock{
+			GetTopicPrivateFunc: func(ctx context.Context, reqHeaders topicSDK.Headers, id string) (*topicModels.TopicResponse, apiError.Error) {
+				return &topicModels.TopicResponse{
+					Next: &topicModels.Topic{
+						Slug: "businessindustryandtrade",
+					},
+				}, nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		api.SetTopicAPIClient(topicClientMock)
+
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/edition1/versions/1", bytes.NewBuffer(validVersionJSON))
+		r = mux.SetURLVars(r, map[string]string{"dataset_id": "123", "edition": "edition1", "version": "1"})
+		w := httptest.NewRecorder()
+
+		successResponse, errorResponse := api.createVersion(w, r)
+
+		So(errorResponse, ShouldBeNil)
+		So(successResponse.Status, ShouldEqual, http.StatusCreated)
+
+		var version models.Version
+		err = json.Unmarshal(successResponse.Body, &version)
+		So(err, ShouldBeNil)
+		So(version.Links, ShouldNotBeNil)
+		So(version.Links.WebPage, ShouldNotBeNil)
+		So(version.Links.WebPage.HRef, ShouldEqual, "businessindustryandtrade/datasets/123/editions/edition1/versions/1")
+
+		So(topicClientMock.GetTopicPrivateCalls(), ShouldHaveLength, 1)
+		So(topicClientMock.GetTopicPrivateCalls()[0].ID, ShouldEqual, "topic-0")
+	})
+
+	Convey("When topic API call fails, version is still created successfully without a web_page link", t, func() {
+		validVersionJSON, err := json.Marshal(validVersion)
+		So(err, ShouldBeNil)
+
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{
+					Next: &models.Dataset{
+						Topics: []string{"topic-0"},
+					},
+				}, nil
+			},
+			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
+				return false, nil
+			},
+			AddVersionStaticFunc: func(_ context.Context, v *models.Version) (*models.Version, error) {
+				return v, nil
+			},
+		}
+
+		topicClientMock := &topicMocks.ClienterMock{
+			GetTopicPrivateFunc: func(ctx context.Context, reqHeaders topicSDK.Headers, id string) (*topicModels.TopicResponse, apiError.Error) {
+				return nil, apiError.StatusError{Err: errors.New("topic api error"), Code: 500}
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		api.SetTopicAPIClient(topicClientMock)
+
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/edition1/versions/1", bytes.NewBuffer(validVersionJSON))
+		r = mux.SetURLVars(r, map[string]string{"dataset_id": "123", "edition": "edition1", "version": "1"})
+		w := httptest.NewRecorder()
+
+		successResponse, errorResponse := api.createVersion(w, r)
+
+		So(errorResponse, ShouldBeNil)
+		So(successResponse.Status, ShouldEqual, http.StatusCreated)
+
+		var version models.Version
+		err = json.Unmarshal(successResponse.Body, &version)
+		So(err, ShouldBeNil)
+		So(version.Links, ShouldNotBeNil)
+		So(version.Links.WebPage, ShouldBeNil)
+
+		So(topicClientMock.GetTopicPrivateCalls(), ShouldHaveLength, 1)
+	})
+
+	Convey("When dataset has no topics, topic API is not called and version is created without a web_page link", t, func() {
+		validVersionJSON, err := json.Marshal(validVersion)
+		So(err, ShouldBeNil)
+
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{}}, nil
+			},
+			CheckVersionExistsStaticFunc: func(context.Context, string, string, int) (bool, error) {
+				return false, nil
+			},
+			AddVersionStaticFunc: func(_ context.Context, v *models.Version) (*models.Version, error) {
+				return v, nil
+			},
+		}
+
+		topicClientMock := &topicMocks.ClienterMock{}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		api.SetTopicAPIClient(topicClientMock)
+
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/edition1/versions/1", bytes.NewBuffer(validVersionJSON))
+		r = mux.SetURLVars(r, map[string]string{"dataset_id": "123", "edition": "edition1", "version": "1"})
+		w := httptest.NewRecorder()
+
+		successResponse, errorResponse := api.createVersion(w, r)
+
+		So(errorResponse, ShouldBeNil)
+		So(successResponse.Status, ShouldEqual, http.StatusCreated)
+
+		var version models.Version
+		err = json.Unmarshal(successResponse.Body, &version)
+		So(err, ShouldBeNil)
+		So(version.Links, ShouldNotBeNil)
+		So(version.Links.WebPage, ShouldBeNil)
+
+		So(topicClientMock.GetTopicPrivateCalls(), ShouldHaveLength, 0)
+	})
+}
+
+func TestAddDatasetVersionCondensed_WebPageLink(t *testing.T) {
+	t.Parallel()
+
+	authorisationMock := &authMock.MiddlewareMock{
+		RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+			return handlerFunc
+		},
+		ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+			return testEntityData, nil
+		},
+	}
+
+	auditServiceMock := &applicationMocks.AuditServiceMock{
+		RecordVersionAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, version *models.Version) error {
+			return nil
+		},
+	}
+
+	body := `{
+		"edition_title": "Edition Title 2025",
+		"release_date": "2025-01-15",
+		"distributions": [{
+			"title": "Full Dataset (CSV)",
+			"download_url": "https://download.ons.gov.uk/my-dataset-download.csv",
+			"byte_size": 4300000,
+			"format": "csv"
+		}]
+	}`
+
+	Convey("When topic API client is set and returns a valid slug, web_page link is set on the version", t, func() {
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			GetLatestVersionStaticFunc: func(context.Context, string, string, string) (*models.Version, error) {
+				return &models.Version{State: models.PublishedState}, nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{
+					Next: &models.Dataset{
+						State:  models.AssociatedState,
+						Links:  &models.DatasetLinks{},
+						Topics: []string{"topic-0"},
+					},
+				}, nil
+			},
+			AddVersionStaticFunc: func(_ context.Context, v *models.Version) (*models.Version, error) {
+				return v, nil
+			},
+			UpsertDatasetFunc: func(context.Context, string, *models.DatasetUpdate) error {
+				return nil
+			},
+		}
+
+		topicClientMock := &topicMocks.ClienterMock{
+			GetTopicPrivateFunc: func(ctx context.Context, reqHeaders topicSDK.Headers, id string) (*topicModels.TopicResponse, apiError.Error) {
+				return &topicModels.TopicResponse{
+					Next: &topicModels.Topic{
+						Slug: "businessindustryandtrade",
+					},
+				}, nil
+			},
+		}
+
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/time-series/versions", bytes.NewBufferString(body))
+		r = mux.SetURLVars(r, map[string]string{"dataset_id": "123", "edition": "time-series"})
+		w := httptest.NewRecorder()
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		api.SetTopicAPIClient(topicClientMock)
+
+		successResponse, errorResponse := api.addDatasetVersionCondensed(w, r)
+
+		So(errorResponse, ShouldBeNil)
+		So(successResponse.Status, ShouldEqual, http.StatusCreated)
+
+		var version models.Version
+		err := json.Unmarshal(successResponse.Body, &version)
+		So(err, ShouldBeNil)
+		So(version.Links, ShouldNotBeNil)
+		So(version.Links.WebPage, ShouldNotBeNil)
+		So(version.Links.WebPage.HRef, ShouldEqual, "businessindustryandtrade/datasets/123/editions/time-series/versions/1")
+
+		So(topicClientMock.GetTopicPrivateCalls(), ShouldHaveLength, 1)
+		So(topicClientMock.GetTopicPrivateCalls()[0].ID, ShouldEqual, "topic-0")
+	})
+
+	Convey("When topic API call fails, version is still created successfully without a web_page link", t, func() {
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			GetLatestVersionStaticFunc: func(context.Context, string, string, string) (*models.Version, error) {
+				return &models.Version{State: models.PublishedState}, nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{
+					Next: &models.Dataset{
+						State:  models.AssociatedState,
+						Links:  &models.DatasetLinks{},
+						Topics: []string{"topic-0"},
+					},
+				}, nil
+			},
+			AddVersionStaticFunc: func(_ context.Context, v *models.Version) (*models.Version, error) {
+				return v, nil
+			},
+			UpsertDatasetFunc: func(context.Context, string, *models.DatasetUpdate) error {
+				return nil
+			},
+		}
+
+		topicClientMock := &topicMocks.ClienterMock{
+			GetTopicPrivateFunc: func(ctx context.Context, reqHeaders topicSDK.Headers, id string) (*topicModels.TopicResponse, apiError.Error) {
+				return nil, apiError.StatusError{Err: errors.New("topic api error"), Code: 500}
+			},
+		}
+
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/time-series/versions", bytes.NewBufferString(body))
+		r = mux.SetURLVars(r, map[string]string{"dataset_id": "123", "edition": "time-series"})
+		w := httptest.NewRecorder()
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		api.SetTopicAPIClient(topicClientMock)
+
+		successResponse, errorResponse := api.addDatasetVersionCondensed(w, r)
+
+		So(errorResponse, ShouldBeNil)
+		So(successResponse.Status, ShouldEqual, http.StatusCreated)
+
+		var version models.Version
+		err := json.Unmarshal(successResponse.Body, &version)
+		So(err, ShouldBeNil)
+		So(version.Links, ShouldNotBeNil)
+		So(version.Links.WebPage, ShouldBeNil)
+
+		So(topicClientMock.GetTopicPrivateCalls(), ShouldHaveLength, 1)
+	})
+
+	Convey("When dataset has no topics, topic API is not called and version is created without a web_page link", t, func() {
+		mockedDataStore := &storetest.StorerMock{
+			CheckDatasetExistsFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			GetLatestVersionStaticFunc: func(context.Context, string, string, string) (*models.Version, error) {
+				return &models.Version{State: models.PublishedState}, nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{
+					Next: &models.Dataset{
+						State: models.AssociatedState,
+						Links: &models.DatasetLinks{},
+					},
+				}, nil
+			},
+			AddVersionStaticFunc: func(_ context.Context, v *models.Version) (*models.Version, error) {
+				return v, nil
+			},
+			UpsertDatasetFunc: func(context.Context, string, *models.DatasetUpdate) error {
+				return nil
+			},
+		}
+
+		topicClientMock := &topicMocks.ClienterMock{}
+
+		r := createRequestWithAuth("POST", "http://localhost:22000/datasets/123/editions/time-series/versions", bytes.NewBufferString(body))
+		r = mux.SetURLVars(r, map[string]string{"dataset_id": "123", "edition": "time-series"})
+		w := httptest.NewRecorder()
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		api.SetTopicAPIClient(topicClientMock)
+
+		successResponse, errorResponse := api.addDatasetVersionCondensed(w, r)
+
+		So(errorResponse, ShouldBeNil)
+		So(successResponse.Status, ShouldEqual, http.StatusCreated)
+
+		var version models.Version
+		err := json.Unmarshal(successResponse.Body, &version)
+		So(err, ShouldBeNil)
+		So(version.Links, ShouldNotBeNil)
+		So(version.Links.WebPage, ShouldBeNil)
+
+		So(topicClientMock.GetTopicPrivateCalls(), ShouldHaveLength, 0)
 	})
 }

--- a/features/static_versions_post.feature
+++ b/features/static_versions_post.feature
@@ -582,7 +582,7 @@ Feature: Static Dataset Versions POST API
             """
         And the response header "ETag" should not be empty
 
-    Scenario: POST creates a version without web_page link when topic API returns an error
+    Scenario: POST returns 500 when topic API returns an error for a dataset with topics
         Given private endpoints are enabled
         And I am an admin user
         And I have these datasets:
@@ -618,4 +618,4 @@ Feature: Static Dataset Versions POST API
                 ]
             }
             """
-        Then the HTTP status code should be "201"
+        Then the HTTP status code should be "500"

--- a/features/static_versions_post.feature
+++ b/features/static_versions_post.feature
@@ -505,3 +505,117 @@ Feature: Static Dataset Versions POST API
                 "version": 1
             }
             """
+
+    Scenario: POST creates a version with web_page link when dataset has topics
+        Given private endpoints are enabled
+        And I am an admin user
+        And I have these datasets:
+            """
+            [
+                {
+                    "id": "static-dataset-topics-condensed",
+                    "title": "Static dataset with topics",
+                    "state": "created",
+                    "type": "static",
+                    "topics": ["economy-topic-id"],
+                    "links": {
+                        "self": {
+                            "href": "http://localhost:22000/datasets/static-dataset-topics-condensed"
+                        }
+                    }
+                }
+            ]
+            """
+        When I POST "/datasets/static-dataset-topics-condensed/editions/2024/versions"
+            """
+            {
+                "release_date": "2024-12-01T09:00:00.000Z",
+                "edition_title": "2024",
+                "type": "static",
+                "distributions": [
+                    {
+                        "title": "Full Dataset CSV",
+                        "format": "csv",
+                        "download_url": "/uuid/filename.csv",
+                        "byte_size": 100
+                    }
+                ]
+            }
+            """
+        Then I should receive the following JSON response with status "201":
+            """
+            {
+                "dataset_id": "static-dataset-topics-condensed",
+                "distributions": [
+                    {
+                        "byte_size": 100,
+                        "download_url": "/uuid/filename.csv",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "title": "Full Dataset CSV"
+                    }
+                ],
+                "edition": "2024",
+                "edition_title": "2024",
+                "last_updated": "{{DYNAMIC_RECENT_TIMESTAMP}}",
+                "links": {
+                    "dataset": {
+                        "href": "http://localhost:22000/datasets/static-dataset-topics-condensed",
+                        "id": "static-dataset-topics-condensed"
+                    },
+                    "edition": {
+                        "href": "http://localhost:22000/datasets/static-dataset-topics-condensed/editions/2024",
+                        "id": "2024"
+                    },
+                    "self": {
+                        "href": "http://localhost:22000/datasets/static-dataset-topics-condensed/editions/2024/versions/1"
+                    },
+                    "web_page": {
+                        "href": "economy/datasets/static-dataset-topics-condensed/editions/2024/versions/1"
+                    }
+                },
+                "release_date": "2024-12-01T09:00:00.000Z",
+                "state": "associated",
+                "type": "static",
+                "version": 1
+            }
+            """
+        And the response header "ETag" should not be empty
+
+    Scenario: POST creates a version without web_page link when topic API returns an error
+        Given private endpoints are enabled
+        And I am an admin user
+        And I have these datasets:
+            """
+            [
+                {
+                    "id": "static-dataset-unknown-topic-condensed",
+                    "title": "Static dataset with unknown topic",
+                    "state": "created",
+                    "type": "static",
+                    "topics": ["unknown-topic-id"],
+                    "links": {
+                        "self": {
+                            "href": "http://localhost:22000/datasets/static-dataset-unknown-topic-condensed"
+                        }
+                    }
+                }
+            ]
+            """
+        When I POST "/datasets/static-dataset-unknown-topic-condensed/editions/2024/versions"
+            """
+            {
+                "release_date": "2024-12-01T09:00:00.000Z",
+                "edition_title": "2024",
+                "type": "static",
+                "distributions": [
+                    {
+                        "title": "Full Dataset CSV",
+                        "format": "csv",
+                        "download_url": "/uuid/filename.csv",
+                        "byte_size": 100
+                    }
+                ]
+            }
+            """
+        Then the HTTP status code should be "201"

--- a/features/static_versions_post_with_id.feature
+++ b/features/static_versions_post_with_id.feature
@@ -890,7 +890,7 @@ Scenario: Successfully creating a version includes web_page link when dataset ha
         """
     And the response header "ETag" should not be empty
 
-Scenario: Creating a version with an unknown topic ID still succeeds but without a web_page link
+Scenario: Creating a version with an unknown topic ID returns 500
     Given private endpoints are enabled
     And I am an admin user
     And I have these datasets:
@@ -921,4 +921,4 @@ Scenario: Creating a version with an unknown topic ID still succeeds but without
             "type": "static"
         }
         """
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "500"

--- a/features/static_versions_post_with_id.feature
+++ b/features/static_versions_post_with_id.feature
@@ -818,3 +818,107 @@ Scenario: POST creates a static version with is_migration true and it is returne
             "version": 2
         }
         """
+
+Scenario: Successfully creating a version includes web_page link when dataset has topics
+    Given private endpoints are enabled
+    And I am an admin user
+    And I have these datasets:
+        """
+        [
+            {
+                "id": "static-dataset-with-topics",
+                "title": "Static dataset with topics",
+                "state": "published",
+                "type": "static",
+                "topics": ["economy-topic-id"]
+            }
+        ]
+        """
+    When I POST "/datasets/static-dataset-with-topics/editions/2024/versions/1"
+        """
+        {
+            "release_date": "2024-12-01T09:00:00.000Z",
+            "edition_title": "2024",
+            "distributions": [
+                {
+                    "title": "Full Dataset CSV",
+                    "format": "csv",
+                    "download_url": "/uuid/filename.csv",
+                    "byte_size": 100
+                }
+            ],
+            "type": "static"
+        }
+        """
+    Then I should receive the following JSON response with status "201":
+        """
+        {
+            "dataset_id": "static-dataset-with-topics",
+            "distributions": [
+                {
+                    "byte_size": 100,
+                    "download_url": "/uuid/filename.csv",
+                    "format": "csv",
+                    "media_type": "text/csv",
+                    "title": "Full Dataset CSV"
+                }
+            ],
+            "edition": "2024",
+            "edition_title": "2024",
+            "last_updated": "{{DYNAMIC_RECENT_TIMESTAMP}}",
+            "links": {
+                "dataset": {
+                    "href": "http://localhost:22000/datasets/static-dataset-with-topics",
+                    "id": "static-dataset-with-topics"
+                },
+                "edition": {
+                    "href": "http://localhost:22000/datasets/static-dataset-with-topics/editions/2024",
+                    "id": "2024"
+                },
+                "self": {
+                    "href": "http://localhost:22000/datasets/static-dataset-with-topics/editions/2024/versions/1"
+                },
+                "web_page": {
+                    "href": "economy/datasets/static-dataset-with-topics/editions/2024/versions/1"
+                }
+            },
+            "release_date": "2024-12-01T09:00:00.000Z",
+            "state": "associated",
+            "type": "static",
+            "version": 1
+        }
+        """
+    And the response header "ETag" should not be empty
+
+Scenario: Creating a version with an unknown topic ID still succeeds but without a web_page link
+    Given private endpoints are enabled
+    And I am an admin user
+    And I have these datasets:
+        """
+        [
+            {
+                "id": "static-dataset-unknown-topic",
+                "title": "Static dataset with unknown topic",
+                "state": "published",
+                "type": "static",
+                "topics": ["unknown-topic-id"]
+            }
+        ]
+        """
+    When I POST "/datasets/static-dataset-unknown-topic/editions/2024/versions/1"
+        """
+        {
+            "release_date": "2024-12-01T09:00:00.000Z",
+            "edition_title": "2024",
+            "distributions": [
+                {
+                    "title": "Full Dataset CSV",
+                    "format": "csv",
+                    "download_url": "/uuid/filename.csv",
+                    "byte_size": 100
+                }
+            ],
+            "type": "static"
+        }
+        """
+    Then the HTTP status code should be "201"

--- a/models/error_content.go
+++ b/models/error_content.go
@@ -19,6 +19,7 @@ const (
 	ErrEditionAlreadyExists      = "ErrEditionAlreadyExists"
 	ErrEditionTitleAlreadyExists = "ErrEditionTitleAlreadyExists"
 	ErrNoSpacesAllowedError      = "ErrSpacesNotAllowed"
+	ErrTopicAPIFailure           = "ErrTopicAPIFailure"
 )
 
 // API error descriptions
@@ -40,4 +41,5 @@ const (
 	ErrTypeNotStaticDescription                   = "version type should be static"
 	ErrEditionAlreadyExistsDescription            = "edition already exists"
 	ErrEditionTitleAlreadyExistsDescription       = "edition title already exists"
+	ErrTopicAPIFailureDescription                 = "topic not found in Topic API"
 )


### PR DESCRIPTION
### What

Store static overview page link for versions
Jira - https://officefornationalstatistics.atlassian.net/browse/DIS-4805

### How to review

To test locally -

- ensure the local Topic API has private endpoints enabled in your stack env, as this is required for the topic slug lookup to work correctly
- create a static dataset that has a topics field set to a valid local topic ID (for example "topic-0")
- send a POST request to create a new static version via both endpoints - 
`/datasets/{dataset_id}/editions/{edition}/versions`
`/datasets/{dataset_id}/editions/{edition}/versions/{version}`
and confirm `links.web_page.href` is present in the 201 response in the format `{topic-slug}/datasets/{dataset_id}/editions/{edition}/versions/{version}`
- send a GET request to the version just created and confirm `links.web_page.href` is present in the response

Confirm changes make sense, tests pass

### Who can review

Anyone
