### PR TITLE
move files validation

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
+	"github.com/ONSdigital/dp-dataset-api/application"
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/utils"
 	filesAPISDK "github.com/ONSdigital/dp-files-api/sdk"
@@ -886,6 +887,8 @@ func handleVersionAPIErr(ctx context.Context, err error, w http.ResponseWriter, 
 func getVersionAPIErrStatusCode(err error) int {
 	var status int
 	switch {
+	case err == errs.ErrFileMetadataNotFound:
+		status = http.StatusUnprocessableEntity
 	case notFound[err] || errs.NotFoundMap[err]:
 		status = http.StatusNotFound
 	case badRequest[err] || errs.BadRequestMap[err]:
@@ -1019,7 +1022,8 @@ func (api *DatasetAPI) putState(w http.ResponseWriter, r *http.Request) {
 		Type:  models.Static.String(),
 	}
 
-	updatedVersion, err := api.smDatasetAPI.AmendVersion(r.Context(), vars, versionUpdate)
+	ctxWithToken := context.WithValue(ctx, application.AccessTokenKey, fetchAccessTokenFromHeader(r))
+	updatedVersion, err := api.smDatasetAPI.AmendVersion(ctxWithToken, vars, versionUpdate)
 	if err != nil {
 		handleVersionAPIErr(ctx, err, w, logData)
 		return
@@ -1142,22 +1146,7 @@ func (api *DatasetAPI) publishDistributionFiles(ctx context.Context, version *mo
 		}
 		maps.Copy(fileLogData, logData)
 
-		_, err := api.filesAPIClient.GetFile(ctx, filepath, filesAPISDK.Headers{
-			Authorization: accessToken,
-		})
-		if err != nil {
-			log.Error(ctx, "failed to get file metadata", err, fileLogData)
-
-			if strings.Contains(err.Error(), "FileNotRegistered") ||
-				strings.Contains(err.Error(), "file not registered") ||
-				strings.Contains(err.Error(), "not found") {
-				filesAPIError = errs.ErrFileMetadataNotFound
-			}
-			lastError = err
-			continue
-		}
-
-		err = api.filesAPIClient.MarkFilePublished(ctx, filepath, filesAPISDK.Headers{Authorization: accessToken})
+		err := api.filesAPIClient.MarkFilePublished(ctx, filepath, filesAPISDK.Headers{Authorization: accessToken})
 		if err != nil {
 			log.Error(ctx, "failed to publish file", err, fileLogData)
 

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -14,16 +14,21 @@ import (
 	"testing"
 	"time"
 
+	clientsidentity "github.com/ONSdigital/dp-api-clients-go/v2/identity"
 	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
 	authMock "github.com/ONSdigital/dp-authorisation/v2/authorisation/mock"
 	errs "github.com/ONSdigital/dp-dataset-api/apierrors"
+	"github.com/ONSdigital/dp-dataset-api/application"
 	applicationMocks "github.com/ONSdigital/dp-dataset-api/application/mock"
 	cloudflareMocks "github.com/ONSdigital/dp-dataset-api/cloudflare/mocks"
 	"github.com/ONSdigital/dp-dataset-api/config"
 	"github.com/ONSdigital/dp-dataset-api/mocks"
 	"github.com/ONSdigital/dp-dataset-api/models"
+	"github.com/ONSdigital/dp-dataset-api/store"
 	storetest "github.com/ONSdigital/dp-dataset-api/store/datastoretest"
 	filesAPIModels "github.com/ONSdigital/dp-files-api/files"
+	filesAPISDK "github.com/ONSdigital/dp-files-api/sdk"
+	filesAPISDKMocks "github.com/ONSdigital/dp-files-api/sdk/mocks"
 	filesAPIErrors "github.com/ONSdigital/dp-files-api/store"
 	permissionsAPISDK "github.com/ONSdigital/dp-permissions-api/sdk"
 	topicAPIModels "github.com/ONSdigital/dp-topic-api/models"
@@ -46,12 +51,7 @@ const (
 )
 
 type mockFilesClient struct {
-	GetFileFunc           func(ctx context.Context, path string) (*filesAPIModels.StoredRegisteredMetaData, error)
 	MarkFilePublishedFunc func(ctx context.Context, path string) error
-}
-
-func (m *mockFilesClient) GetFile(ctx context.Context, path string) (*filesAPIModels.StoredRegisteredMetaData, error) {
-	return m.GetFileFunc(ctx, path)
 }
 
 func (m *mockFilesClient) MarkFilePublished(ctx context.Context, path string) error {
@@ -5034,14 +5034,9 @@ func TestPublishDistributionFiles(t *testing.T) {
 		logData := log.Data{}
 
 		Convey("When publishDistributionFiles is called with a mocked files client that succeeds", func() {
-			getFileCalls := 0
 			markPublishedCalls := 0
 
 			mockClient := &mockFilesClient{
-				GetFileFunc: func(ctx context.Context, path string) (*filesAPIModels.StoredRegisteredMetaData, error) {
-					getFileCalls++
-					return &filesAPIModels.StoredRegisteredMetaData{}, nil
-				},
 				MarkFilePublishedFunc: func(ctx context.Context, path string) error {
 					markPublishedCalls++
 					return nil
@@ -5049,72 +5044,24 @@ func TestPublishDistributionFiles(t *testing.T) {
 			}
 
 			testFunc := func() error {
-				getFileFn := func(ctx context.Context, path string) (*filesAPIModels.StoredRegisteredMetaData, error) {
-					return mockClient.GetFile(ctx, path)
-				}
-
 				markPublishedFn := func(ctx context.Context, path string) error {
 					return mockClient.MarkFilePublished(ctx, path)
 				}
-
-				return publishDistributionFilesTest(ctx, version, logData, getFileFn, markPublishedFn)
+				return publishDistributionFilesTest(ctx, version, logData, markPublishedFn)
 			}
 
 			err := testFunc()
 
 			Convey("Then no error should be returned", func() {
 				So(err, ShouldBeNil)
-				So(getFileCalls, ShouldEqual, 2)
 				So(markPublishedCalls, ShouldEqual, 2)
 			})
 		})
 
-		Convey("When publishDistributionFiles is called with a mocked files client that fails on GetFile", func() {
-			getFileCalls := 0
-			markPublishedCalls := 0
-
-			mockClient := &mockFilesClient{
-				GetFileFunc: func(ctx context.Context, path string) (*filesAPIModels.StoredRegisteredMetaData, error) {
-					getFileCalls++
-					return &filesAPIModels.StoredRegisteredMetaData{}, errors.New("get file error")
-				},
-				MarkFilePublishedFunc: func(ctx context.Context, path string) error {
-					markPublishedCalls++
-					return nil
-				},
-			}
-
-			testFunc := func() error {
-				getFileFn := func(ctx context.Context, path string) (*filesAPIModels.StoredRegisteredMetaData, error) {
-					return mockClient.GetFile(ctx, path)
-				}
-
-				markPublishedFn := func(ctx context.Context, path string) error {
-					return mockClient.MarkFilePublished(ctx, path)
-				}
-
-				return publishDistributionFilesTest(ctx, version, logData, getFileFn, markPublishedFn)
-			}
-
-			err := testFunc()
-
-			Convey("Then an error should be returned", func() {
-				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldContainSubstring, "get file error")
-				So(getFileCalls, ShouldEqual, 2)
-				So(markPublishedCalls, ShouldEqual, 0)
-			})
-		})
-
 		Convey("When publishDistributionFiles is called with a mocked files client that fails on MarkFilePublished", func() {
-			getFileCalls := 0
 			markPublishedCalls := 0
 
 			mockClient := &mockFilesClient{
-				GetFileFunc: func(ctx context.Context, path string) (*filesAPIModels.StoredRegisteredMetaData, error) {
-					getFileCalls++
-					return &filesAPIModels.StoredRegisteredMetaData{}, nil
-				},
 				MarkFilePublishedFunc: func(ctx context.Context, path string) error {
 					markPublishedCalls++
 					return errors.New("mark published error")
@@ -5122,15 +5069,10 @@ func TestPublishDistributionFiles(t *testing.T) {
 			}
 
 			testFunc := func() error {
-				getFileFn := func(ctx context.Context, path string) (*filesAPIModels.StoredRegisteredMetaData, error) {
-					return mockClient.GetFile(ctx, path)
-				}
-
 				markPublishedFn := func(ctx context.Context, path string) error {
 					return mockClient.MarkFilePublished(ctx, path)
 				}
-
-				return publishDistributionFilesTest(ctx, version, logData, getFileFn, markPublishedFn)
+				return publishDistributionFilesTest(ctx, version, logData, markPublishedFn)
 			}
 
 			err := testFunc()
@@ -5138,7 +5080,6 @@ func TestPublishDistributionFiles(t *testing.T) {
 			Convey("Then an error should be returned", func() {
 				So(err, ShouldNotBeNil)
 				So(err.Error(), ShouldContainSubstring, "mark published error")
-				So(getFileCalls, ShouldEqual, 2)
 				So(markPublishedCalls, ShouldEqual, 2)
 			})
 		})
@@ -5257,7 +5198,6 @@ func TestPutStatePublishDistributionFilesCondition(t *testing.T) {
 }
 
 func publishDistributionFilesTest(ctx context.Context, version *models.Version, logData log.Data,
-	getFileFn func(context.Context, string) (*filesAPIModels.StoredRegisteredMetaData, error),
 	markPublishedFn func(context.Context, string) error) error {
 	if version.Distributions == nil || len(*version.Distributions) == 0 {
 		return nil
@@ -5279,19 +5219,11 @@ func publishDistributionFilesTest(ctx context.Context, version *models.Version, 
 			"distribution_title":  distribution.Title,
 			"distribution_format": distribution.Format,
 		}
-
 		for k, v := range logData {
 			fileLogData[k] = v
 		}
 
-		_, err := getFileFn(ctx, filepath)
-		if err != nil {
-			log.Error(ctx, "failed to get file metadata", err, fileLogData)
-			lastError = err
-			continue
-		}
-
-		err = markPublishedFn(ctx, filepath)
+		err := markPublishedFn(ctx, filepath)
 		if err != nil {
 			log.Error(ctx, "failed to publish file", err, fileLogData)
 			lastError = err
@@ -5311,7 +5243,6 @@ func publishDistributionFilesTest(ctx context.Context, version *models.Version, 
 	if lastError != nil {
 		return fmt.Errorf("one or more errors occurred while publishing files: %w", lastError)
 	}
-
 	return nil
 }
 
@@ -5395,21 +5326,6 @@ func TestPublishDistributionFilesErrorMapping(t *testing.T) {
 	t.Parallel()
 
 	Convey("When testing error mapping logic in publishDistributionFiles", t, func() {
-		Convey("Given ErrFileNotRegistered", func() {
-			err := filesAPIErrors.ErrFileNotRegistered
-			var filesAPIError error
-
-			if strings.Contains(err.Error(), "FileNotRegistered") ||
-				strings.Contains(err.Error(), "file not registered") ||
-				strings.Contains(err.Error(), "not found") {
-				filesAPIError = errs.ErrFileMetadataNotFound
-			}
-
-			Convey("Then it should be mapped to ErrFileMetadataNotFound", func() {
-				So(filesAPIError, ShouldEqual, errs.ErrFileMetadataNotFound)
-			})
-		})
-
 		Convey("Given ErrFileNotInUploadedState", func() {
 			err := filesAPIErrors.ErrFileNotInUploadedState
 			var filesAPIError error
@@ -5424,51 +5340,6 @@ func TestPublishDistributionFilesErrorMapping(t *testing.T) {
 				So(filesAPIError, ShouldEqual, errs.ErrFileNotInCorrectState)
 			})
 		})
-
-		Convey("Given error with 'FileNotRegistered' in message", func() {
-			err := errors.New("FileNotRegistered: file not found")
-			var filesAPIError error
-
-			if strings.Contains(err.Error(), "FileNotRegistered") ||
-				strings.Contains(err.Error(), "file not registered") ||
-				strings.Contains(err.Error(), "not found") {
-				filesAPIError = errs.ErrFileMetadataNotFound
-			}
-
-			Convey("Then it should be mapped to ErrFileMetadataNotFound", func() {
-				So(filesAPIError, ShouldEqual, errs.ErrFileMetadataNotFound)
-			})
-		})
-
-		Convey("Given error with 'file not registered' in message", func() {
-			err := errors.New("file not registered")
-			var filesAPIError error
-
-			if strings.Contains(err.Error(), "FileNotRegistered") ||
-				strings.Contains(err.Error(), "file not registered") ||
-				strings.Contains(err.Error(), "not found") {
-				filesAPIError = errs.ErrFileMetadataNotFound
-			}
-
-			Convey("Then it should be mapped to ErrFileMetadataNotFound", func() {
-				So(filesAPIError, ShouldEqual, errs.ErrFileMetadataNotFound)
-			})
-		})
-
-		Convey("Given error with 'not found' in message", func() {
-			err := errors.New("resource not found")
-			var filesAPIError error
-
-			if strings.Contains(err.Error(), "FileNotRegistered") ||
-				strings.Contains(err.Error(), "file not registered") ||
-				strings.Contains(err.Error(), "not found") {
-				filesAPIError = errs.ErrFileMetadataNotFound
-			}
-
-			Convey("Then it should be mapped to ErrFileMetadataNotFound", func() {
-				So(filesAPIError, ShouldEqual, errs.ErrFileMetadataNotFound)
-			})
-		})
 	})
 }
 
@@ -5479,8 +5350,8 @@ func TestErrorStatusCodeMapping(t *testing.T) {
 		Convey("Given ErrFileMetadataNotFound", func() {
 			statusCode := getVersionAPIErrStatusCode(errs.ErrFileMetadataNotFound)
 
-			Convey("Then it should return 404", func() {
-				So(statusCode, ShouldEqual, http.StatusNotFound)
+			Convey("Then it should return 422", func() {
+				So(statusCode, ShouldEqual, http.StatusUnprocessableEntity)
 			})
 		})
 
@@ -5955,6 +5826,281 @@ func TestPutVersionIsMigration(t *testing.T) {
 			So(capturedVersionUpdate, ShouldNotBeNil)
 			So(capturedVersionUpdate.IsMigration, ShouldNotBeNil)
 			So(*capturedVersionUpdate.IsMigration, ShouldBeTrue)
+		})
+	})
+}
+
+func TestPutStateApproveDistributionFilesCheck(t *testing.T) {
+	buildAPIWithApproval := func(
+		mockedDataStore store.Storer,
+		filesClient filesAPISDK.Clienter,
+		authorisationMock *authMock.MiddlewareMock,
+		auditServiceMock *applicationMocks.AuditServiceMock,
+	) *DatasetAPI {
+		mu.Lock()
+		defer mu.Unlock()
+
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		cfg.ServiceAuthToken = authToken
+		cfg.DatasetAPIURL = host
+		cfg.EnablePrivateEndpoints = true
+		cfg.DefaultLimit = 0
+		cfg.DefaultOffset = 0
+		cfg.EnableDeleteStaticVersion = true
+		cfg.EnablePermissionsAuth = true
+		cfg.CloudflareEnabled = false
+
+		mockedMapSMGeneratedDownloads := map[models.DatasetType]application.DownloadsGenerator{}
+
+		states := []application.State{
+			application.Published,
+			application.Associated,
+			application.Approved,
+		}
+		transitions := []application.Transition{
+			{
+				Label:               "associated",
+				TargetState:         application.Associated,
+				AllowedSourceStates: []string{"created", "associated"},
+				Type:                "static",
+			},
+			{
+				Label:               "approved",
+				TargetState:         application.Approved,
+				AllowedSourceStates: []string{"associated"},
+				Type:                "static",
+			},
+			{
+				Label:               "published",
+				TargetState:         application.Published,
+				AllowedSourceStates: []string{"approved"},
+				Type:                "static",
+			},
+		}
+
+		smDS := &application.StateMachineDatasetAPI{
+			DataStore:          store.DataStore{Backend: mockedDataStore},
+			DownloadGenerators: mockedMapSMGeneratedDownloads,
+			StateMachine:       application.NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore}),
+		}
+		smDS.SetFilesAPIClient(filesClient)
+
+		testIdentityClient := clientsidentity.New(cfg.ZebedeeURL)
+		permissionsChecker := &authMock.PermissionsCheckerMock{
+			HasPermissionFunc: func(ctx context.Context, entityData permissionsAPISDK.EntityData, permission string, attributes map[string]string) (bool, error) {
+				return true, nil
+			},
+		}
+
+		mockedMapGeneratedDownloads := map[models.DatasetType]DownloadsGenerator{}
+
+		return Setup(testContext, cfg, mux.NewRouter(), store.DataStore{Backend: mockedDataStore}, urlBuilder, mockedMapGeneratedDownloads, authorisationMock, enableURLRewriting, smDS, auditServiceMock, permissionsChecker, testIdentityClient, nil, &cloudflareMocks.ClienterMock{})
+	}
+
+	distributions := []models.Distribution{
+		{
+			Title:       "Full Dataset (CSV)",
+			Format:      "csv",
+			DownloadURL: "datasets/test-dataset/editions/test-edition/myfile.csv",
+		},
+	}
+
+	baseVersion := func() *models.Version {
+		return &models.Version{
+			ID:            "789",
+			State:         models.AssociatedState,
+			Type:          models.Static.String(),
+			Edition:       "test-edition",
+			EditionTitle:  "Test Edition",
+			ReleaseDate:   "2025-01-01T00:00:00Z",
+			Distributions: &distributions,
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/test-dataset",
+					ID:   "test-dataset",
+				},
+				Edition: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/test-dataset/editions/test-edition",
+					ID:   "test-edition",
+				},
+				Self: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/test-dataset/editions/test-edition/versions/1",
+				},
+				Version: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/test-dataset/editions/test-edition/versions/1",
+					ID:   "1",
+				},
+			},
+		}
+	}
+
+	authorisationMock := &authMock.MiddlewareMock{
+		RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+			return handlerFunc
+		},
+		RequireWithAttributesFunc: func(permission string, handlerFunc http.HandlerFunc, getAttributes authorisation.GetAttributesFromRequest) http.HandlerFunc {
+			return handlerFunc
+		},
+		ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+			return testEntityData, nil
+		},
+	}
+
+	auditServiceMock := &applicationMocks.AuditServiceMock{
+		RecordVersionAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, version *models.Version) error {
+			return nil
+		},
+	}
+
+	Convey("When approving a version and all distribution files exist in files API", t, func() {
+		mockedDataStore := &storetest.StorerMock{
+			GetVersionStaticFunc: func(ctx context.Context, datasetID, editionID string, version int, state string) (*models.Version, error) {
+				return baseVersion(), nil
+			},
+			AcquireVersionsLockFunc: func(context.Context, string) (string, error) {
+				return testLockID, nil
+			},
+			UnlockVersionsFunc: func(context.Context, string) {},
+			CheckEditionExistsStaticFunc: func(context.Context, string, string, string) error {
+				return nil
+			},
+			UpdateVersionStaticFunc: func(context.Context, *models.Version, *models.Version, string) (string, error) {
+				return "", nil
+			},
+		}
+
+		filesClient := &filesAPISDKMocks.ClienterMock{
+			GetFileFunc: func(ctx context.Context, filePath string, headers filesAPISDK.Headers) (*filesAPIModels.StoredRegisteredMetaData, error) {
+				return &filesAPIModels.StoredRegisteredMetaData{}, nil
+			},
+		}
+
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/test-dataset/editions/test-edition/versions/1/state", bytes.NewBufferString(`{"state":"approved"}`))
+		w := httptest.NewRecorder()
+
+		api := buildAPIWithApproval(mockedDataStore, filesClient, authorisationMock, auditServiceMock)
+		api.Router.ServeHTTP(w, r)
+
+		Convey("Then a 200 response is returned", func() {
+			So(w.Code, ShouldEqual, http.StatusOK)
+		})
+
+		Convey("And GetFile was called for the distribution", func() {
+			So(filesClient.GetFileCalls(), ShouldHaveLength, 1)
+			So(filesClient.GetFileCalls()[0].FilePath, ShouldEqual, "datasets/test-dataset/editions/test-edition/myfile.csv")
+		})
+	})
+
+	Convey("When approving a version and a distribution file does not exist in files API", t, func() {
+		mockedDataStore := &storetest.StorerMock{
+			GetVersionStaticFunc: func(ctx context.Context, datasetID, editionID string, version int, state string) (*models.Version, error) {
+				return baseVersion(), nil
+			},
+			AcquireVersionsLockFunc: func(context.Context, string) (string, error) {
+				return testLockID, nil
+			},
+			UnlockVersionsFunc: func(context.Context, string) {},
+			CheckEditionExistsStaticFunc: func(context.Context, string, string, string) error {
+				return nil
+			},
+			UpdateVersionStaticFunc: func(context.Context, *models.Version, *models.Version, string) (string, error) {
+				return "", nil
+			},
+		}
+
+		filesClient := &filesAPISDKMocks.ClienterMock{
+			GetFileFunc: func(ctx context.Context, filePath string, headers filesAPISDK.Headers) (*filesAPIModels.StoredRegisteredMetaData, error) {
+				return nil, errs.ErrFileMetadataNotFound
+			},
+		}
+
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/test-dataset/editions/test-edition/versions/1/state", bytes.NewBufferString(`{"state":"approved"}`))
+		w := httptest.NewRecorder()
+
+		api := buildAPIWithApproval(mockedDataStore, filesClient, authorisationMock, auditServiceMock)
+		api.Router.ServeHTTP(w, r)
+
+		Convey("Then a 422 response is returned", func() {
+			So(w.Code, ShouldEqual, http.StatusUnprocessableEntity)
+		})
+
+		Convey("And the error message states distribution files could not be found", func() {
+			So(w.Body.String(), ShouldContainSubstring, errs.ErrFileMetadataNotFound.Error())
+		})
+
+		Convey("And GetFile was called for the distribution", func() {
+			So(filesClient.GetFileCalls(), ShouldHaveLength, 1)
+		})
+	})
+
+	Convey("When publishing a version, GetFile is not called", t, func() {
+		mockedDataStore := &storetest.StorerMock{
+			GetVersionStaticFunc: func(ctx context.Context, datasetID, editionID string, version int, state string) (*models.Version, error) {
+				v := baseVersion()
+				v.State = models.ApprovedState
+				return v, nil
+			},
+			AcquireVersionsLockFunc: func(context.Context, string) (string, error) {
+				return testLockID, nil
+			},
+			UnlockVersionsFunc: func(context.Context, string) {},
+			CheckEditionExistsStaticFunc: func(context.Context, string, string, string) error {
+				return nil
+			},
+			UpdateVersionStaticFunc: func(context.Context, *models.Version, *models.Version, string) (string, error) {
+				return "", nil
+			},
+			GetDatasetTypeFunc: func(context.Context, string, bool) (string, error) {
+				return models.Static.String(), nil
+			},
+			UpsertVersionStaticFunc: func(context.Context, *models.Version) error {
+				return nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{
+					ID: "test-dataset",
+					Next: &models.Dataset{
+						State: models.ApprovedState,
+						Type:  models.Static.String(),
+						Links: &models.DatasetLinks{},
+					},
+				}, nil
+			},
+			UpsertDatasetFunc: func(context.Context, string, *models.DatasetUpdate) error {
+				return nil
+			},
+		}
+
+		getFileCalled := false
+		filesClient := &filesAPISDKMocks.ClienterMock{
+			GetFileFunc: func(ctx context.Context, filePath string, headers filesAPISDK.Headers) (*filesAPIModels.StoredRegisteredMetaData, error) {
+				getFileCalled = true
+				return &filesAPIModels.StoredRegisteredMetaData{}, nil
+			},
+			MarkFilePublishedFunc: func(ctx context.Context, filePath string, headers filesAPISDK.Headers) error {
+				return nil
+			},
+		}
+
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/test-dataset/editions/test-edition/versions/1/state", bytes.NewBufferString(`{"state":"published"}`))
+		w := httptest.NewRecorder()
+
+		scuProducerMock := getSearchContentUpdatedMock()
+		searchContentUpdated := SearchContentUpdatedProducer{Producer: scuProducerMock}
+
+		api := buildAPIWithApproval(mockedDataStore, filesClient, authorisationMock, auditServiceMock)
+		api.SetFilesAPIClient(filesClient, "")
+		api.searchContentUpdatedProducer = &searchContentUpdated
+
+		api.Router.ServeHTTP(w, r)
+
+		Convey("Then GetFile is never called during publish", func() {
+			So(getFileCalled, ShouldBeFalse)
+		})
+
+		Convey("And MarkFilePublished is called instead", func() {
+			So(filesClient.MarkFilePublishedCalls(), ShouldHaveLength, 1)
 		})
 	})
 }

--- a/application/application.go
+++ b/application/application.go
@@ -35,6 +35,10 @@ var (
 	trueStringified = strconv.FormatBool(true)
 )
 
+type contextKey string
+
+const AccessTokenKey contextKey = "access_token"
+
 // VersionDetails contains the details that uniquely identify a version resource
 type VersionDetails struct {
 	datasetID string
@@ -50,6 +54,7 @@ type StateMachineDatasetAPI struct {
 	DataStore          store.DataStore
 	DownloadGenerators map[models.DatasetType]DownloadsGenerator
 	StateMachine       *StateMachine
+	FilesAPIClient     filesAPISDK.Clienter
 }
 
 func Setup(dataStoreVal store.DataStore, downloadGenerators map[models.DatasetType]DownloadsGenerator, stateMachine *StateMachine) *StateMachineDatasetAPI {
@@ -60,6 +65,10 @@ func Setup(dataStoreVal store.DataStore, downloadGenerators map[models.DatasetTy
 	}
 
 	return newDS
+}
+
+func (smDS *StateMachineDatasetAPI) SetFilesAPIClient(client filesAPISDK.Clienter) {
+	smDS.FilesAPIClient = client
 }
 
 func (v VersionDetails) baseLogData() log.Data {
@@ -491,6 +500,14 @@ func ApproveVersion(ctx context.Context, smDS *StateMachineDatasetAPI,
 		return errModel
 	}
 
+	if smDS.FilesAPIClient != nil && versionUpdate.Distributions != nil && len(*versionUpdate.Distributions) > 0 {
+		accessToken, _ := ctx.Value(AccessTokenKey).(string)
+		if err := checkDistributionFilesExist(ctx, smDS.FilesAPIClient, versionUpdate, accessToken); err != nil {
+			log.Error(ctx, "State machine - Approving: checkDistributionFilesExist: distribution file(s) not found", err, data)
+			return err
+		}
+	}
+
 	_, err := UpdateVersionInfo(ctx, smDS, currentVersion, versionUpdate, versionDetails)
 	if err != nil {
 		log.Error(ctx, "State machine - Approving: UpdateVersionInfo : failed to update the version", err, data)
@@ -828,4 +845,28 @@ func (smDS *StateMachineDatasetAPI) DeleteStaticVersion(ctx context.Context, dat
 
 	log.Info(ctx, "DeleteStaticVersion: successfully deleted static version", logData)
 	return versionDoc, nil
+}
+
+func checkDistributionFilesExist(ctx context.Context, filesAPIClient filesAPISDK.Clienter, version *models.Version, accessToken string) error {
+	if version.Distributions == nil || len(*version.Distributions) == 0 {
+		return nil
+	}
+
+	for _, distribution := range *version.Distributions {
+		if distribution.DownloadURL == "" {
+			continue
+		}
+
+		_, err := filesAPIClient.GetFile(ctx, distribution.DownloadURL, filesAPISDK.Headers{
+			Authorization: accessToken,
+		})
+		if err != nil {
+			log.Error(ctx, "checkDistributionFilesExist: file not found in files API", err, log.Data{
+				"filepath": distribution.DownloadURL,
+			})
+			return errs.ErrFileMetadataNotFound
+		}
+	}
+
+	return nil
 }

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/store"
 	storetest "github.com/ONSdigital/dp-dataset-api/store/datastoretest"
+	filesAPIModels "github.com/ONSdigital/dp-files-api/files"
 	filesAPISDK "github.com/ONSdigital/dp-files-api/sdk"
 	filesAPISDKMocks "github.com/ONSdigital/dp-files-api/sdk/mocks"
 	. "github.com/smartystreets/goconvey/convey"
@@ -3394,5 +3395,119 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 		So(len(mockFilesAPIClient.DeleteFileCalls()), ShouldEqual, 1)
 		So(len(mocked.DeleteStaticDatasetVersionCalls()), ShouldEqual, 1)
 		So(len(mocked.UpsertDatasetCalls()), ShouldEqual, 1)
+	})
+}
+
+func TestApproveVersionDistributionFilesCheck(t *testing.T) {
+	t.Parallel()
+
+	distributions := []models.Distribution{
+		{
+			Title:       "Full Dataset (CSV)",
+			Format:      "csv",
+			DownloadURL: "datasets/test-dataset/editions/test-edition/myfile.csv",
+		},
+	}
+
+	currentVersion := &models.Version{
+		State:        models.AssociatedState,
+		CollectionID: "3434",
+		Type:         models.Static.String(),
+	}
+
+	versionUpdate := &models.Version{
+		State:         models.ApprovedState,
+		ReleaseDate:   "2024-12-31",
+		ID:            "789",
+		CollectionID:  "3434",
+		Type:          models.Static.String(),
+		Distributions: &distributions,
+	}
+
+	generatorMock := &mocks.DownloadsGeneratorMock{
+		GenerateFunc: func(context.Context, string, string, string, string) error {
+			return nil
+		},
+	}
+
+	mockedDataStore := &storetest.StorerMock{
+		UpdateVersionStaticFunc: func(context.Context, *models.Version, *models.Version, string) (string, error) {
+			return "", nil
+		},
+	}
+
+	states, transitions := setUpStatesTransitions()
+	stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
+
+	Convey("When FilesAPIClient is nil, the file check is skipped and approve succeeds", t, func() {
+		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
+		smDS.FilesAPIClient = nil
+
+		err := ApproveVersion(testContext, smDS, currentVersion, versionUpdate, versionDetails, "")
+
+		So(err, ShouldBeNil)
+		So(len(mockedDataStore.UpdateVersionStaticCalls()), ShouldEqual, 1)
+	})
+
+	Convey("When FilesAPIClient is set and all files exist, approve succeeds", t, func() {
+		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
+
+		filesClient := &filesAPISDKMocks.ClienterMock{
+			GetFileFunc: func(ctx context.Context, filePath string, headers filesAPISDK.Headers) (*filesAPIModels.StoredRegisteredMetaData, error) {
+				return &filesAPIModels.StoredRegisteredMetaData{}, nil
+			},
+		}
+		smDS.SetFilesAPIClient(filesClient)
+
+		ctxWithToken := context.WithValue(testContext, AccessTokenKey, "test-token")
+		err := ApproveVersion(ctxWithToken, smDS, currentVersion, versionUpdate, versionDetails, "")
+
+		So(err, ShouldBeNil)
+		So(filesClient.GetFileCalls(), ShouldHaveLength, 1)
+		So(filesClient.GetFileCalls()[0].FilePath, ShouldEqual, "datasets/test-dataset/editions/test-edition/myfile.csv")
+	})
+
+	Convey("When FilesAPIClient is set and a file does not exist, approve returns ErrFileMetadataNotFound", t, func() {
+		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
+
+		filesClient := &filesAPISDKMocks.ClienterMock{
+			GetFileFunc: func(ctx context.Context, filePath string, headers filesAPISDK.Headers) (*filesAPIModels.StoredRegisteredMetaData, error) {
+				return nil, errs.ErrFileMetadataNotFound
+			},
+		}
+		smDS.SetFilesAPIClient(filesClient)
+
+		ctxWithToken := context.WithValue(testContext, AccessTokenKey, "test-token")
+		err := ApproveVersion(ctxWithToken, smDS, currentVersion, versionUpdate, versionDetails, "")
+
+		So(err, ShouldEqual, errs.ErrFileMetadataNotFound)
+		So(filesClient.GetFileCalls(), ShouldHaveLength, 1)
+	})
+
+	Convey("When the version has no distributions, the file check is skipped and approve succeeds", t, func() {
+		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine)
+
+		getFileCalled := false
+		filesClient := &filesAPISDKMocks.ClienterMock{
+			GetFileFunc: func(ctx context.Context, filePath string, headers filesAPISDK.Headers) (*filesAPIModels.StoredRegisteredMetaData, error) {
+				getFileCalled = true
+				return &filesAPIModels.StoredRegisteredMetaData{}, nil
+			},
+		}
+		smDS.SetFilesAPIClient(filesClient)
+
+		versionUpdateNoDistributions := &models.Version{
+			State:        models.ApprovedState,
+			ReleaseDate:  "2024-12-31",
+			ID:           "789",
+			CollectionID: "3434",
+			Type:         models.Static.String(),
+		}
+
+		ctxWithToken := context.WithValue(testContext, AccessTokenKey, "test-token")
+		err := ApproveVersion(ctxWithToken, smDS, currentVersion, versionUpdateNoDistributions, versionDetails, "")
+
+		So(err, ShouldBeNil)
+		So(getFileCalled, ShouldBeFalse)
 	})
 }

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -414,6 +414,67 @@ Feature: Static Dataset Versions PUT API
             """
         Then the HTTP status code should be "400"
 
+    Scenario: PUT state returns 422 when approving and distribution file does not exist in files API
+        Given private endpoints are enabled
+        And I am an admin user
+        And I have a static dataset with version:
+                """
+                {
+                    "dataset": {
+                        "id": "static-dataset-missing-file",
+                        "title": "Static Dataset Missing File Test",
+                        "state": "associated",
+                        "type": "static"
+                    },
+                    "version": {
+                        "id": "static-version-missing-file",
+                        "edition": "2025",
+                        "edition_title": "2025 Edition",
+                        "links": {
+                            "dataset": {
+                                "id": "static-dataset-missing-file"
+                            },
+                            "edition": {
+                                "href": "/datasets/static-dataset-missing-file/editions/2025",
+                                "id": "2025"
+                            },
+                            "self": {
+                                "href": "/datasets/static-dataset-missing-file/editions/2025/versions/1"
+                            }
+                        },
+                        "version": 1,
+                        "release_date": "2025-01-01T09:00:00.000Z",
+                        "state": "associated",
+                        "type": "static",
+                        "distributions": [
+                            {
+                                "title": "Missing File (CSV)",
+                                "format": "csv",
+                                "download_url": "datasets/test-static-dataset/editions/test-edition/missing-file.csv"
+                            }
+                        ]
+                    }
+                }
+                """
+        When I PUT "/datasets/static-dataset-missing-file/editions/2025/versions/1/state"
+                """
+                {"state": "approved"}
+                """
+        Then the HTTP status code should be "422"
+        And I should receive the following response:
+                """
+                file metadata not found
+                """
+
+    Scenario: PUT state returns 200 when approving and all distribution files exist in files API
+        Given private endpoints are enabled
+        And I am an admin user
+        When I PUT "/datasets/static-dataset-update/editions/2025/versions/1/state"
+                """
+                {"state": "approved"}
+                """
+        Then the HTTP status code should be "200"
+
     Scenario: PUT state fails with invalid state
         Given private endpoints are enabled
         And I am an admin user

--- a/features/steps/dataset_component.go
+++ b/features/steps/dataset_component.go
@@ -24,6 +24,7 @@ import (
 	serviceMock "github.com/ONSdigital/dp-dataset-api/service/mock"
 	"github.com/ONSdigital/dp-dataset-api/store"
 	storeMock "github.com/ONSdigital/dp-dataset-api/store/datastoretest"
+	filesAPIModels "github.com/ONSdigital/dp-files-api/files"
 	filesAPISDK "github.com/ONSdigital/dp-files-api/sdk"
 	filesAPISDKMocks "github.com/ONSdigital/dp-files-api/sdk/mocks"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
@@ -290,6 +291,15 @@ func (c *DatasetComponent) DoGetFilesAPIClientOk(ctx context.Context, cfg *confi
 			if filePath == "/fail/to/delete.csv" {
 				return fmt.Errorf("failed to delete file at path: %s", filePath)
 			}
+			return nil
+		},
+		GetFileFunc: func(ctx context.Context, filePath string, headers filesAPISDK.Headers) (*filesAPIModels.StoredRegisteredMetaData, error) {
+			if filePath == "datasets/test-static-dataset/editions/test-edition/missing-file.csv" {
+				return nil, fmt.Errorf("FileNotRegistered: file not found")
+			}
+			return &filesAPIModels.StoredRegisteredMetaData{}, nil
+		},
+		MarkFilePublishedFunc: func(ctx context.Context, filePath string, headers filesAPISDK.Headers) error {
 			return nil
 		},
 	}, nil

--- a/service/service.go
+++ b/service/service.go
@@ -375,7 +375,8 @@ func (svc *Service) Run(ctx context.Context, buildTime, gitCommit, version strin
 	// Set the files API client on the DatasetAPI after initialisation
 	if svc.config.EnablePrivateEndpoints && svc.filesAPIClient != nil {
 		svc.api.SetFilesAPIClient(svc.filesAPIClient, svc.config.ServiceAuthToken)
-		log.Info(ctx, "files API client set on dataset API")
+		svc.smDS.SetFilesAPIClient(svc.filesAPIClient)
+		log.Info(ctx, "files API client set on dataset API and state machine")
 	}
 
 	// Set the topic API client on the DatasetAPI after initialisation


### PR DESCRIPTION
### What

Move distribution file exists validation from publication to approval step in dataset-api
Jira - https://officefornationalstatistics.atlassian.net/browse/DIS-4796

### How to review

To test locally -

1. register a file in files-api and mark it as uploaded - 

make a POST request to `localhost:26900/files` with a path such as `datasets/test-dataset/editions/test-edition/myfile.csv` and `"is_publishable": true`
then PATCH the file to an `UPLOADED` state

2. create a dataset and an associated version in dataset-api pointing to that file path in its `distributions.download_url`

3. make a PUT request to the `/state` endpoint if your newly created dataset, for example `localhost:22000/datasets/test-dataset/editions/test-edition/versions/1/state` with an `approved` state

- confirm that approve succeeds when file exists

4. create a second version whose download_url points to a path not registered in dp-files-api

- attempt to approve it and confirm you get a 422 with a message stating the distribution file could not be found

5. with version 1 in approved state, PUT its state to `published` and confirm a 200 is returned

- check the dataset-api logs and `checkDistributionFilesExist` should appear during the approve flow but not during the publish flow

### Who can review

Anyone
