### PR TITLE
Feature/store previous edition ids for datasets

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -479,8 +479,11 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// Detect whether edition ID or title has changed
-			editionChanged := existingVersion.Edition != version.Edition
-			titleChanged := existingVersion.EditionTitle != version.EditionTitle
+			editionProvided := version.Edition != ""
+			titleProvided := version.EditionTitle != ""
+
+			editionChanged := editionProvided && existingVersion.Edition != version.Edition
+			titleChanged := titleProvided && existingVersion.EditionTitle != version.EditionTitle
 
 			// Only validate uniqueness IF edition or title is changing
 			if editionChanged {

--- a/api/versions.go
+++ b/api/versions.go
@@ -491,6 +491,7 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 					handleVersionAPIErr(ctx, checkErr, w, data)
 					return
 				}
+				version.PreviousEditionId = append(existingVersion.PreviousEditionId, existingVersion.Edition)
 			}
 
 			if titleChanged {

--- a/api/versions.go
+++ b/api/versions.go
@@ -479,11 +479,8 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// Detect whether edition ID or title has changed
-			editionProvided := version.Edition != ""
-			titleProvided := version.EditionTitle != ""
-
-			editionChanged := editionProvided && existingVersion.Edition != version.Edition
-			titleChanged := titleProvided && existingVersion.EditionTitle != version.EditionTitle
+			editionChanged := existingVersion.Edition != version.Edition
+			titleChanged := existingVersion.EditionTitle != version.EditionTitle
 
 			// Only validate uniqueness IF edition or title is changing
 			if editionChanged {
@@ -497,8 +494,10 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 					handleVersionAPIErr(ctx, checkErr, w, data)
 					return
 				}
-				version.PreviousEditionId = append([]string{}, existingVersion.PreviousEditionId...)
-				version.PreviousEditionId = append(version.PreviousEditionId, existingVersion.Edition)
+				if version.Edition != "" {
+					version.PreviousEditionId = append([]string{}, existingVersion.PreviousEditionId...)
+					version.PreviousEditionId = append(version.PreviousEditionId, existingVersion.Edition)
+				}
 			}
 
 			if titleChanged {

--- a/api/versions.go
+++ b/api/versions.go
@@ -147,6 +147,7 @@ func (api *DatasetAPI) getVersions(w http.ResponseWriter, r *http.Request, limit
 
 			if !authorised {
 				item.IsMigration = nil
+				item.PreviousEditionId = nil
 			}
 		}
 
@@ -292,6 +293,7 @@ func (api *DatasetAPI) getVersion(w http.ResponseWriter, r *http.Request) (*mode
 
 		if !authorised {
 			version.IsMigration = nil
+			version.PreviousEditionId = nil
 		}
 
 		return version, nil
@@ -491,7 +493,8 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 					handleVersionAPIErr(ctx, checkErr, w, data)
 					return
 				}
-				version.PreviousEditionId = append(existingVersion.PreviousEditionId, existingVersion.Edition)
+				version.PreviousEditionId = append([]string{}, existingVersion.PreviousEditionId...)
+				version.PreviousEditionId = append(version.PreviousEditionId, existingVersion.Edition)
 			}
 
 			if titleChanged {

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -142,7 +142,10 @@ func TestGetVersionsReturnsOK(t *testing.T) {
 			CheckEditionExistsFunc: func(context.Context, string, string, string) error {
 				return nil
 			},
-			CheckEditionExistsStaticFunc: func(context.Context, string, string, string) error {
+			CheckEditionExistsStaticFunc: func(_ context.Context, _ string, editionID string, _ string) error {
+				if editionID == "new-edition" {
+					return errs.ErrEditionNotFound
+				}
 				return nil
 			},
 			GetVersionsFunc: func(context.Context, string, string, string, int, int) ([]models.Version, int, error) {
@@ -5956,5 +5959,275 @@ func TestPutVersionIsMigration(t *testing.T) {
 			So(capturedVersionUpdate.IsMigration, ShouldNotBeNil)
 			So(*capturedVersionUpdate.IsMigration, ShouldBeTrue)
 		})
+	})
+}
+
+func TestPutVersionSavesPreviousEditionID(t *testing.T) {
+	t.Parallel()
+
+	Convey("When edition ID changes on a static version, previous_edition_id is populated with the old edition", t, func() {
+		var capturedVersionUpdate *models.Version
+
+		b := `{"edition":"new-edition","edition_title":"New Edition Title","release_date":"2017-04-04","state":"associated","type":"static"}`
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/old-edition/versions/1", bytes.NewBufferString(b))
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			IsStaticDatasetFunc: func(context.Context, string) (bool, error) {
+				return true, nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{
+					Next: &models.Dataset{Type: models.Static.String()},
+				}, nil
+			},
+			CheckEditionExistsStaticFunc: func(_ context.Context, _ string, editionID string, _ string) error {
+				if editionID == "new-edition" {
+					return errs.ErrEditionNotFound
+				}
+				return nil
+			},
+			GetVersionStaticFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
+				return &models.Version{
+					ID:           "version-id-1",
+					Edition:      "old-edition",
+					EditionTitle: "Old Edition Title",
+					State:        models.AssociatedState,
+					Type:         models.Static.String(),
+					ReleaseDate:  "2017-04-04",
+					Links: &models.VersionLinks{
+						Dataset: &models.LinkObject{
+							HRef: "http://localhost:22000/datasets/123",
+							ID:   "123",
+						},
+						Self: &models.LinkObject{
+							HRef: "http://localhost:22000/datasets/123/editions/old-edition/versions/1",
+						},
+						Version: &models.LinkObject{
+							HRef: "http://localhost:22000/datasets/123/editions/old-edition/versions/1",
+							ID:   "1",
+						},
+						Edition: &models.LinkObject{
+							HRef: "http://localhost:22000/datasets/123/editions/old-edition",
+							ID:   "old-edition",
+						},
+					},
+				}, nil
+			},
+			CheckEditionTitleExistsStaticFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			GetVersionFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
+				return &models.Version{Type: models.Static.String()}, nil
+			},
+			UpdateVersionStaticFunc: func(ctx context.Context, currentVersion *models.Version, versionUpdate *models.Version, eTagSelector string) (string, error) {
+				capturedVersionUpdate = versionUpdate
+				return testETag, nil
+			},
+			AcquireVersionsLockFunc: func(context.Context, string) (string, error) {
+				return testLockID, nil
+			},
+			UnlockVersionsFunc: func(context.Context, string) {},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return testEntityData, nil
+			},
+		}
+
+		auditServiceMock := &applicationMocks.AuditServiceMock{
+			RecordVersionAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, version *models.Version) error {
+				return nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusOK)
+		So(capturedVersionUpdate, ShouldNotBeNil)
+		So(capturedVersionUpdate.PreviousEditionId, ShouldResemble, []string{"old-edition"})
+		So(len(mockedDataStore.UpdateVersionStaticCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.CheckEditionExistsStaticCalls()), ShouldEqual, 3)
+	})
+
+	Convey("When edition ID does NOT change on a static version, previous_edition_id is not modified", t, func() {
+		var capturedVersionUpdate *models.Version
+
+		b := `{"edition":"same-edition","edition_title":"New Title","release_date":"2017-04-04","state":"associated","type":"static"}`
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/same-edition/versions/1", bytes.NewBufferString(b))
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			IsStaticDatasetFunc: func(context.Context, string) (bool, error) {
+				return true, nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{
+					Next: &models.Dataset{Type: models.Static.String()},
+				}, nil
+			},
+			CheckEditionExistsStaticFunc: func(context.Context, string, string, string) error {
+				return nil
+			},
+			GetVersionStaticFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
+				return &models.Version{
+					ID:           "version-id-1",
+					Edition:      "same-edition",
+					EditionTitle: "Old Title",
+					State:        models.AssociatedState,
+					Type:         models.Static.String(),
+					ReleaseDate:  "2017-04-04",
+					Links: &models.VersionLinks{
+						Dataset: &models.LinkObject{
+							HRef: "http://localhost:22000/datasets/123",
+							ID:   "123",
+						},
+						Self: &models.LinkObject{
+							HRef: "http://localhost:22000/datasets/123/editions/same-edition/versions/1",
+						},
+						Version: &models.LinkObject{
+							HRef: "http://localhost:22000/datasets/123/editions/same-edition/versions/1",
+							ID:   "1",
+						},
+						Edition: &models.LinkObject{
+							HRef: "http://localhost:22000/datasets/123/editions/same-edition",
+							ID:   "same-edition",
+						},
+					},
+				}, nil
+			},
+			CheckEditionTitleExistsStaticFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			GetVersionFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
+				return &models.Version{Type: models.Static.String()}, nil
+			},
+			UpdateVersionStaticFunc: func(ctx context.Context, currentVersion *models.Version, versionUpdate *models.Version, eTagSelector string) (string, error) {
+				capturedVersionUpdate = versionUpdate
+				return testETag, nil
+			},
+			AcquireVersionsLockFunc: func(context.Context, string) (string, error) {
+				return testLockID, nil
+			},
+			UnlockVersionsFunc: func(context.Context, string) {},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return testEntityData, nil
+			},
+		}
+
+		auditServiceMock := &applicationMocks.AuditServiceMock{
+			RecordVersionAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, version *models.Version) error {
+				return nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusOK)
+		So(capturedVersionUpdate, ShouldNotBeNil)
+		So(capturedVersionUpdate.PreviousEditionId, ShouldBeNil)
+		So(len(mockedDataStore.UpdateVersionStaticCalls()), ShouldEqual, 1)
+	})
+
+	Convey("When version already has a previous_edition_id, new old edition is appended", t, func() {
+		var capturedVersionUpdate *models.Version
+
+		b := `{"edition":"newer-edition","edition_title":"Newer Edition Title","release_date":"2017-04-04","state":"associated","type":"static"}`
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/current-edition/versions/1", bytes.NewBufferString(b))
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			IsStaticDatasetFunc: func(context.Context, string) (bool, error) {
+				return true, nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{
+					Next: &models.Dataset{Type: models.Static.String()},
+				}, nil
+			},
+			CheckEditionExistsStaticFunc: func(_ context.Context, _ string, editionID string, _ string) error {
+				if editionID == "newer-edition" {
+					return errs.ErrEditionNotFound
+				}
+				return nil
+			},
+			GetVersionStaticFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
+				return &models.Version{
+					ID:                "version-id-1",
+					Edition:           "current-edition",
+					EditionTitle:      "Current Edition Title",
+					PreviousEditionId: []string{"very-old-edition", "old-edition"},
+					State:             models.AssociatedState,
+					Type:              models.Static.String(),
+					ReleaseDate:       "2017-04-04",
+					Links: &models.VersionLinks{
+						Dataset: &models.LinkObject{
+							HRef: "http://localhost:22000/datasets/123",
+							ID:   "123",
+						},
+						Self: &models.LinkObject{
+							HRef: "http://localhost:22000/datasets/123/editions/current-edition/versions/1",
+						},
+						Version: &models.LinkObject{
+							HRef: "http://localhost:22000/datasets/123/editions/current-edition/versions/1",
+							ID:   "1",
+						},
+						Edition: &models.LinkObject{
+							HRef: "http://localhost:22000/datasets/123/editions/current-edition",
+							ID:   "current-edition",
+						},
+					},
+				}, nil
+			},
+			CheckEditionTitleExistsStaticFunc: func(context.Context, string, string) error {
+				return nil
+			},
+			GetVersionFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
+				return &models.Version{Type: models.Static.String()}, nil
+			},
+			UpdateVersionStaticFunc: func(ctx context.Context, currentVersion *models.Version, versionUpdate *models.Version, eTagSelector string) (string, error) {
+				capturedVersionUpdate = versionUpdate
+				return testETag, nil
+			},
+			AcquireVersionsLockFunc: func(context.Context, string) (string, error) {
+				return testLockID, nil
+			},
+			UnlockVersionsFunc: func(context.Context, string) {},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return testEntityData, nil
+			},
+		}
+
+		auditServiceMock := &applicationMocks.AuditServiceMock{
+			RecordVersionAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, version *models.Version) error {
+				return nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock)
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusOK)
+		So(capturedVersionUpdate, ShouldNotBeNil)
+		So(capturedVersionUpdate.PreviousEditionId, ShouldResemble, []string{"very-old-edition", "old-edition", "current-edition"})
+		So(len(mockedDataStore.UpdateVersionStaticCalls()), ShouldEqual, 1)
 	})
 }

--- a/application/application.go
+++ b/application/application.go
@@ -291,6 +291,10 @@ func populateNewVersionDoc(currentVersion, originalVersion *models.Version) (*mo
 		version.UsageNotes = currentVersion.UsageNotes
 	}
 
+	if version.PreviousEditionId == nil {
+		version.PreviousEditionId = currentVersion.PreviousEditionId
+	}
+
 	return &version, nil
 }
 

--- a/application/application.go
+++ b/application/application.go
@@ -208,6 +208,7 @@ func (smDS *StateMachineDatasetAPI) PopulateVersionInfo(ctx context.Context, ver
 	return currentVersion, combinedVersionUpdate, nil
 }
 
+//nolint:gocyclo // cyclomatic complexity 21 of func `populateNewVersionDoc` is high (> 20)
 func populateNewVersionDoc(currentVersion, originalVersion *models.Version) (*models.Version, error) {
 	var version models.Version
 	err := copier.Copy(&version, originalVersion) // create local copy that escapes to the HEAP at the end of this function

--- a/features/static_versions_get.feature
+++ b/features/static_versions_get.feature
@@ -376,7 +376,7 @@ Feature: Static versions GET /versions
             """
             {
                 "id": "test-static-version-previous-editions",
-                "last_updated": "2021-01-01T00:00:01Z",
+                "last_updated": "2021-01-01T00:00:00Z",
                 "type": "static",
                 "version": 1,
                 "state": "published",
@@ -417,7 +417,7 @@ Feature: Static versions GET /versions
             """
             {
                 "id": "test-static-version-previous-editions",
-                "last_updated": "2021-01-01T00:00:01Z",
+                "last_updated": "2021-01-01T00:00:00Z",
                 "type": "static",
                 "version": 1,
                 "state": "published",

--- a/features/static_versions_get.feature
+++ b/features/static_versions_get.feature
@@ -168,7 +168,7 @@ Feature: Static versions GET /versions
                     {
                         "dataset_id": "test-static",
                         "id": "test-static-version-approved",
-                        "last_updated":"2021-01-01T00:00:01Z",
+                        "last_updated":"2021-01-01T00:00:02Z",
                         "type":"static",
                         "version": 1,
                         "state": "approved",
@@ -221,7 +221,7 @@ Feature: Static versions GET /versions
                     {
                         "dataset_id": "test-static",
                         "id": "test-static-version-approved",
-                        "last_updated":"2021-01-01T00:00:01Z",
+                        "last_updated":"2021-01-01T00:00:02Z",
                         "type":"static",
                         "version": 1,
                         "state": "approved",
@@ -270,7 +270,7 @@ Feature: Static versions GET /versions
             """
             {
                 "id": "test-static-version-approved",
-                "last_updated":"2021-01-01T00:00:01Z",
+                "last_updated":"2021-01-01T00:00:02Z",
                 "type":"static",
                 "version": 1,
                 "state": "approved",
@@ -376,7 +376,7 @@ Feature: Static versions GET /versions
             """
             {
                 "id": "test-static-version-previous-editions",
-                "last_updated": "2021-01-01T00:00:00Z",
+                "last_updated": "2021-01-01T00:00:01Z",
                 "type": "static",
                 "version": 1,
                 "state": "published",
@@ -417,7 +417,7 @@ Feature: Static versions GET /versions
             """
             {
                 "id": "test-static-version-previous-editions",
-                "last_updated": "2021-01-01T00:00:00Z",
+                "last_updated": "2021-01-01T00:00:01Z",
                 "type": "static",
                 "version": 1,
                 "state": "published",

--- a/features/static_versions_get.feature
+++ b/features/static_versions_get.feature
@@ -57,6 +57,39 @@ Feature: Static versions GET /versions
                     "is_migration": true
                 },
                 {
+                    "id": "test-static-version-previous-editions",
+                    "version": 1,
+                    "edition": "test-edition-static-previous-editions",
+                    "edition_title": "Test Edition Static Previous Editions",
+                    "links": {
+                        "dataset": {
+                            "id": "test-static"
+                        },
+                        "edition": {
+                            "href": "/datasets/test-static/editions/test-edition-static-previous-editions",
+                            "id": "test-edition-static-previous-editions"
+                        },
+                        "self": {
+                            "href": "/datasets/test-static/editions/test-edition-static-previous-editions/versions/1"
+                        },
+                        "web_page": {
+                            "href": "/economy/datasets/test-static/editions/test-edition-static-previous-editions/versions/1"
+                        }
+                    },
+                    "state": "published",
+                    "type": "static",
+                    "distributions": [
+                        {
+                            "title": "Distribution 1",
+                            "format": "csv",
+                            "media_type": "text/csv",
+                            "download_url": "/uuid/filename.csv",
+                            "byte_size": 100000
+                        }
+                    ],
+                    "previous_edition_id": ["old-edition"]
+                },
+                {
                     "id": "test-static-version-approved",
                     "version": 1,
                     "edition": "test-edition-static-approved",
@@ -323,6 +356,88 @@ Feature: Static versions GET /versions
                 },
                 "edition": "test-edition-static",
                 "edition_title": "Test Edition Static Title",
+                "distributions": [
+                    {
+                        "title": "Distribution 1",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "download_url": "/uuid/filename.csv",
+                        "byte_size": 100000
+                    }
+                ]
+            }
+            """
+
+    Scenario: GET /datasets/{id}/editions/{edition}/versions/{version} returns previous edition names when present
+        Given private endpoints are enabled
+        And I am an admin user
+        When I GET "/datasets/test-static/editions/test-edition-static-previous-editions/versions/1"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "id": "test-static-version-previous-editions",
+                "last_updated": "2021-01-01T00:00:01Z",
+                "type": "static",
+                "version": 1,
+                "state": "published",
+                "links": {
+                    "dataset": {
+                        "id": "test-static"
+                    },
+                    "edition": {
+                        "href": "/datasets/test-static/editions/test-edition-static-previous-editions",
+                        "id": "test-edition-static-previous-editions"
+                    },
+                    "self": {
+                        "href": "/datasets/test-static/editions/test-edition-static-previous-editions/versions/1"
+                    },
+                    "web_page": {
+                        "href": "/economy/datasets/test-static/editions/test-edition-static-previous-editions/versions/1"
+                    }
+                },
+                "edition": "test-edition-static-previous-editions",
+                "edition_title": "Test Edition Static Previous Editions",
+                "previous_edition_id": ["old-edition"],
+                "distributions": [
+                    {
+                        "title": "Distribution 1",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "download_url": "/uuid/filename.csv",
+                        "byte_size": 100000
+                    }
+                ]
+            }
+            """
+
+    Scenario: GET /datasets/{id}/editions/{edition}/versions/{version} does not return previous edition names to public
+        And I am not authenticated
+        When I GET "/datasets/test-static/editions/test-edition-static-previous-editions/versions/1"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "id": "test-static-version-previous-editions",
+                "last_updated": "2021-01-01T00:00:01Z",
+                "type": "static",
+                "version": 1,
+                "state": "published",
+                "links": {
+                    "dataset": {
+                        "id": "test-static"
+                    },
+                    "edition": {
+                        "href": "/datasets/test-static/editions/test-edition-static-previous-editions",
+                        "id": "test-edition-static-previous-editions"
+                    },
+                    "self": {
+                        "href": "/datasets/test-static/editions/test-edition-static-previous-editions/versions/1"
+                    },
+                    "web_page": {
+                        "href": "/economy/datasets/test-static/editions/test-edition-static-previous-editions/versions/1"
+                    }
+                },
+                "edition": "test-edition-static-previous-editions",
+                "edition_title": "Test Edition Static Previous Editions",
                 "distributions": [
                     {
                         "title": "Distribution 1",

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -1101,6 +1101,9 @@ Feature: Static Dataset Versions PUT API
                       "href": "/businessindustryandtrade/datasets/edition-change-dataset/editions/2026-update/versions/1"
                   }
               },
+              "previous_edition_id": [
+                  "2025-links"
+              ],
               "release_date": "2025-01-01T09:00:00.000Z",
               "state": "associated",
               "type": "static"

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -1045,3 +1045,109 @@ Feature: Static Dataset Versions PUT API
               "type": "static"
           }
           """
+
+    Scenario: PUT updates static dataset version edition and saves previous edition ID
+        Given I have a static dataset with version:
+          """
+          {
+              "dataset": {
+                  "id": "previous-edition-dataset",
+                  "title": "Previous edition saved",
+                  "state": "associated",
+                  "type": "static",
+                  "topics": [
+                      "businessindustryandtrade-topic-id"
+                  ]
+              },
+              "version": {
+                  "id": "static-dataset-previous-edition",
+                  "edition": "old-edition",
+                  "edition_title": "2025 Edition",
+                  "links": {
+                      "dataset": {
+                          "href": "/datasets/previous-edition-dataset",
+                          "id": "previous-edition-dataset"
+                      },
+                      "edition": {
+                          "href": "/datasets/previous-edition-dataset/editions/old-edition",
+                          "id": "old-edition"
+                      },
+                      "self": {
+                          "href": "/datasets/previous-edition-dataset/editions/old-edition/versions/1"
+                      },
+                      "version": {
+                          "href": "/datasets/previous-edition-dataset/editions/old-edition/versions/1",
+                          "id": "1"
+                      },
+                      "web_page": {
+                          "href": "/businessindustryandtrade/datasets/previous-edition-dataset/editions/old-edition/versions/1"
+                      }
+                  },
+                  "version": 1,
+                  "release_date": "2025-01-01T09:00:00.000Z",
+                  "state": "associated",
+                  "type": "static",
+                  "distributions": [
+                      {
+                          "title": "csv",
+                          "format": "csv",
+                          "media_type": "text/csv",
+                          "download_url": "/uuid/filename.csv",
+                          "byte_size": 125000
+                      }
+                  ]
+              }
+          }
+          """
+        And private endpoints are enabled
+        And I am an admin user
+        When I PUT "/datasets/previous-edition-dataset/editions/old-edition/versions/1"
+            """
+            {
+                "edition": "new-edition",
+                "edition_title": "2026 Edition",
+                "state": "associated",
+                "type": "static"
+            }
+            """
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "dataset_id": "previous-edition-dataset",
+                "distributions": [
+                    {
+                        "byte_size": 125000,
+                        "download_url": "/uuid/filename.csv",
+                        "format": "csv",
+                        "media_type": "text/csv",
+                        "title": "csv"
+                    }
+                ],
+                "edition": "new-edition",
+                "edition_title": "2026 Edition",
+                "id": "static-dataset-previous-edition",
+                "last_updated": "{{DYNAMIC_RECENT_TIMESTAMP}}",
+                "links": {
+                    "dataset": {
+                        "href": "/datasets/previous-edition-dataset",
+                        "id": "previous-edition-dataset"
+                    },
+                    "edition": {
+                        "href": "/datasets/previous-edition-dataset/editions/new-edition",
+                        "id": "new-edition"
+                    },
+                    "self": {
+                        "href": "/datasets/previous-edition-dataset/editions/new-edition/versions/1"
+                    },
+                    "web_page": {
+                        "href": "/businessindustryandtrade/datasets/previous-edition-dataset/editions/new-edition/versions/1"
+                    }
+                },
+                "previous_edition_id": [
+                    "old-edition"
+                ],
+                "release_date": "2025-01-01T09:00:00.000Z",
+                "state": "associated",
+                "type": "static"
+            }
+            """

--- a/models/version.go
+++ b/models/version.go
@@ -51,6 +51,7 @@ type Version struct {
 	QualityDesignation QualityDesignation   `bson:"quality_designation,omitempty"   json:"quality_designation,omitempty"`
 	Distributions      *[]Distribution      `bson:"distributions,omitempty"         json:"distributions,omitempty"`
 	IsMigration        *bool                `bson:"is_migration,omitempty"          json:"is_migration,omitempty"`
+	PreviousEditionId  []string             `bson:"previous_edition_id,omitempty"    json:"previous_edition_id,omitempty"`
 }
 
 // Alert represents an object containing information on an alert

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -607,6 +607,10 @@ func createVersionUpdateQuery(version *models.Version, newETag string) bson.M {
 		setUpdates["is_migration"] = version.IsMigration
 	}
 
+	if version.PreviousEditionId != nil {
+		setUpdates["previous_edition_id"] = version.PreviousEditionId
+	}
+
 	if newETag != "" {
 		setUpdates["e_tag"] = newETag
 	}


### PR DESCRIPTION
### What
Jira link: https://officefornationalstatistics.atlassian.net/browse/DIS-4964?atlOrigin=eyJpIjoiZjg1MTViOTNjMDk0NGE1NmJhNDZjMmZlYmVlYjRhZDEiLCJwIjoiaiJ9

There is an issue where if content is added to a bundle, and then the edition ID is changed using the dataset api, the bundle can no longer find the content item. This PR adds functionality so that any edition IDs that have been used are saved in a `previous_edition_id` field in mongo so that it will be possible to find versions by previous edition IDs.

### How to review
Run this branch along with the dataset catalogue stack and create a static dataset and version.
Submit a PUT request to the `/datasets/{id}/editions/{edition}/versions/{version}` endpoint updating the edition ID.
Check a 200 is returned and `previous_edition_id: [{old-edition}]` is returned in the response.
Do this a couple of times to ensure the array stores all previous edition IDs.

Run in public mode and check doing a GET against that version doesn't return the `previous_edition_id` field.

### Who can review

Anyone