### PR TITLE
fix ordering of static editions

### DIFF
--- a/mongo/version_store.go
+++ b/mongo/version_store.go
@@ -288,14 +288,10 @@ func (m *Mongo) GetEditionsStatic(ctx context.Context, datasetID, state string, 
 
 	pipeline := []bson.M{
 		{"$match": selector},
-		{"$sort": bson.M{
-			"edition": 1,
-			"version": 1,
-		}},
 		{"$group": bson.M{
 			"_id": "$edition",
 			"oldest_version_release_date": bson.M{
-				"$first": "$release_date",
+				"$min": "$release_date",
 			},
 		}},
 		{"$sort": bson.M{


### PR DESCRIPTION
### What

Fix for component tests for static editions occasionally failing in CI because the ordering of editions isn't always consistent. This is potentially caused by the mongo pipeline relying on a sort before grouping to determine the order. Switching to `$min` could fix this by always picking the earliest release date regardless of document order

### How to review

To test locally, make some GET requests to the following endpoints using static datasets and confirm that the editions are returned in the correct order (most recent release date first) - 

GET `/datasets/{id}/editions` check editions are ordered correctly and total count is accurate
GET `/datasets/{id}/editions?limit=1&offset=0` and GET` /datasets/{id}/editions?limit=1&offset=1` check pagination returns the correct edition at each offset
GET `/datasets/{id}/editions/{edition_id}` check a specific edition still returns correctly

Confirm changes make sense, tests pass

### Who can review

Anyone
