### PR TITLE
Fix context cancel on cloudflare purge

### DIFF
--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -11,6 +11,7 @@ import (
 	neturl "net/url"
 	"sync"
 	"testing"
+	"time"
 
 	clientsidentity "github.com/ONSdigital/dp-api-clients-go/v2/identity"
 	topicAPIModels "github.com/ONSdigital/dp-topic-api/models"
@@ -183,6 +184,8 @@ func GetAPIWithCMDMocks(mockedDataStore store.Storer, mockedGeneratedDownloads D
 			Type:                "static",
 		}}
 
+	clouflareTimeout := 2 * time.Second
+
 	mockStatemachineDatasetAPI := application.StateMachineDatasetAPI{
 		DataStore:                    store.DataStore{Backend: mockedDataStore},
 		DownloadGenerators:           mockedMapSMGeneratedDownloads,
@@ -192,6 +195,7 @@ func GetAPIWithCMDMocks(mockedDataStore store.Storer, mockedGeneratedDownloads D
 		CloudflareEnabled:            cfg.CloudflareEnabled,
 		UrlBuilder:                   urlBuilder,
 		CloudflareClient:             cloudflareMock,
+		CloudflareTimeout:            &clouflareTimeout,
 	}
 
 	testIdentityClient := clientsidentity.New(cfg.ZebedeeURL)

--- a/application/application.go
+++ b/application/application.go
@@ -70,10 +70,11 @@ type StateMachineDatasetAPI struct {
 	SearchContentUpdatedProducer *SearchContentUpdatedProducer
 	CloudflareClient             cloudflare.Clienter
 	CloudflareEnabled            bool
+	CloudflareTimeout            *time.Duration
 	UrlBuilder                   *url.Builder
 }
 
-func Setup(dataStoreVal store.DataStore, downloadGenerators map[models.DatasetType]DownloadsGenerator, stateMachine *StateMachine, searchContentUpdatedProducer *SearchContentUpdatedProducer, cloudflareClient cloudflare.Clienter, cloudflareEnabled bool, urlBuilder *url.Builder, filesAPIClient filesAPISDK.Clienter) *StateMachineDatasetAPI {
+func Setup(dataStoreVal store.DataStore, downloadGenerators map[models.DatasetType]DownloadsGenerator, stateMachine *StateMachine, searchContentUpdatedProducer *SearchContentUpdatedProducer, cloudflareClient cloudflare.Clienter, cloudflareEnabled bool, urlBuilder *url.Builder, filesAPIClient filesAPISDK.Clienter, cloudflareTimeout *time.Duration) *StateMachineDatasetAPI {
 	newDS := &StateMachineDatasetAPI{
 		DataStore:                    dataStoreVal,
 		DownloadGenerators:           downloadGenerators,
@@ -81,6 +82,7 @@ func Setup(dataStoreVal store.DataStore, downloadGenerators map[models.DatasetTy
 		SearchContentUpdatedProducer: searchContentUpdatedProducer,
 		CloudflareClient:             cloudflareClient,
 		CloudflareEnabled:            cloudflareEnabled,
+		CloudflareTimeout:            cloudflareTimeout,
 		UrlBuilder:                   urlBuilder,
 		FilesAPIClient:               filesAPIClient,
 	}
@@ -732,11 +734,13 @@ func PublishVersionInfo(ctx context.Context, smDS *StateMachineDatasetAPI,
 						prefixes := utils.GeneratePurgePrefixes(smDS.UrlBuilder.GetPublicWebsiteURL().String(), smDS.UrlBuilder.GetAPIRouterPublicURL().String(), topic[0], versionDetails.datasetID, versionDetails.edition, versionDetails.version)
 						logData["purge_prefixes"] = prefixes
 
-						errPurge := smDS.CloudflareClient.PurgeByPrefixes(ctx, prefixes)
+						cfCtx, cancel := context.WithTimeout(ctx, *smDS.CloudflareTimeout)
+						defer cancel()
+						errPurge := smDS.CloudflareClient.PurgeByPrefixes(cfCtx, prefixes)
 						if errPurge != nil {
-							log.Error(ctx, "putState endpoint: failed to purge cache by prefixes", errPurge, logData)
+							log.Error(cfCtx, "putState endpoint: failed to purge cache by prefixes", errPurge, logData)
 						} else {
-							log.Info(ctx, "putState endpoint: successfully purged cache by prefixes", logData)
+							log.Info(cfCtx, "putState endpoint: successfully purged cache by prefixes", logData)
 						}
 					}()
 				}

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -2836,7 +2836,7 @@ func GetStateMachineAPIWithCMDMocks(mockedDataStore store.Storer, mockedGenerate
 		models.CantabularFlexibleTable: mockedGeneratedDownloads,
 	}
 
-	return Setup(store.DataStore{Backend: mockedDataStore}, mockedMapSMGeneratedDownloads, statemachine, searchContentUpdated, cloudflareMock, cloudflareEnabled, urlBuilder, filesAPIClient)
+	return Setup(store.DataStore{Backend: mockedDataStore}, mockedMapSMGeneratedDownloads, statemachine, searchContentUpdated, cloudflareMock, cloudflareEnabled, urlBuilder, filesAPIClient, nil)
 }
 
 func TestPopulateNewVersionDocWithEditionChange(t *testing.T) {
@@ -3140,7 +3140,7 @@ func TestDeleteStaticVersion_ReturnSuccess(t *testing.T) {
 		}
 
 		sm := &StateMachine{}
-		smDS := Setup(store.DataStore{Backend: mocked}, map[models.DatasetType]DownloadsGenerator{}, sm, nil, nil, false, nil, nil)
+		smDS := Setup(store.DataStore{Backend: mocked}, map[models.DatasetType]DownloadsGenerator{}, sm, nil, nil, false, nil, nil, nil)
 
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 1, mockFilesAPIClient, "test-token")
 		So(err, ShouldBeNil)
@@ -3184,7 +3184,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 			},
 		}
 
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil, nil)
 
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 1, mockFilesAPIClient, invalidToken)
 
@@ -3197,7 +3197,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 		mocked := &storetest.StorerMock{
 			CheckEditionExistsStaticFunc: func(context.Context, string, string, string) error { return errs.ErrEditionNotFound },
 		}
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil, nil)
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "missing", 1, nil, "test-token")
 		So(err, ShouldEqual, errs.ErrEditionNotFound)
 		So(len(mocked.CheckEditionExistsStaticCalls()), ShouldEqual, 1)
@@ -3210,7 +3210,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 				return nil, errs.ErrVersionNotFound
 			},
 		}
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil, nil)
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 10, nil, "test-token")
 		So(err, ShouldEqual, errs.ErrVersionNotFound)
 		So(len(mocked.CheckEditionExistsStaticCalls()), ShouldEqual, 1)
@@ -3224,7 +3224,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 				return &models.Version{State: models.PublishedState}, nil
 			},
 		}
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil, nil)
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 3, nil, "test-token")
 		So(err, ShouldEqual, errs.ErrDeletePublishedVersionForbidden)
 	})
@@ -3253,7 +3253,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 			},
 		}
 
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, mockFilesAPIClient)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, mockFilesAPIClient, nil)
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 2, mockFilesAPIClient, "test-token")
 		So(err, ShouldEqual, expectedError)
 		So(len(mockFilesAPIClient.DeleteFileCalls()), ShouldEqual, 1)
@@ -3281,7 +3281,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 			},
 		}
 
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, &mockFilesAPIClient)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, &mockFilesAPIClient, nil)
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 4, &mockFilesAPIClient, "test-token")
 		So(err, ShouldEqual, errs.ErrInternalServer)
 		So(len(mockFilesAPIClient.DeleteFileCalls()), ShouldEqual, 1)
@@ -3312,7 +3312,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 			},
 		}
 
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, mockFilesAPIClient)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, mockFilesAPIClient, nil)
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 5, mockFilesAPIClient, "test-token")
 		So(err, ShouldEqual, errs.ErrInternalServer)
 		So(len(mockFilesAPIClient.DeleteFileCalls()), ShouldEqual, 1)
@@ -3345,7 +3345,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 			},
 		}
 
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, mockFilesAPIClient)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, mockFilesAPIClient, nil)
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 6, mockFilesAPIClient, "test-token")
 		So(err, ShouldEqual, errs.ErrInternalServer)
 		So(len(mockFilesAPIClient.DeleteFileCalls()), ShouldEqual, 1)

--- a/config/config.go
+++ b/config/config.go
@@ -66,9 +66,10 @@ type Configuration struct {
 	OTBatchTimeout                 time.Duration `envconfig:"OTEL_BATCH_TIMEOUT"`
 	OtelEnabled                    bool          `envconfig:"OTEL_ENABLED"`
 	MongoConfig
-	AuthConfig        *authorisation.Config
-	CloudflareEnabled bool `envconfig:"CLOUDFLARE_ENABLED"`
-	CloudflareConfig  *cloudflare.Config
+	AuthConfig               *authorisation.Config
+	CloudflareEnabled        bool `envconfig:"CLOUDFLARE_ENABLED"`
+	CloudflareConfig         *cloudflare.Config
+	CloudflareContextTimeout time.Duration `envconfig:"CLOUDFLARE_CTX_TIMEOUT"`
 }
 
 var cfg *Configuration
@@ -156,10 +157,11 @@ func Get() (*Configuration, error) {
 			CodeListAPIURL: "http://localhost:22400",
 			DatasetAPIURL:  "http://localhost:22000",
 		},
-		ComponentTestUseLogFile: false,
-		AuthConfig:              authorisation.NewDefaultConfig(),
-		CloudflareEnabled:       false,
-		CloudflareConfig:        cloudflare.NewDefaultConfig(),
+		ComponentTestUseLogFile:  false,
+		AuthConfig:               authorisation.NewDefaultConfig(),
+		CloudflareEnabled:        false,
+		CloudflareConfig:         cloudflare.NewDefaultConfig(),
+		CloudflareContextTimeout: 30 * time.Second,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -78,6 +78,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.AuthConfig, ShouldEqual, authorisation.NewDefaultConfig())
 				So(cfg.CloudflareEnabled, ShouldBeFalse)
 				So(cfg.CloudflareConfig, ShouldEqual, cloudflare.NewDefaultConfig())
+				So(cfg.CloudflareContextTimeout, ShouldEqual, 30*time.Second)
 			})
 		})
 	})

--- a/service/service.go
+++ b/service/service.go
@@ -361,7 +361,7 @@ func (svc *Service) Run(ctx context.Context, buildTime, gitCommit, version strin
 	}
 
 	sm := GetStateMachine(ctx, ds)
-	svc.smDS = application.Setup(ds, smDownloadGenerators, sm, searchContentUpdatedProducer, svc.cloudflareClient, svc.config.CloudflareEnabled, urlBuilder, svc.filesAPIClient)
+	svc.smDS = application.Setup(ds, smDownloadGenerators, sm, searchContentUpdatedProducer, svc.cloudflareClient, svc.config.CloudflareEnabled, urlBuilder, svc.filesAPIClient, &svc.config.CloudflareContextTimeout)
 
 	auditService := application.NewAuditService(ds)
 


### PR DESCRIPTION
### What

Resolve issue with context cancelling when the cloudflare cache is purged in environments.  When testing the cache purge in a go routine in sandbox, the context for the request was being cancelled before the cloudflare purge had a chance to complete.  This PR introduces a separate context based off the parent context for the cache purge specifically.  A default setting of 30 seconds has been applied and can be adjusted in config if necessary.

### How to review

Ensure the tests pass and the changes make sense.  For a more detailed review, run the dataset catalogue stack and create an edition and publish it.  Ensure the logs indicate that the cloudflare purge was successful.

### Who can review

Anyone.
