### PR TITLE
Revert context with timeout functionality

### DIFF
--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -11,7 +11,6 @@ import (
 	neturl "net/url"
 	"sync"
 	"testing"
-	"time"
 
 	clientsidentity "github.com/ONSdigital/dp-api-clients-go/v2/identity"
 	topicAPIModels "github.com/ONSdigital/dp-topic-api/models"
@@ -184,8 +183,6 @@ func GetAPIWithCMDMocks(mockedDataStore store.Storer, mockedGeneratedDownloads D
 			Type:                "static",
 		}}
 
-	clouflareTimeout := 2 * time.Second
-
 	mockStatemachineDatasetAPI := application.StateMachineDatasetAPI{
 		DataStore:                    store.DataStore{Backend: mockedDataStore},
 		DownloadGenerators:           mockedMapSMGeneratedDownloads,
@@ -195,7 +192,6 @@ func GetAPIWithCMDMocks(mockedDataStore store.Storer, mockedGeneratedDownloads D
 		CloudflareEnabled:            cfg.CloudflareEnabled,
 		UrlBuilder:                   urlBuilder,
 		CloudflareClient:             cloudflareMock,
-		CloudflareTimeout:            &clouflareTimeout,
 	}
 
 	testIdentityClient := clientsidentity.New(cfg.ZebedeeURL)

--- a/application/application.go
+++ b/application/application.go
@@ -70,11 +70,10 @@ type StateMachineDatasetAPI struct {
 	SearchContentUpdatedProducer *SearchContentUpdatedProducer
 	CloudflareClient             cloudflare.Clienter
 	CloudflareEnabled            bool
-	CloudflareTimeout            *time.Duration
 	UrlBuilder                   *url.Builder
 }
 
-func Setup(dataStoreVal store.DataStore, downloadGenerators map[models.DatasetType]DownloadsGenerator, stateMachine *StateMachine, searchContentUpdatedProducer *SearchContentUpdatedProducer, cloudflareClient cloudflare.Clienter, cloudflareEnabled bool, urlBuilder *url.Builder, filesAPIClient filesAPISDK.Clienter, cloudflareTimeout *time.Duration) *StateMachineDatasetAPI {
+func Setup(dataStoreVal store.DataStore, downloadGenerators map[models.DatasetType]DownloadsGenerator, stateMachine *StateMachine, searchContentUpdatedProducer *SearchContentUpdatedProducer, cloudflareClient cloudflare.Clienter, cloudflareEnabled bool, urlBuilder *url.Builder, filesAPIClient filesAPISDK.Clienter) *StateMachineDatasetAPI {
 	newDS := &StateMachineDatasetAPI{
 		DataStore:                    dataStoreVal,
 		DownloadGenerators:           downloadGenerators,
@@ -82,7 +81,6 @@ func Setup(dataStoreVal store.DataStore, downloadGenerators map[models.DatasetTy
 		SearchContentUpdatedProducer: searchContentUpdatedProducer,
 		CloudflareClient:             cloudflareClient,
 		CloudflareEnabled:            cloudflareEnabled,
-		CloudflareTimeout:            cloudflareTimeout,
 		UrlBuilder:                   urlBuilder,
 		FilesAPIClient:               filesAPIClient,
 	}
@@ -705,20 +703,27 @@ func PublishVersionInfo(ctx context.Context, smDS *StateMachineDatasetAPI,
 					log.Error(ctx, "putState endpoint: failed to publish distribution files", err, log.Data{})
 					return versionUpdate, err
 				}
+
+				updatedV, errVersion := smDS.DataStore.Backend.UpdateStateStatic(ctx, currentVersion, &models.StateUpdate{State: "published"}, eTag)
+				if errVersion != nil {
+					log.Error(ctx, "putVersion endpoint: UpdateVersionStatic returned an error", err)
+					return nil, errVersion
+				}
+
 				searchContentUpdatedEvent := map[string]interface{}{
 					"dataset_id":   versionDetails.datasetID,
 					"uri":          fmt.Sprintf("/datasets/%s", versionDetails.datasetID),
-					"title":        currentVersion.EditionTitle,
-					"edition":      currentVersion.Edition,
+					"title":        updatedV.EditionTitle,
+					"edition":      updatedV.Edition,
 					"content_type": "dataset_landing_page",
-					"release_date": currentVersion.ReleaseDate,
+					"release_date": updatedV.ReleaseDate,
 				}
 
 				logData["search_content_updated_event"] = searchContentUpdatedEvent
 				jsonBytes, err := json.Marshal(searchContentUpdatedEvent)
 				if err != nil {
 					log.Error(ctx, "failed to marshal searchContentUpdatedEvent for kafka", err, logData)
-					return currentVersion, err
+					return updatedV, err
 				} else {
 					go func() {
 						smDS.SearchContentUpdatedProducer.Producer.Output() <- kafka.BytesMessage{Value: jsonBytes, Context: ctx}
@@ -728,27 +733,17 @@ func PublishVersionInfo(ctx context.Context, smDS *StateMachineDatasetAPI,
 
 				// Purge Cloudflare cache if enabled and version is being published
 				if smDS.CloudflareEnabled {
-					go func() {
-						webLink := strings.TrimLeft(currentVersion.Links.WebPage.HRef, "/")
-						topic := strings.Split(webLink, "/")
-						prefixes := utils.GeneratePurgePrefixes(smDS.UrlBuilder.GetPublicWebsiteURL().String(), smDS.UrlBuilder.GetAPIRouterPublicURL().String(), topic[0], versionDetails.datasetID, versionDetails.edition, versionDetails.version)
-						logData["purge_prefixes"] = prefixes
+					webLink := strings.TrimLeft(updatedV.Links.WebPage.HRef, "/")
+					topic := strings.Split(webLink, "/")
+					prefixes := utils.GeneratePurgePrefixes(smDS.UrlBuilder.GetPublicWebsiteURL().String(), smDS.UrlBuilder.GetAPIRouterPublicURL().String(), topic[0], versionDetails.datasetID, versionDetails.edition, versionDetails.version)
+					logData["purge_prefixes"] = prefixes
 
-						cfCtx, cancel := context.WithTimeout(ctx, *smDS.CloudflareTimeout)
-						defer cancel()
-						errPurge := smDS.CloudflareClient.PurgeByPrefixes(cfCtx, prefixes)
-						if errPurge != nil {
-							log.Error(cfCtx, "putState endpoint: failed to purge cache by prefixes", errPurge, logData)
-						} else {
-							log.Info(cfCtx, "putState endpoint: successfully purged cache by prefixes", logData)
-						}
-					}()
-				}
-
-				updatedV, errVersion := smDS.DataStore.Backend.UpdateStateStatic(ctx, currentVersion, &models.StateUpdate{State: "published"}, eTag)
-				if errVersion != nil {
-					log.Error(ctx, "putVersion endpoint: UpdateVersionStatic returned an error", err)
-					return nil, errVersion
+					errPurge := smDS.CloudflareClient.PurgeByPrefixes(ctx, prefixes)
+					if errPurge != nil {
+						log.Error(ctx, "putState endpoint: failed to purge cache by prefixes", errPurge, logData)
+					} else {
+						log.Info(ctx, "putState endpoint: successfully purged cache by prefixes", logData)
+					}
 				}
 
 				return updatedV, nil

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -2836,7 +2836,7 @@ func GetStateMachineAPIWithCMDMocks(mockedDataStore store.Storer, mockedGenerate
 		models.CantabularFlexibleTable: mockedGeneratedDownloads,
 	}
 
-	return Setup(store.DataStore{Backend: mockedDataStore}, mockedMapSMGeneratedDownloads, statemachine, searchContentUpdated, cloudflareMock, cloudflareEnabled, urlBuilder, filesAPIClient, nil)
+	return Setup(store.DataStore{Backend: mockedDataStore}, mockedMapSMGeneratedDownloads, statemachine, searchContentUpdated, cloudflareMock, cloudflareEnabled, urlBuilder, filesAPIClient)
 }
 
 func TestPopulateNewVersionDocWithEditionChange(t *testing.T) {
@@ -3140,7 +3140,7 @@ func TestDeleteStaticVersion_ReturnSuccess(t *testing.T) {
 		}
 
 		sm := &StateMachine{}
-		smDS := Setup(store.DataStore{Backend: mocked}, map[models.DatasetType]DownloadsGenerator{}, sm, nil, nil, false, nil, nil, nil)
+		smDS := Setup(store.DataStore{Backend: mocked}, map[models.DatasetType]DownloadsGenerator{}, sm, nil, nil, false, nil, nil)
 
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 1, mockFilesAPIClient, "test-token")
 		So(err, ShouldBeNil)
@@ -3184,7 +3184,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 			},
 		}
 
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil, nil)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil)
 
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 1, mockFilesAPIClient, invalidToken)
 
@@ -3197,7 +3197,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 		mocked := &storetest.StorerMock{
 			CheckEditionExistsStaticFunc: func(context.Context, string, string, string) error { return errs.ErrEditionNotFound },
 		}
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil, nil)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil)
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "missing", 1, nil, "test-token")
 		So(err, ShouldEqual, errs.ErrEditionNotFound)
 		So(len(mocked.CheckEditionExistsStaticCalls()), ShouldEqual, 1)
@@ -3210,7 +3210,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 				return nil, errs.ErrVersionNotFound
 			},
 		}
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil, nil)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil)
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 10, nil, "test-token")
 		So(err, ShouldEqual, errs.ErrVersionNotFound)
 		So(len(mocked.CheckEditionExistsStaticCalls()), ShouldEqual, 1)
@@ -3224,7 +3224,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 				return &models.Version{State: models.PublishedState}, nil
 			},
 		}
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil, nil)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, nil)
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 3, nil, "test-token")
 		So(err, ShouldEqual, errs.ErrDeletePublishedVersionForbidden)
 	})
@@ -3253,7 +3253,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 			},
 		}
 
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, mockFilesAPIClient, nil)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, mockFilesAPIClient)
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 2, mockFilesAPIClient, "test-token")
 		So(err, ShouldEqual, expectedError)
 		So(len(mockFilesAPIClient.DeleteFileCalls()), ShouldEqual, 1)
@@ -3281,7 +3281,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 			},
 		}
 
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, &mockFilesAPIClient, nil)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, &mockFilesAPIClient)
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 4, &mockFilesAPIClient, "test-token")
 		So(err, ShouldEqual, errs.ErrInternalServer)
 		So(len(mockFilesAPIClient.DeleteFileCalls()), ShouldEqual, 1)
@@ -3312,7 +3312,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 			},
 		}
 
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, mockFilesAPIClient, nil)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, mockFilesAPIClient)
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 5, mockFilesAPIClient, "test-token")
 		So(err, ShouldEqual, errs.ErrInternalServer)
 		So(len(mockFilesAPIClient.DeleteFileCalls()), ShouldEqual, 1)
@@ -3345,7 +3345,7 @@ func TestDeleteStaticVersion_Errors(t *testing.T) {
 			},
 		}
 
-		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, mockFilesAPIClient, nil)
+		smDS := Setup(store.DataStore{Backend: mocked}, nil, &StateMachine{}, nil, nil, false, nil, mockFilesAPIClient)
 		_, err := smDS.DeleteStaticVersion(context.Background(), "ds1", "ed1", 6, mockFilesAPIClient, "test-token")
 		So(err, ShouldEqual, errs.ErrInternalServer)
 		So(len(mockFilesAPIClient.DeleteFileCalls()), ShouldEqual, 1)

--- a/config/config.go
+++ b/config/config.go
@@ -66,10 +66,9 @@ type Configuration struct {
 	OTBatchTimeout                 time.Duration `envconfig:"OTEL_BATCH_TIMEOUT"`
 	OtelEnabled                    bool          `envconfig:"OTEL_ENABLED"`
 	MongoConfig
-	AuthConfig               *authorisation.Config
-	CloudflareEnabled        bool `envconfig:"CLOUDFLARE_ENABLED"`
-	CloudflareConfig         *cloudflare.Config
-	CloudflareContextTimeout time.Duration `envconfig:"CLOUDFLARE_CTX_TIMEOUT"`
+	AuthConfig        *authorisation.Config
+	CloudflareEnabled bool `envconfig:"CLOUDFLARE_ENABLED"`
+	CloudflareConfig  *cloudflare.Config
 }
 
 var cfg *Configuration
@@ -157,11 +156,10 @@ func Get() (*Configuration, error) {
 			CodeListAPIURL: "http://localhost:22400",
 			DatasetAPIURL:  "http://localhost:22000",
 		},
-		ComponentTestUseLogFile:  false,
-		AuthConfig:               authorisation.NewDefaultConfig(),
-		CloudflareEnabled:        false,
-		CloudflareConfig:         cloudflare.NewDefaultConfig(),
-		CloudflareContextTimeout: 30 * time.Second,
+		ComponentTestUseLogFile: false,
+		AuthConfig:              authorisation.NewDefaultConfig(),
+		CloudflareEnabled:       false,
+		CloudflareConfig:        cloudflare.NewDefaultConfig(),
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -78,7 +78,6 @@ func TestSpec(t *testing.T) {
 				So(cfg.AuthConfig, ShouldEqual, authorisation.NewDefaultConfig())
 				So(cfg.CloudflareEnabled, ShouldBeFalse)
 				So(cfg.CloudflareConfig, ShouldEqual, cloudflare.NewDefaultConfig())
-				So(cfg.CloudflareContextTimeout, ShouldEqual, 30*time.Second)
 			})
 		})
 	})

--- a/service/service.go
+++ b/service/service.go
@@ -361,7 +361,7 @@ func (svc *Service) Run(ctx context.Context, buildTime, gitCommit, version strin
 	}
 
 	sm := GetStateMachine(ctx, ds)
-	svc.smDS = application.Setup(ds, smDownloadGenerators, sm, searchContentUpdatedProducer, svc.cloudflareClient, svc.config.CloudflareEnabled, urlBuilder, svc.filesAPIClient, &svc.config.CloudflareContextTimeout)
+	svc.smDS = application.Setup(ds, smDownloadGenerators, sm, searchContentUpdatedProducer, svc.cloudflareClient, svc.config.CloudflareEnabled, urlBuilder, svc.filesAPIClient)
 
 	auditService := application.NewAuditService(ds)
 


### PR DESCRIPTION
### What

The fix for the cloudflare purge context issue didn't work, so have removed invoking the functionality via a go routine.  The update state of the version in the database has also been moved to beneath the publication of the distribution files.  This should mean that the files are set to published before the version so when a user accesses the version metadata the files should be available for download.

The search content updated and cloudflare purge should be ok after that because everything will be in place should a user search the record and the cache will definitely not be cleared until the record is made public.

### How to review

Ensure the tests pass and the changes make sense.
For a more detailed review, run the dataset catalogue stack and publish an edition.  Ensure all steps of publication are ok (file metadata is set as published, version and dataset metadata set as published, search content updated kafka message is sent and the cloudflare cache is purged).

### Who can review

Anyone.
