### PR TITLE
Feature/add publish failed state

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ where a PST user has attached the *version* to the wrong collection and so not o
 updated with the new one (or removed altogether)
 but the state will need to revert back to `edition-confirmed`.
 
+For static versions, if publication fails then the state is set to `publish_failed` and can be retried by transitioning from
+`publish_failed` to `published`.
+
 Lastly, **skipping a state**: it is possibly to jump from `edition-confirmed` to `published`
 as long as all the mandatory fields are there. There also might be a scenario whereby the state can change
 from `created` to `completed`, missing out the step to `submitted`

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -112,7 +112,7 @@ func GetAPIWithCMDMocks(mockedDataStore store.Storer, mockedGeneratedDownloads D
 		models.CantabularFlexibleTable: mockedGeneratedDownloads,
 	}
 
-	states := []application.State{application.Published, application.EditionConfirmed, application.Associated}
+	states := []application.State{application.Published, application.EditionConfirmed, application.Associated, application.Approved, application.PublishFailed}
 	transitions := []application.Transition{{
 		Label:               "published",
 		TargetState:         application.Published,
@@ -167,19 +167,25 @@ func GetAPIWithCMDMocks(mockedDataStore store.Storer, mockedGeneratedDownloads D
 		{
 			Label:               "associated",
 			TargetState:         application.Associated,
-			AllowedSourceStates: []string{"created"},
+			AllowedSourceStates: []string{"created", "associated", "approved"},
 			Type:                "static",
 		},
 		{
 			Label:               "published",
 			TargetState:         application.Published,
-			AllowedSourceStates: []string{"created", "associated", "published"},
+			AllowedSourceStates: []string{"approved", "publish_failed"},
 			Type:                "static",
 		},
 		{
-			Label:               "associated",
-			TargetState:         application.Associated,
-			AllowedSourceStates: []string{"created", "associated"},
+			Label:               "approved",
+			TargetState:         application.Approved,
+			AllowedSourceStates: []string{"associated"},
+			Type:                "static",
+		},
+		{
+			Label:               "publish_failed",
+			TargetState:         application.PublishFailed,
+			AllowedSourceStates: []string{"approved"},
 			Type:                "static",
 		}}
 

--- a/api/versions.go
+++ b/api/versions.go
@@ -995,6 +995,12 @@ func (api *DatasetAPI) putState(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if stateUpdate.State == models.PublishFailedState {
+		log.Error(ctx, "putState endpoint: publish_failed is not allowed for this endpoint", models.ErrVersionStateInvalid, log.Data{"state": stateUpdate.State})
+		handleVersionAPIErr(ctx, models.ErrVersionStateInvalid, w, logData)
+		return
+	}
+
 	// Create a version update with the target state
 	versionUpdate := &models.Version{
 		ID:    strconv.Itoa(versionID),

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -4786,7 +4786,7 @@ func TestPutStateReturnsOk(t *testing.T) {
 						  }
 						},
 						"release_date": "2025-01-15",
-						"state": "associated",
+						"state": "approved",
 						"distributions": [
 						  {
 							"title": "Full Dataset (CSV)",
@@ -5025,6 +5025,30 @@ func TestPutStateReturnsError(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(w.Body.String(), ShouldContainSubstring, models.ErrVersionStateInvalid.Error())
+	})
+
+	Convey("When the request attempts to set state to publish_failed, return a bad request error", t, func() {
+		b := `{"state":"publish_failed"}`
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123-456/editions/678/versions/1/state", bytes.NewBufferString(b))
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{}
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return testEntityData, nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, application.SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{}, &applicationMocks.StaticDatasetServiceMock{}, nil, &filesAPISDKMocks.ClienterMock{})
+
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Body.String(), ShouldContainSubstring, models.ErrVersionStateInvalid.Error())
+		So(len(mockedDataStore.UpdateStateStaticCalls()), ShouldEqual, 0)
 	})
 
 	Convey("When the version is not found, return a not found error", t, func() {
@@ -5316,6 +5340,7 @@ func TestPutStateApproveDistributionFilesCheck(t *testing.T) {
 			application.Published,
 			application.Associated,
 			application.Approved,
+			application.PublishFailed,
 		}
 		transitions := []application.Transition{
 			{
@@ -5333,6 +5358,12 @@ func TestPutStateApproveDistributionFilesCheck(t *testing.T) {
 			{
 				Label:               "published",
 				TargetState:         application.Published,
+				AllowedSourceStates: []string{"approved", "publish_failed"},
+				Type:                "static",
+			},
+			{
+				Label:               "publish_failed",
+				TargetState:         application.PublishFailed,
 				AllowedSourceStates: []string{"approved"},
 				Type:                "static",
 			},

--- a/application/application.go
+++ b/application/application.go
@@ -563,16 +563,22 @@ func PublishVersion(ctx context.Context, smDS *StateMachineDatasetAPI,
 	authEntityData *sdk.EntityData,
 	accessToken string) error {
 	data := versionDetails.baseLogData()
+	isStatic := currentVersion.Type == models.Static.String()
 	log.Info(ctx, "putVersion endpoint (publishVersion): beginning transition to published", data)
 
 	versionUpdate, err := PublishVersionInfo(ctx, smDS, currentVersion, versionUpdate, versionDetails, authEntityData, accessToken)
 	if err != nil {
 		log.Error(ctx, "State machine - Publish: UpdateVersionInfo : failed to update the version", err, data)
+		if isStatic {
+			if setStateErr := PublishFailedVersion(ctx, smDS, currentVersion, nil, versionDetails, hasDownloads, authEntityData, accessToken); setStateErr != nil {
+				log.Error(ctx, "State machine - Publish: PublishFailedVersion : failed to set version state to publish_failed", setStateErr, data)
+			}
+		}
 		return err
 	}
 
 	if hasDownloads != trueStringified {
-		if versionUpdate.Type != models.Static.String() {
+		if !isStatic {
 			log.Info(ctx, "attempting to publish edition", data)
 
 			err = PublishEdition(ctx, smDS, versionUpdate, versionDetails, data)
@@ -599,8 +605,33 @@ func PublishVersion(ctx context.Context, smDS *StateMachineDatasetAPI,
 		err = PublishDataset(ctx, smDS, currentVersion, versionUpdate, versionDetails, data)
 		if err != nil {
 			log.Error(ctx, "State machine - Publish: PublishDataset : failed to publish dataset", err, data)
+			if isStatic {
+				if setStateErr := PublishFailedVersion(ctx, smDS, versionUpdate, nil, versionDetails, hasDownloads, authEntityData, accessToken); setStateErr != nil {
+					log.Error(ctx, "State machine - Publish: PublishFailedVersion : failed to set version state to publish_failed", setStateErr, data)
+				}
+			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+// PublishFailedVersion is the enter function for the publish-failed state.
+// It updates the version state to publish-failed.
+func PublishFailedVersion(ctx context.Context, smDS *StateMachineDatasetAPI, currentVersion *models.Version,
+	_ *models.Version,
+	_ VersionDetails,
+	_ string,
+	_ *sdk.EntityData,
+	_ string) error {
+	eTag := headers.IfMatchAnyETag
+	if currentVersion.ETag != "" {
+		eTag = currentVersion.ETag
+	}
+
+	if _, err := smDS.DataStore.Backend.UpdateStateStatic(ctx, currentVersion, &models.StateUpdate{State: models.PublishFailedState}, eTag); err != nil {
+		return err
 	}
 
 	return nil
@@ -629,12 +660,12 @@ func UpdateVersionInfo(ctx context.Context, smDS *StateMachineDatasetAPI,
 		if versionUpdate != nil {
 			if versionUpdate.Type == models.Static.String() {
 				if _, errVersion := smDS.DataStore.Backend.UpdateVersionStatic(ctx, currentVersion, versionUpdate, eTag); errVersion != nil {
-					log.Error(ctx, "putVersion endpoint: UpdateVersionStatic returned an error", err)
+					log.Error(ctx, "putVersion endpoint: UpdateVersionStatic returned an error", errVersion)
 					return errVersion
 				}
 			} else {
 				if _, errVersion := smDS.DataStore.Backend.UpdateVersion(ctx, currentVersion, versionUpdate, eTag); errVersion != nil {
-					log.Error(ctx, "putVersion endpoint: UpdateVersion returned an error", err)
+					log.Error(ctx, "putVersion endpoint: UpdateVersion returned an error", errVersion)
 					return errVersion
 				}
 			}
@@ -706,7 +737,7 @@ func PublishVersionInfo(ctx context.Context, smDS *StateMachineDatasetAPI,
 
 				updatedV, errVersion := smDS.DataStore.Backend.UpdateStateStatic(ctx, currentVersion, &models.StateUpdate{State: "published"}, eTag)
 				if errVersion != nil {
-					log.Error(ctx, "putVersion endpoint: UpdateVersionStatic returned an error", err)
+					log.Error(ctx, "putVersion endpoint: UpdateVersionStatic returned an error", errVersion)
 					return nil, errVersion
 				}
 
@@ -992,6 +1023,9 @@ func publishFile(ctx context.Context, filesAPIClient filesAPISDK.Clienter, distr
 			"distribution_title":  distribution.Title,
 			"distribution_format": distribution.Format,
 		})
+
+		// Default to internal server error if no specific error is matched
+		filesAPIError = errs.ErrInternalServer
 
 		if strings.Contains(err.Error(), "FileNotRegistered") ||
 			strings.Contains(err.Error(), "file not registered") ||

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -80,7 +80,7 @@ var authEntityData = &permissionsAPISDK.EntityData{
 }
 
 func setUpStatesTransitions() ([]State, []Transition) {
-	states := []State{Published, EditionConfirmed, Associated}
+	states := []State{Published, EditionConfirmed, Associated, Approved, PublishFailed}
 	transitions := []Transition{{
 		Label:               "published",
 		TargetState:         Published,
@@ -116,17 +116,22 @@ func setUpStatesTransitions() ([]State, []Transition) {
 		{
 			Label:               "published",
 			TargetState:         Published,
-			AllowedSourceStates: []string{"associated", "published", "edition-confirmed"},
+			AllowedSourceStates: []string{"approved", "publish_failed"},
 			Type:                "static",
 		}, {
 			Label:               "associated",
 			TargetState:         Associated,
-			AllowedSourceStates: []string{"edition-confirmed", "associated", "created"},
+			AllowedSourceStates: []string{"created", "associated", "approved"},
 			Type:                "static",
 		}, {
-			Label:               "edition-confirmed",
-			TargetState:         EditionConfirmed,
-			AllowedSourceStates: []string{"edition-confirmed", "completed", "published"},
+			Label:               "approved",
+			TargetState:         Approved,
+			AllowedSourceStates: []string{"associated"},
+			Type:                "static",
+		}, {
+			Label:               "publish_failed",
+			TargetState:         PublishFailed,
+			AllowedSourceStates: []string{"approved"},
 			Type:                "static",
 		},
 	}
@@ -336,7 +341,7 @@ func TestAmendVersionStaticSuccess(t *testing.T) {
 						},
 					},
 					ReleaseDate: "2017-12-12",
-					State:       models.EditionConfirmedState,
+					State:       models.AssociatedState,
 					ETag:        "12345",
 					Type:        "static",
 				}, nil
@@ -1738,6 +1743,142 @@ func TestPublishVersionDatabaseFails(t *testing.T) {
 		So(len(mockedDataStore.UpsertEditionCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.SetInstanceIsPublishedCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 1)
+	})
+}
+
+func TestPublishVersionFailedStatic(t *testing.T) {
+	t.Parallel()
+	Convey("When a static version publish fails while updating dataset, state transitions to publish_failed", t, func() {
+		currentVersion := &models.Version{
+			State:         models.ApprovedState,
+			Type:          models.Static.String(),
+			Distributions: &[]models.Distribution{{Format: "csv", DownloadURL: "uuid/1.csv"}},
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{HRef: "http://localhost:22000/datasets/123", ID: "123"},
+				Edition: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2017", ID: "2017"},
+				Version: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2017/versions/1", ID: "1"},
+				WebPage: &models.LinkObject{HRef: "/economy/datasets/123/editions/2017/versions/1"},
+			},
+		}
+
+		versionUpdate := &models.Version{
+			State:         models.PublishedState,
+			ReleaseDate:   "2024-12-31",
+			Version:       1,
+			ID:            "789",
+			Type:          models.Static.String(),
+			Distributions: &[]models.Distribution{{Format: "csv", DownloadURL: "uuid/1.csv"}},
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{HRef: "http://localhost:22000/datasets/123", ID: "123"},
+				Edition: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2017", ID: "2017"},
+				Version: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2017/versions/1", ID: "1"},
+				WebPage: &models.LinkObject{HRef: "/economy/datasets/123/editions/2017/versions/1"},
+			},
+		}
+
+		updatedStates := []string{}
+		generatorMock := &mocks.DownloadsGeneratorMock{GenerateFunc: func(context.Context, string, string, string, string) error { return nil }}
+
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(_ context.Context, _ string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{Next: &models.Dataset{Links: &models.DatasetLinks{LatestVersion: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2017/versions/1", ID: "1"}}}, ID: "123"}, nil
+			},
+			UpsertDatasetFunc: func(context.Context, string, *models.DatasetUpdate) error { return errs.ErrDatasetNotFound },
+			GetDatasetTypeFunc: func(ctx context.Context, datasetID string, authorised bool) (string, error) {
+				return models.Static.String(), nil
+			},
+			UpdateStateStaticFunc: func(ctx context.Context, currentVersion *models.Version, updatedState *models.StateUpdate, eTagSelector string) (*models.Version, error) {
+				updatedStates = append(updatedStates, updatedState.State)
+				if updatedState.State == models.PublishedState {
+					return versionUpdate, nil
+				}
+				return &models.Version{State: models.PublishFailedState, Type: models.Static.String()}, nil
+			},
+		}
+
+		states, transitions := setUpStatesTransitions()
+		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
+		mockFilesAPIClient := &filesAPISDKMocks.ClienterMock{MarkFilePublishedFunc: func(ctx context.Context, filePath string, headers filesAPISDK.Headers) error { return nil }}
+		cloudflareMock := &cloudflareMocks.ClienterMock{PurgeByPrefixesFunc: func(ctx context.Context, prefixes []string) error { return nil }}
+		producerMock := &mocks.KafkaProducerMock{OutputFunc: func() chan kafka.BytesMessage { return make(chan kafka.BytesMessage, 1) }}
+		searchContentUpdated := SearchContentUpdatedProducer{Producer: producerMock}
+		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine, &searchContentUpdated, cloudflareMock, false, nil, mockFilesAPIClient)
+
+		err := PublishVersion(testContext, smDS, currentVersion, versionUpdate, versionDetails, "", authEntityData, "")
+
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "dataset not found")
+		So(updatedStates, ShouldResemble, []string{models.PublishedState, models.PublishFailedState})
+		So(len(mockedDataStore.UpdateStateStaticCalls()), ShouldEqual, 2)
+	})
+
+	Convey("When static publish fails while publishing distribution files, state is set to publish_failed", t, func() {
+		currentVersion := &models.Version{
+			State:        models.ApprovedState,
+			CollectionID: "3434",
+			Type:         models.Static.String(),
+			Distributions: &[]models.Distribution{
+				{Format: "csv", DownloadURL: "uuid/1.csv"},
+			},
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{HRef: "http://localhost:22000/datasets/123", ID: "123"},
+				Edition: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2017", ID: "2017"},
+				Version: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2017/versions/1", ID: "1"},
+				WebPage: &models.LinkObject{HRef: "/economy/datasets/123/editions/2017/versions/1"},
+			},
+		}
+
+		versionUpdate := &models.Version{
+			State:       models.PublishedState,
+			ReleaseDate: "2024-12-31",
+			Version:     1,
+			ID:          "789",
+			Type:        models.Static.String(),
+			Distributions: &[]models.Distribution{
+				{Format: "csv", DownloadURL: "uuid/1.csv"},
+			},
+			Links: &models.VersionLinks{
+				Dataset: &models.LinkObject{HRef: "http://localhost:22000/datasets/123", ID: "123"},
+				Edition: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2017", ID: "2017"},
+				Version: &models.LinkObject{HRef: "http://localhost:22000/datasets/123/editions/2017/versions/1", ID: "1"},
+				WebPage: &models.LinkObject{HRef: "/economy/datasets/123/editions/2017/versions/1"},
+			},
+		}
+
+		updatedStates := []string{}
+		generatorMock := &mocks.DownloadsGeneratorMock{
+			GenerateFunc: func(context.Context, string, string, string, string) error {
+				return nil
+			},
+		}
+
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetTypeFunc: func(ctx context.Context, datasetID string, authorised bool) (string, error) {
+				return models.Static.String(), nil
+			},
+			UpdateStateStaticFunc: func(ctx context.Context, currentVersion *models.Version, updatedState *models.StateUpdate, eTagSelector string) (*models.Version, error) {
+				updatedStates = append(updatedStates, updatedState.State)
+				return &models.Version{State: updatedState.State, Type: models.Static.String()}, nil
+			},
+		}
+
+		states, transitions := setUpStatesTransitions()
+		stateMachine := NewStateMachine(testContext, states, transitions, store.DataStore{Backend: mockedDataStore})
+
+		mockFilesAPIClient := &filesAPISDKMocks.ClienterMock{
+			MarkFilePublishedFunc: func(ctx context.Context, filePath string, headers filesAPISDK.Headers) error {
+				return errors.New("file not registered")
+			},
+		}
+
+		smDS := GetStateMachineAPIWithCMDMocks(mockedDataStore, generatorMock, stateMachine, nil, nil, false, nil, mockFilesAPIClient)
+
+		err := PublishVersion(testContext, smDS, currentVersion, versionUpdate, versionDetails, "", authEntityData, "")
+
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "file metadata not found")
+		So(updatedStates, ShouldResemble, []string{models.PublishFailedState})
+		So(len(mockedDataStore.UpdateStateStaticCalls()), ShouldEqual, 1)
 	})
 }
 

--- a/application/state_machine.go
+++ b/application/state_machine.go
@@ -54,6 +54,8 @@ func castStateToState(state string) (*State, bool) {
 		return &Approved, true
 	case "edition-confirmed":
 		return &EditionConfirmed, true
+	case "publish_failed":
+		return &PublishFailed, true
 	default:
 		return nil, false
 	}

--- a/application/state_machine_test.go
+++ b/application/state_machine_test.go
@@ -32,12 +32,20 @@ func TestCastStateToState(t *testing.T) {
 		So(publishedOk, ShouldBeTrue)
 
 		associatedState, associatedOk := castStateToState("associated")
-		So(associatedState.Name, ShouldEqual, associatedState.Name)
+		So(associatedState.Name, ShouldEqual, Associated.Name)
 		So(associatedOk, ShouldBeTrue)
 
 		editionConfirmedState, editionConfirmedOk := castStateToState("edition-confirmed")
 		So(editionConfirmedState.Name, ShouldEqual, EditionConfirmed.Name)
 		So(editionConfirmedOk, ShouldBeTrue)
+
+		approvedState, approvedOk := castStateToState("approved")
+		So(approvedState.Name, ShouldEqual, Approved.Name)
+		So(approvedOk, ShouldBeTrue)
+
+		publishFailedState, publishFailedOk := castStateToState("publish_failed")
+		So(publishFailedState.Name, ShouldEqual, PublishFailed.Name)
+		So(publishFailedOk, ShouldBeTrue)
 
 		nilState, ok := castStateToState("")
 		So(nilState, ShouldBeNil)

--- a/application/states.go
+++ b/application/states.go
@@ -19,3 +19,8 @@ var Approved = State{
 	Name:      "approved",
 	EnterFunc: ApproveVersion,
 }
+
+var PublishFailed = State{
+	Name:      "publish_failed",
+	EnterFunc: PublishFailedVersion,
+}

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -79,6 +79,113 @@ Feature: Static Dataset Versions PUT API
             ]
             """
 
+        And I have a static dataset with version:
+            """
+            {
+                "dataset": {
+                    "id": "static-dataset-retry-publish",
+                    "title": "Static Dataset for retry publish",
+                    "state": "associated",
+                    "type": "static",
+                    "links": {
+                        "editions": {
+                            "href": "/datasets/static-dataset-retry-publish/editions"
+                        },
+                        "self": {
+                            "href": "/datasets/static-dataset-retry-publish"
+                        }
+                    },
+                    "topics": ["economy-topic-id"]
+                },
+                "version": {
+                    "id": "static-version-publish-failed",
+                    "edition": "2026",
+                    "edition_title": "2026 Edition",
+                    "links": {
+                        "dataset": {
+                            "id": "static-dataset-retry-publish"
+                        },
+                        "edition": {
+                            "href": "/datasets/static-dataset-retry-publish/editions/2026",
+                            "id": "2026"
+                        },
+                        "self": {
+                            "href": "/datasets/static-dataset-retry-publish/editions/2026/versions/1"
+                        },
+                        "version": {
+                            "href": "/datasets/static-dataset-retry-publish/editions/2026/versions/1",
+                            "id": "1"
+                        },
+                        "web_page": {
+                            "href": "/economy/static-dataset-retry-publish/editions/2026/versions/1"
+                        }
+                    },
+                    "distributions": [
+                        {
+                            "title": "Full Dataset (CSV)",
+                            "byte_size": 4300000,
+                            "download_url": "testing/test-retry.csv",
+                            "format": "csv",
+                            "media_type": "text/csv"
+                        }
+                    ],
+                    "version": 1,
+                    "release_date": "2026-02-01T09:00:00.000Z",
+                    "state": "publish_failed",
+                    "type": "static"
+                }
+            }
+            """
+
+        And I have a static dataset with version:
+            """
+            {
+                "dataset": {
+                    "id": "static-dataset-publish-mark-fail",
+                    "title": "Static Dataset for publish mark failure",
+                    "state": "associated",
+                    "type": "static"
+                },
+                "version": {
+                    "id": "static-version-publish-mark-fail",
+                    "edition": "2027",
+                    "edition_title": "2027 Edition",
+                    "links": {
+                        "dataset": {
+                            "id": "static-dataset-publish-mark-fail"
+                        },
+                        "edition": {
+                            "href": "/datasets/static-dataset-publish-mark-fail/editions/2027",
+                            "id": "2027"
+                        },
+                        "self": {
+                            "href": "/datasets/static-dataset-publish-mark-fail/editions/2027/versions/1"
+                        },
+                        "version": {
+                            "href": "/datasets/static-dataset-publish-mark-fail/editions/2027/versions/1",
+                            "id": "1"
+                        },
+                        "web_page": {
+                            "href": "/economy/static-dataset-publish-mark-fail/editions/2027/versions/1"
+                        }
+                    },
+                    "distributions": [
+                        {
+                            "title": "Full Dataset (CSV)",
+                            "byte_size": 4300000,
+                            "download_url": "/fail/to/mark/published.csv",
+                            "format": "csv",
+                            "media_type": "text/csv"
+                        }
+                    ],
+                    "version": 1,
+                    "release_date": "2027-02-01T09:00:00.000Z",
+                    "state": "approved",
+                    "type": "static"
+                }
+            }
+            """
+
     Scenario: PUT updates static dataset version successfully for an admin user
         Given private endpoints are enabled
         And I am an admin user
@@ -334,6 +441,51 @@ Feature: Static Dataset Versions PUT API
         And the total number of audit events should be 1
         And the number of events with action "UPDATE" and resource "/datasets/static-dataset-update/editions/2025/versions/1/state" should be 1
         And there are no cloudflare purge calls
+
+    Scenario: PUT state rejects publish_failed in request body
+        Given private endpoints are enabled
+        And I am an admin user
+        When I PUT "/datasets/static-dataset-update/editions/2025/versions/1/state"
+            """
+            {
+                "state": "publish_failed"
+            }
+            """
+        Then the HTTP status code should be "400"
+        And I should receive the following response:
+            """
+            incorrect state, can be one of the following: edition-confirmed, associated, approved or published
+            """
+
+    Scenario: PUT state transitions from publish_failed to published
+        Given private endpoints are enabled
+        And cloudflare is enabled
+        And I am an admin user
+        When I PUT "/datasets/static-dataset-retry-publish/editions/2026/versions/1/state"
+            """
+            {
+                "state": "published"
+            }
+            """
+        Then the HTTP status code should be "200"
+        And the total number of audit events should be 1
+        And the number of events with action "UPDATE" and resource "/datasets/static-dataset-retry-publish/editions/2026/versions/1/state" should be 1
+
+    Scenario: PUT state publish fails when a distribution file cannot be marked published and sets state to publish_failed
+        Given private endpoints are enabled
+        And I am an admin user
+        When I PUT "/datasets/static-dataset-publish-mark-fail/editions/2027/versions/1/state"
+            """
+            {
+                "state": "published"
+            }
+            """
+        Then the HTTP status code should be "500"
+        And I should receive the following response:
+            """
+            internal error: internal error
+            """
+        And the static version "static-version-publish-mark-fail" should have state "publish_failed"
 
     Scenario: PUT state transitions from approved to published and purges URL's
         Given I have a static dataset with version:

--- a/features/steps/dataset_component.go
+++ b/features/steps/dataset_component.go
@@ -300,6 +300,9 @@ func (c *DatasetComponent) DoGetFilesAPIClientOk(ctx context.Context, cfg *confi
 			return &filesAPIModels.StoredRegisteredMetaData{}, nil
 		},
 		MarkFilePublishedFunc: func(ctx context.Context, filePath string, headers filesAPISDK.Headers) error {
+			if filePath == "/fail/to/mark/published.csv" {
+				return fmt.Errorf("failed to mark file as published at path: %s", filePath)
+			}
 			return nil
 		},
 	}, nil

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -55,6 +55,7 @@ func (c *DatasetComponent) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the dataset "([^"]*)" should not exist$`, c.datasetShouldNotExist)
 	ctx.Step(`^the static version "([^"]*)" should exist$`, c.staticVersionShouldExist)
 	ctx.Step(`^the static version "([^"]*)" should not exist$`, c.staticVersionShouldNotExist)
+	ctx.Step(`^the static version "([^"]*)" should have state "([^"]*)"$`, c.staticVersionShouldHaveState)
 	ctx.Step(`^the response header "([^"]*)" should not be empty$`, c.theResponseHeaderShouldNotBeEmpty)
 	ctx.Step(`^the dataset "([^"]*)" should have next equal to current$`, c.theDatasetShouldHaveNextEqualToCurrent)
 	ctx.Step(`^the "([^"]*)" feature flag is "([^"]*)"$`, c.theFeatureFlagIs)
@@ -665,6 +666,22 @@ func (c *DatasetComponent) staticVersionShouldExist(versionID string) error {
 // staticVersionShouldNotExist checks the version document does not exist in the versions collection
 func (c *DatasetComponent) staticVersionShouldNotExist(versionID string) error {
 	return c.checkDocumentExistence(config.VersionsCollection, versionID, false)
+}
+
+// staticVersionShouldHaveState checks the state field for a version document in the versions collection
+func (c *DatasetComponent) staticVersionShouldHaveState(versionID, expectedState string) error {
+	collection := c.MongoClient.ActualCollectionName(config.VersionsCollection)
+	var got models.Version
+
+	if err := c.MongoClient.Connection.Collection(collection).FindOne(context.Background(), bson.M{"_id": versionID}, &got); err != nil {
+		return fmt.Errorf("failed to get static version from collection: %w", err)
+	}
+
+	if got.State != expectedState {
+		return fmt.Errorf("expected static version %q to have state %q but got %q", versionID, expectedState, got.State)
+	}
+
+	return nil
 }
 
 func (c *DatasetComponent) theDatasetShouldHaveNextEqualToCurrent(datasetID string) error {

--- a/models/state.go
+++ b/models/state.go
@@ -15,6 +15,7 @@ const (
 	AssociatedState       = "associated"
 	ApprovedState         = "approved"
 	PublishedState        = "published"
+	PublishFailedState    = "publish_failed"
 	DetachedState         = "detached"
 	FailedState           = "failed"
 )
@@ -24,6 +25,7 @@ var validVersionStates = map[string]int{
 	AssociatedState:       1,
 	ApprovedState:         1,
 	PublishedState:        1,
+	PublishFailedState:    1,
 }
 
 var validStates = map[string]int{
@@ -34,6 +36,7 @@ var validStates = map[string]int{
 	ApprovedState:         1,
 	AssociatedState:       1,
 	PublishedState:        1,
+	PublishFailedState:    1,
 	FailedState:           1,
 }
 

--- a/models/state_test.go
+++ b/models/state_test.go
@@ -24,6 +24,11 @@ func TestCheckState(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 
+		Convey("when the version has state of publish_failed", func() {
+			err := CheckState("version", PublishFailedState)
+			So(err, ShouldBeNil)
+		})
+
 		Convey("when a resource has state of created", func() {
 			err := CheckState("resource", CreatedState)
 			So(err, ShouldBeNil)
@@ -46,6 +51,11 @@ func TestCheckState(t *testing.T) {
 
 		Convey("when a resource has state of published", func() {
 			err := CheckState("resource", PublishedState)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("when a resource has state of publish_failed", func() {
+			err := CheckState("resource", PublishFailedState)
 			So(err, ShouldBeNil)
 		})
 	})

--- a/service/service.go
+++ b/service/service.go
@@ -98,7 +98,7 @@ func GetListStaticTransitions() []application.Transition {
 	publishedTransition := application.Transition{
 		Label:               "published",
 		TargetState:         application.Published,
-		AllowedSourceStates: []string{"approved"},
+		AllowedSourceStates: []string{"approved", "publish_failed"},
 		Type:                "static",
 	}
 
@@ -116,8 +116,15 @@ func GetListStaticTransitions() []application.Transition {
 		Type:                "static",
 	}
 
+	publishFailedTransition := application.Transition{
+		Label:               "publish_failed",
+		TargetState:         application.PublishFailed,
+		AllowedSourceStates: []string{"approved"},
+		Type:                "static",
+	}
+
 	return []application.Transition{publishedTransition,
-		associatedTransition, approvedTransition}
+		associatedTransition, approvedTransition, publishFailedTransition}
 }
 
 func GetListCantabularTransitions() []application.Transition {
@@ -174,7 +181,7 @@ func GetListMultivariateCantabularTransitions() []application.Transition {
 
 func GetStateMachine(ctx context.Context, dataStore store.DataStore) *application.StateMachine {
 	stateMachineInit.Do(func() {
-		states := []application.State{application.Published, application.EditionConfirmed, application.Associated}
+		states := []application.State{application.Published, application.EditionConfirmed, application.Associated, application.PublishFailed}
 		transitions := slices.Concat(GetListTransitions(), GetListCantabularTransitions(), GetListMultivariateCantabularTransitions(), GetListStaticTransitions())
 		stateMachine = application.NewStateMachine(ctx, states, transitions, dataStore)
 	})


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-5030

- Create new `publish_failed` state for static versions which fail to publish. Allowed state transitions are `approved -> failed_publish` and `failed_publish -> published`.
- There was another issue spotted where an unrecognised error from the files-api on filePublish would not be recorded so that has also been fixed.

### How to review

1. Create a dataset version and have it in the state `approved`
2. Go into the files database and change the path for your distribution to something else (remember the old value). This is to simulate a files-api error on publish
3. Try to publish the version. An error should be returned and the version document should be in the state `publish_failed`. Attempting the request multiple times should return the same error.
4. Go back into the files database and update the path for your distribution back to the correct value
5. Try to publish the version again and it should succeed with the new state being `published`

### Who can review

- Anyone
