### PR TITLE
add zookeeper healthcheck

### DIFF
--- a/features/compose/kafka-cluster.yml
+++ b/features/compose/kafka-cluster.yml
@@ -8,12 +8,20 @@ services:
       ZOOKEEPER_SERVER_ID: 1
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
+    healthcheck:
+      test: ["CMD", "bash", "-c", "echo ruok | nc localhost 2181 | grep imok"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+      start_period: 10s
+
   kafka-1:
     image: confluentinc/cp-kafka:6.0.0
     expose:
       - "9092" # exposed port to docker network so that the broker is reachable by other brokers, value needs to match PLAINTEXT port
     depends_on:
-      - zookeeper-1
+      zookeeper-1:
+        condition: service_healthy
     environment:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181
       KAFKA_BROKER_ID: 1

--- a/features/compose/kafka-cluster.yml
+++ b/features/compose/kafka-cluster.yml
@@ -9,7 +9,7 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
     healthcheck:
-      test: ["CMD", "bash", "-c", "echo ruok | nc localhost 2181 | grep imok"]
+      test: ["CMD", "bash", "-c", "echo srvr | nc localhost 2181 | grep -q Mode"]
       interval: 5s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
### What

Jira - https://officefornationalstatistics.atlassian.net/browse/DIS-4850

Potential fix for component tests failing in concourse due to kafka trying to connect to zookeeper before zookeeper is fully ready. The fix adds a health check to zookeeper so that kafka waits until zookeeper is ready before starting, rather than trying to connect immediately

### How to review

Confirm changes make sense
We will be able to see if the fix has had any effect once a few PR's have gone into the dataset api

### Who can review

Anyone
