### PR TITLE
Fix/remove duplicate error response writing

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -160,7 +160,7 @@ func (api *DatasetAPI) getDataset(w http.ResponseWriter, r *http.Request) {
 	b, err := func() ([]byte, error) {
 		attrs, attrsErr := api.getPermissionAttributesFromRequest(r)
 		if attrsErr != nil {
-			handleDatasetAPIErr(ctx, attrsErr, w, logData)
+			return nil, attrsErr
 		}
 
 		dataset, err := api.dataStore.Backend.GetDataset(ctx, datasetID)

--- a/api/editions.go
+++ b/api/editions.go
@@ -133,17 +133,13 @@ func (api *DatasetAPI) getEdition(w http.ResponseWriter, r *http.Request) {
 	b, err := func() ([]byte, error) {
 		attrs, attrsErr := api.getPermissionAttributesFromRequest(r)
 		if attrsErr != nil {
-			handleVersionAPIErr(ctx, attrsErr, w, logData)
+			return nil, attrsErr
 		}
 
 		var authorised bool
 		isStatic, err := api.dataStore.Backend.IsStaticDataset(ctx, datasetID)
 		if err != nil {
-			if err == errs.ErrDatasetNotFound {
-				handleVersionAPIErr(ctx, err, w, logData)
-			} else {
-				handleVersionAPIErr(ctx, errs.ErrInternalServer, w, logData)
-			}
+			return nil, err
 		}
 
 		if isStatic {

--- a/api/editions_test.go
+++ b/api/editions_test.go
@@ -752,7 +752,7 @@ func TestGetEditionReturnsError(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrInternalServer.Error())
-		So(len(mockedDataStore.GetDatasetTypeCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDatasetTypeCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.GetLatestVersionStaticCalls()), ShouldEqual, 0)
 	})
@@ -784,7 +784,7 @@ func TestGetEditionReturnsError(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 		So(w.Body.String(), ShouldContainSubstring, errs.ErrDatasetNotFound.Error())
-		So(len(mockedDataStore.GetDatasetTypeCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetDatasetTypeCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.GetEditionCalls()), ShouldEqual, 0)
 		So(len(mockedDataStore.GetLatestVersionStaticCalls()), ShouldEqual, 0)
 	})

--- a/api/metadata.go
+++ b/api/metadata.go
@@ -35,7 +35,7 @@ func (api *DatasetAPI) getMetadata(w http.ResponseWriter, r *http.Request) {
 		}
 		attrs, attrsErr := api.getPermissionAttributesFromRequest(r)
 		if attrsErr != nil {
-			handleDatasetAPIErr(ctx, attrsErr, w, logData)
+			return nil, attrsErr
 		}
 
 		datasetDoc, err := api.dataStore.Backend.GetDataset(ctx, datasetID)
@@ -137,35 +137,30 @@ func (api *DatasetAPI) getMetadata(w http.ResponseWriter, r *http.Request) {
 			err = utils.RewriteMetadataLinks(ctx, metaDataDoc.Links, datasetLinksBuilder)
 			if err != nil {
 				log.Error(ctx, "getMetadata endpoint: failed to rewrite metadata links", err, logData)
-				handleMetadataErr(w, err)
 				return nil, err
 			}
 
 			metaDataDoc.Dimensions, err = utils.RewriteDimensions(ctx, metaDataDoc.Dimensions, datasetLinksBuilder, codeListLinksBuilder)
 			if err != nil {
 				log.Error(ctx, "getMetadata endpoint: failed to rewrite metadata dimensions", err, logData)
-				handleMetadataErr(w, err)
 				return nil, err
 			}
 
 			err = utils.RewriteDatasetLinks(ctx, metaDataDoc.DatasetLinks, datasetLinksBuilder)
 			if err != nil {
 				log.Error(ctx, "getMetadata endpoint: failed to rewrite dataset links", err, logData)
-				handleMetadataErr(w, err)
 				return nil, err
 			}
 
 			err = utils.RewriteDownloadLinks(ctx, metaDataDoc.Downloads, api.urlBuilder.GetDownloadServiceURL())
 			if err != nil {
 				log.Error(ctx, "getMetadata endpoint: failed to rewrite download links", err, logData)
-				handleMetadataErr(w, err)
 				return nil, err
 			}
 
 			metaDataDoc.Distributions, err = utils.RewriteDistributions(ctx, metaDataDoc.Distributions, api.urlBuilder.GetDownloadServiceURL())
 			if err != nil {
 				log.Error(ctx, "getMetadata endpoint: failed to rewrite distributions DownloadURL", err, logData)
-				handleMetadataErr(w, err)
 				return nil, err
 			}
 		}

--- a/api/versions.go
+++ b/api/versions.go
@@ -69,7 +69,7 @@ func (api *DatasetAPI) getVersions(w http.ResponseWriter, r *http.Request, limit
 		var state string
 		attrs, attrsErr := api.getPermissionAttributesFromRequest(r)
 		if attrsErr != nil {
-			handleVersionAPIErr(ctx, attrsErr, w, logData)
+			return nil, 0, attrsErr
 		}
 
 		// Check if dataset exists
@@ -210,11 +210,6 @@ func (api *DatasetAPI) getVersion(w http.ResponseWriter, r *http.Request) (*mode
 
 		isStatic, err := api.dataStore.Backend.IsStaticDataset(ctx, datasetID)
 		if err != nil {
-			if err == errs.ErrDatasetNotFound {
-				http.Error(w, err.Error(), http.StatusNotFound)
-			} else {
-				http.Error(w, errs.ErrInternalServer.Error(), http.StatusInternalServerError)
-			}
 			return nil, err
 		}
 
@@ -278,7 +273,7 @@ func (api *DatasetAPI) getVersion(w http.ResponseWriter, r *http.Request) (*mode
 		return version, nil
 	}()
 	if getVersionErr != nil {
-		responseError := models.NewError(getVersionErr, getVersionErr.Error(), "internal error")
+		responseError := models.NewError(getVersionErr, getVersionErr.Error(), getVersionErr.Error())
 		return nil, models.NewErrorResponse(getVersionAPIErrStatusCode(getVersionErr), nil, responseError)
 	}
 
@@ -495,7 +490,7 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 		Groups: authEntityData.EntityData.Groups,
 	}
 
-	amendedVersion, err = api.smDatasetAPI.AmendVersion(r.Context(), vars, version, &permissionEntity, fetchAccessTokenFromHeader(r))
+	amendedVersion, err = api.smDatasetAPI.AmendVersion(ctx, vars, version, &permissionEntity, fetchAccessTokenFromHeader(r))
 	if err != nil {
 		handleVersionAPIErr(ctx, err, w, data)
 		return

--- a/features/editions.feature
+++ b/features/editions.feature
@@ -246,5 +246,27 @@ Feature: Dataset API
             }
             """
 
+    Scenario: GET /datasets/{id}/editions/{edition_id} for a non-existent dataset returns 404
+        When I GET "/datasets/non-existent-dataset/editions/january"
+        Then the HTTP status code should be "404"
+        And I should receive the following response:
+            """
+            dataset not found
+            """
 
-
+    Scenario: GET /datasets/{id}/editions/{edition_id} for a non-existent edition returns 404
+        Given I have these datasets:
+            """
+                [
+                    {
+                        "id": "population-estimates",
+                        "state": "published"
+                }
+            ]
+            """
+        When I GET "/datasets/population-estimates/editions/non-existent-edition"
+        Then the HTTP status code should be "404"
+        And I should receive the following response:
+            """
+            edition not found
+            """

--- a/features/versions.feature
+++ b/features/versions.feature
@@ -609,6 +609,62 @@ Feature: Dataset API
         """
     And the response header "ETag" should be "etag-test-item-2"
 
+  Scenario: GET /datasets/{id}/editions/{edition}/versions/{version} for a non-existent dataset returns 404
+    When I GET "/datasets/non-existent-dataset/editions/hello/versions/1"
+    Then I should receive the following JSON response with status "404":
+        """
+        {
+            "errors": [
+                {
+                    "code": "dataset not found",
+                    "description": "dataset not found"
+                }
+            ]
+        }
+        """
+
+  Scenario: GET /datasets/{id}/editions/{edition}/versions/{version} for a non-existent edition returns 404
+    When I GET "/datasets/population-estimates/editions/non-existent-edition/versions/1"
+    Then I should receive the following JSON response with status "404":
+        """
+        {
+            "errors": [
+                {
+                    "code": "edition not found",
+                    "description": "edition not found"
+                }
+            ]
+        }
+        """
+
+  Scenario: GET /datasets/{id}/editions/{edition}/versions/{version} for an invalid version returns bad request
+    When I GET "/datasets/population-estimates/editions/hello/versions/invalid-version"
+    Then I should receive the following JSON response with status "400":
+        """
+        {
+            "errors": [
+                {
+                    "code": "invalid version requested",
+                    "description": "invalid version requested"
+                }
+            ]
+        }
+        """
+
+  Scenario: GET /datasets/{id}/editions/{edition}/versions/{version} for a non-existent version returns 404
+    When I GET "/datasets/population-estimates/editions/hello/versions/1000"
+    Then I should receive the following JSON response with status "404":
+        """
+        {
+            "errors": [
+                {
+                    "code": "version not found",
+                    "description": "version not found"
+                }
+            ]
+        }
+        """
+
   Scenario: PUT versions for CMD dataset produces Kafka event and returns OK
     Given private endpoints are enabled
     And I am an admin user


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-4985

- `GET /datasets/{id}/editions/{edition_id}` and `GET /datasets/{id}/editions/{edition}/versions/{version}` were returning incorrect response bodies and sometimes writing duplicate HTTP errors due to incorrect error handling. This behaviour has been removed and asserted within component tests.

Notes:
- `GET /datasets/{id}/editions/{edition}/versions/{version}` will return the same message for both the `code` and `description`. This is not ideal but matches previous behaviour with the change being that it will no longer always return "internal error" for the description.

### How to review

- Test the endpoints listed in the ticket for all 404 scenarios
- Component tests have been added for where behaviour was previously unchecked

### Who can review

- Anyone
