### PR TITLE
handle publishing and web responses for edition endpoints in SDK

### DIFF
--- a/sdk/edition.go
+++ b/sdk/edition.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -29,8 +30,30 @@ func (c *Client) GetEdition(ctx context.Context, headers Headers, datasetID, edi
 
 	defer closeResponseBody(ctx, resp)
 
-	// Unmarshal the response body to target
-	err = unmarshalResponseBodyExpectingStringError(resp, &edition)
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return edition, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return edition, fmt.Errorf("did not receive success response. received status %d, response body: %s", resp.StatusCode, string(b))
+	}
+
+	// Response could be either an Edition or an EditionUpdate.
+	var bodyMap map[string]interface{}
+	if err := json.Unmarshal(b, &bodyMap); err != nil {
+		return edition, err
+	}
+
+	// If the response is an EditionUpdate, return the "next" edition.
+	if next, ok := bodyMap["next"]; ok {
+		b, err = json.Marshal(next)
+		if err != nil {
+			return edition, err
+		}
+	}
+
+	err = json.Unmarshal(b, &edition)
 
 	return edition, err
 }
@@ -75,14 +98,13 @@ func (c *Client) GetEditions(ctx context.Context, headers Headers, datasetID str
 
 	defer closeResponseBody(ctx, resp)
 
-	if resp.StatusCode != http.StatusOK {
-		err = unmarshalResponseBodyExpectingStringError(resp, &editionList)
-		return editionList, err
-	}
-
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return editionList, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return editionList, fmt.Errorf("did not receive success response. received status %d, response body: %s", resp.StatusCode, string(b))
 	}
 
 	var body map[string]interface{}
@@ -91,7 +113,7 @@ func (c *Client) GetEditions(ctx context.Context, headers Headers, datasetID str
 	}
 
 	if body["items"] != nil {
-		if _, ok := body["items"].([]interface{})[0].(map[string]interface{})["next"]; ok && headers.AccessToken != "" {
+		if _, ok := body["items"].([]interface{})[0].(map[string]interface{})["next"]; ok {
 			var items []map[string]interface{}
 			for _, item := range body["items"].([]interface{}) {
 				items = append(items, item.(map[string]interface{})["next"].(map[string]interface{}))

--- a/sdk/edition_test.go
+++ b/sdk/edition_test.go
@@ -12,33 +12,64 @@ import (
 
 // Tests for the `GetEdition` client method
 func TestGetEdition(t *testing.T) {
-	mockGetResponse := models.Edition{
+	testCurrentEdition := models.Edition{
 		DatasetID: datasetID,
-		Edition:   editionID,
+		Edition:   "current-edition",
 	}
 
-	Convey("If requested edition is valid and get request returns 200", t, func() {
-		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, mockGetResponse, map[string]string{}})
+	testNextEdition := models.Edition{
+		DatasetID: datasetID,
+		Edition:   "next-edition",
+	}
+
+	testEditionUpdate := models.EditionUpdate{
+		Current: &testCurrentEdition,
+		Next:    &testNextEdition,
+	}
+
+	Convey("When the edition response is of type Edition", t, func() {
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, testCurrentEdition, map[string]string{}})
 		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
 		returnedEdition, err := datasetAPIClient.GetEdition(ctx, headers, datasetID, editionID)
-		Convey("Test that the request URI is constructed correctly and the correct method is used", func() {
+
+		Convey("Then request URI should be constructed correctly", func() {
 			expectedURI := fmt.Sprintf("/datasets/%s/editions/%s", datasetID, editionID)
 			So(httpClient.DoCalls()[0].Req.Method, ShouldEqual, http.MethodGet)
 			So(httpClient.DoCalls()[0].Req.URL.RequestURI(), ShouldResemble, expectedURI)
 		})
-		Convey("Test that the requested edition is returned without error", func() {
+
+		Convey("And the edition should be returned without error", func() {
 			So(err, ShouldBeNil)
-			So(returnedEdition, ShouldResemble, mockGetResponse)
+			So(returnedEdition, ShouldResemble, testCurrentEdition)
 		})
 	})
 
-	Convey("If requested edition is not valid and get request returns 404", t, func() {
+	Convey("When the edition response is of type EditionUpdate", t, func() {
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, testEditionUpdate, map[string]string{}})
+		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+		returnedEdition, err := datasetAPIClient.GetEdition(ctx, headers, datasetID, editionID)
+
+		Convey("Then request URI should be constructed correctly", func() {
+			expectedURI := fmt.Sprintf("/datasets/%s/editions/%s", datasetID, editionID)
+			So(httpClient.DoCalls()[0].Req.Method, ShouldEqual, http.MethodGet)
+			So(httpClient.DoCalls()[0].Req.URL.RequestURI(), ShouldResemble, expectedURI)
+		})
+
+		Convey("And the next edition should be returned without error", func() {
+			So(err, ShouldBeNil)
+			So(returnedEdition, ShouldResemble, testNextEdition)
+		})
+	})
+
+	Convey("When the edition is not found", t, func() {
 		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusNotFound, apierrors.ErrEditionNotFound.Error(), map[string]string{}})
 		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
 		_, err := datasetAPIClient.GetEdition(ctx, headers, datasetID, editionID)
-		Convey("Test that an error is raised and should contain status code", func() {
+
+		Convey("Then an error should be returned containing the status code and error message", func() {
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, apierrors.ErrEditionNotFound.Error())
+			So(err.Error(), ShouldContainSubstring, "status 404")
+			So(err.Error(), ShouldContainSubstring, apierrors.ErrEditionNotFound.Error())
 		})
 	})
 }
@@ -46,17 +77,16 @@ func TestGetEdition(t *testing.T) {
 // Tests for the `GetEditions` client method
 func TestGetEditions(t *testing.T) {
 	editions := []models.Edition{
-		{
-			DatasetID: datasetID,
-			Edition:   editionID,
-		},
-		{
-			DatasetID: datasetID,
-			Edition:   editionID,
-		},
+		{DatasetID: datasetID, Edition: editionID},
+		{DatasetID: datasetID, Edition: editionID},
 	}
-	mockGetResponse := MockGetListRequestResponse{
-		Items: editions,
+
+	currentEdition := models.Edition{DatasetID: datasetID, Edition: "current-edition"}
+	nextEdition := models.Edition{DatasetID: datasetID, Edition: "next-edition"}
+
+	editionUpdates := []models.EditionUpdate{
+		{Current: &currentEdition, Next: &nextEdition},
+		{Current: &currentEdition, Next: &nextEdition},
 	}
 
 	Convey("If input query params are nil", t, func() {
@@ -69,6 +99,7 @@ func TestGetEditions(t *testing.T) {
 			So(httpClient.DoCalls()[0].Req.URL.RequestURI(), ShouldResemble, expectedURI)
 		})
 	})
+
 	Convey("If input query params are empty", t, func() {
 		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, nil, map[string]string{}})
 		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
@@ -81,6 +112,7 @@ func TestGetEditions(t *testing.T) {
 			So(httpClient.DoCalls()[0].Req.URL.RequestURI(), ShouldResemble, expectedURI)
 		})
 	})
+
 	Convey("If input query params are not empty but invalid", t, func() {
 		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, nil, map[string]string{}})
 		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
@@ -97,6 +129,7 @@ func TestGetEditions(t *testing.T) {
 			So(err.Error(), ShouldEqual, "negative offsets or limits are not allowed")
 		})
 	})
+
 	Convey("If input query params are not empty and valid", t, func() {
 		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, nil, map[string]string{}})
 		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
@@ -116,27 +149,46 @@ func TestGetEditions(t *testing.T) {
 			So(httpClient.DoCalls()[0].Req.URL.RequestURI(), ShouldResemble, expectedURI)
 		})
 	})
-	Convey("If requested dataset and edition is valid", t, func() {
-		requestedEditionList := EditionsList{
-			Items: editions,
-		}
-		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, mockGetResponse, map[string]string{}})
+
+	Convey("When the items in the response are of type Edition", t, func() {
+		mockBody := map[string]interface{}{"items": editions}
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, mockBody, map[string]string{}})
 		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
 		queryParams := QueryParams{}
 		returnedEditionsList, err := datasetAPIClient.GetEditions(ctx, headers, datasetID, &queryParams)
-		Convey("Test that the requested edition is returned without error", func() {
+
+		Convey("Then the editions should be returned without error", func() {
 			So(err, ShouldBeNil)
-			So(returnedEditionsList, ShouldResemble, requestedEditionList)
+			So(returnedEditionsList.Items, ShouldHaveLength, 2)
+			So(returnedEditionsList.Items[0], ShouldResemble, editions[0])
+			So(returnedEditionsList.Items[1], ShouldResemble, editions[1])
 		})
 	})
+
+	Convey("When the items in the response are of type EditionUpdate", t, func() {
+		mockBody := map[string]interface{}{"items": editionUpdates}
+		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, mockBody, map[string]string{}})
+		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
+		queryParams := QueryParams{}
+		returnedEditionsList, err := datasetAPIClient.GetEditions(ctx, Headers{}, datasetID, &queryParams)
+
+		Convey("Then the next edition from each EditionUpdate should be returned", func() {
+			So(err, ShouldBeNil)
+			So(returnedEditionsList.Items, ShouldHaveLength, 2)
+			So(returnedEditionsList.Items[0], ShouldResemble, nextEdition)
+			So(returnedEditionsList.Items[1], ShouldResemble, nextEdition)
+		})
+	})
+
 	Convey("If requested dataset and edition is not valid and get request returns 404", t, func() {
 		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusNotFound, apierrors.ErrEditionNotFound.Error(), map[string]string{}})
 		datasetAPIClient := newDatasetAPIHealthcheckClient(t, httpClient)
 		queryParams := QueryParams{}
 		_, err := datasetAPIClient.GetEditions(ctx, headers, datasetID, &queryParams)
-		Convey("Test that an error is raised and should contain status code", func() {
+		Convey("Test that an error is raised and should contain status code and error message", func() {
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, apierrors.ErrEditionNotFound.Error())
+			So(err.Error(), ShouldContainSubstring, "status 404")
+			So(err.Error(), ShouldContainSubstring, apierrors.ErrEditionNotFound.Error())
 		})
 	})
 }


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-4912

- Update `GetEditions` and `GetEdition` SDK methods so both web and publishing responses can be handled correctly
- Both methods will also include the status code in the returned `err`
- Improved test coverage for `GetEditions`

### How to review

- Check changes are ok and unit tests are accurate

### Who can review

- Anyone
