### PR TITLE
Update latest version link in dataset following edition ID change

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -490,6 +490,7 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 
 					if err := api.dataStore.Backend.UpdateDataset(ctx, dataset.ID, datasetUpdate, dataset.Next.State); err != nil {
 						log.Error(ctx, "putVersion endpoint: failed to update dataset resource", err, data)
+						handleVersionAPIErr(ctx, err, w, data)
 						return
 					}
 				}

--- a/api/versions.go
+++ b/api/versions.go
@@ -475,6 +475,28 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 				if version.Edition != "" {
 					version.PreviousEditionId = append([]string{}, existingVersion.PreviousEditionId...)
 					version.PreviousEditionId = append(version.PreviousEditionId, existingVersion.Edition)
+
+					dataset, err := api.dataStore.Backend.GetDataset(ctx, version.DatasetID)
+					if err != nil {
+						handleVersionAPIErr(ctx, err, w, data)
+						return
+					}
+
+					latestVersionLink := &models.LinkObject{
+						HRef: fmt.Sprintf("/datasets/%s/editions/%s/versions/%s", dataset.ID, version.Edition, versionStr),
+						ID:   versionStr,
+					}
+
+					datasetUpdate := &models.Dataset{
+						Links: &models.DatasetLinks{
+							LatestVersion: latestVersionLink,
+						},
+					}
+
+					if err := api.dataStore.Backend.UpdateDataset(ctx, dataset.ID, datasetUpdate, dataset.Next.State); err != nil {
+						log.Error(ctx, "putVersion endpoint: failed to update dataset resource", err, data)
+						return
+					}
 				}
 			}
 

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -1183,6 +1183,15 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 					ETag:        testETag,
 				}, nil
 			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{
+					ID: "123",
+					Next: &models.Dataset{
+						Links: &models.DatasetLinks{},
+						State: models.CreatedState,
+					},
+				}, nil
+			},
 			UpdateVersionFunc: func(context.Context, *models.Version, *models.Version, string) (string, error) {
 				So(isLocked, ShouldBeTrue)
 				return "", nil
@@ -1227,6 +1236,7 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 				So(len(mockedDataStore.SetInstanceIsPublishedCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpsertDatasetCalls()), ShouldEqual, 0)
 				So(len(mockedDataStore.UpdateDatasetWithAssociationCalls()), ShouldEqual, 0)
+				So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 0)
 				So(len(generatorMock.GenerateCalls()), ShouldEqual, 0)
 				So(auditServiceMock.RecordVersionAuditEventCalls(), ShouldHaveLength, 1)
 			})
@@ -1493,6 +1503,18 @@ func TestPutVersionReturnsSuccessfully(t *testing.T) {
 					EditionTitle: "Test Title",
 					State:        models.EditionConfirmedState,
 				}, nil
+			},
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{
+					ID: "123",
+					Next: &models.Dataset{
+						Links: &models.DatasetLinks{},
+						State: models.CreatedState,
+					},
+				}, nil
+			},
+			UpdateDatasetFunc: func(ctx context.Context, ID string, dataset *models.Dataset, currentState string) error {
+				return nil
 			},
 		}
 
@@ -5556,6 +5578,9 @@ func TestPutVersionSavesPreviousEditionID(t *testing.T) {
 				capturedVersionUpdate = versionUpdate
 				return testETag, nil
 			},
+			UpdateDatasetFunc: func(ctx context.Context, ID string, dataset *models.Dataset, currentState string) error {
+				return nil
+			},
 			AcquireVersionsLockFunc: func(context.Context, string) (string, error) {
 				return testLockID, nil
 			},
@@ -5728,6 +5753,9 @@ func TestPutVersionSavesPreviousEditionID(t *testing.T) {
 			},
 			GetVersionFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
 				return &models.Version{Type: models.Static.String()}, nil
+			},
+			UpdateDatasetFunc: func(ctx context.Context, ID string, dataset *models.Dataset, currentState string) error {
+				return nil
 			},
 			UpdateVersionStaticFunc: func(ctx context.Context, currentVersion *models.Version, versionUpdate *models.Version, eTagSelector string) (string, error) {
 				capturedVersionUpdate = versionUpdate

--- a/features/compose/dp-dataset-api.yml
+++ b/features/compose/dp-dataset-api.yml
@@ -11,6 +11,8 @@ services:
       - -race
       - -coverpkg=github.com/ONSdigital/dp-dataset-api/...
       - -component
+      - -test.run=TestComponent/PUT_succeeds_when_distributions_contain_valid_formats
+      - features/static_versions_put.feature
     volumes:
       - ../../:/dp-dataset-api
       - /var/run/docker.sock:/var/run/docker.sock

--- a/features/compose/dp-dataset-api.yml
+++ b/features/compose/dp-dataset-api.yml
@@ -11,8 +11,6 @@ services:
       - -race
       - -coverpkg=github.com/ONSdigital/dp-dataset-api/...
       - -component
-      - -test.run=TestComponent/PUT_succeeds_when_distributions_contain_valid_formats
-      - features/static_versions_put.feature
     volumes:
       - ../../:/dp-dataset-api
       - /var/run/docker.sock:/var/run/docker.sock

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -862,8 +862,8 @@ Feature: Static Dataset Versions PUT API
                 "quality_designation": "accredited-official",
                 "release_date": "2025-03-06T14:49:23.354Z",
                 "type": "static",
-                "edition": "march",
-                "dataset_id": "test-static-dataset",
+                "edition": "2025",
+                "dataset_id": "static-dataset-update",
                 "usage_notes": [
                     {
                         "title": "This dataset",

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -1100,7 +1100,7 @@ Feature: Static Dataset Versions PUT API
             }
             """
 
-    Scenario: PUT updates static version edition ID and updates webpage link and dataset latest version link
+    Scenario: PUT successfully updates edition ID and all associated links
       Given I have a static dataset with version:
           """
           {

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -696,7 +696,7 @@ Feature: Static Dataset Versions PUT API
     Scenario: PUT succeeds when distributions contain valid formats
         Given private endpoints are enabled
         And I am an admin user
-        When I PUT "/datasets/static-dataset-update/editions/2026/versions/1"
+        When I PUT "/datasets/static-dataset-update/editions/2025/versions/1"
             """
             {
                 "distributions": [
@@ -954,7 +954,7 @@ Feature: Static Dataset Versions PUT API
           {
               "dataset": {
                   "id": "edition-change-dataset",
-                  "title": "Change topic in version link test",
+                  "title": "Change edition in version link test",
                   "state": "associated",
                   "type": "static",
                   "topics": [
@@ -1055,27 +1055,35 @@ Feature: Static Dataset Versions PUT API
           """
         And I GET "/datasets/edition-change-dataset"
         Then I should receive the following JSON response with status "200":
-            """
+             """
             {
+              "id": "edition-change-dataset",
+              "current": {
                 "id": "edition-change-dataset",
-                "title": "Change topic in version link test",
+                "last_updated": "0001-01-01T00:00:00Z",
                 "state": "associated",
-                "type": "static",
+                "title": "Change edition in version link test",
                 "topics": [
-                    "businessindustryandtrade-topic-id"
+                  "businessindustryandtrade-topic-id"
                 ],
+                "type": "static"
+              },
+              "next": {
+                "id": "edition-change-dataset",
+                "last_updated": "0001-01-01T00:00:00Z",
                 "links": {
-                    "editions": {
-                        "href": "/datasets/edition-change-dataset/editions"
-                    },
-                    "latest_version": {
-                        "href": "/datasets/edition-change-dataset/editions/2026-update/versions/1",
-                        "id: "1"
-                    },
-                    "self": {
-                        "href": "/datasets/edition-change-dataset"
-                    }
-                }
+                  "latest_version": {
+                    "href": "/datasets/edition-change-dataset/editions/2026-update/versions/1",
+                    "id": "1"
+                  }
+                },
+                "state": "associated",
+                "title": "Change edition in version link test",
+                "topics": [
+                  "businessindustryandtrade-topic-id"
+                ],
+                "type": "static"
+              }
             }
             """
 

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -696,7 +696,7 @@ Feature: Static Dataset Versions PUT API
     Scenario: PUT succeeds when distributions contain valid formats
         Given private endpoints are enabled
         And I am an admin user
-        When I PUT "/datasets/static-dataset-update/editions/2025/versions/1"
+        When I PUT "/datasets/static-dataset-update/editions/2026/versions/1"
             """
             {
                 "distributions": [
@@ -1069,7 +1069,8 @@ Feature: Static Dataset Versions PUT API
                         "href": "/datasets/edition-change-dataset/editions"
                     },
                     "latest_version": {
-                        "href": "/datasets/edition-change-dataset/editions/2026-update/versions/1"
+                        "href": "/datasets/edition-change-dataset/editions/2026-update/versions/1",
+                        "id: "1"
                     },
                     "self": {
                         "href": "/datasets/edition-change-dataset"

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -948,7 +948,7 @@ Feature: Static Dataset Versions PUT API
             }
             """
 
-    Scenario: PUT updates static version edition ID and updates webpage link
+    Scenario: PUT updates static version edition ID and updates webpage link and dataset latest version link
       Given I have a static dataset with version:
           """
           {
@@ -1053,6 +1053,30 @@ Feature: Static Dataset Versions PUT API
               "type": "static"
           }
           """
+        And I GET "/datasets/edition-change-dataset"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "id": "edition-change-dataset",
+                "title": "Change topic in version link test",
+                "state": "associated",
+                "type": "static",
+                "topics": [
+                    "businessindustryandtrade-topic-id"
+                ],
+                "links": {
+                    "editions": {
+                        "href": "/datasets/edition-change-dataset/editions"
+                    },
+                    "latest_version": {
+                        "href": "/datasets/edition-change-dataset/editions/2026-update/versions/1"
+                    },
+                    "self": {
+                        "href": "/datasets/edition-change-dataset"
+                    }
+                }
+            }
+            """
 
     Scenario: PUT updates static dataset version edition and saves previous edition ID
         Given I have a static dataset with version:

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -1205,39 +1205,7 @@ Feature: Static Dataset Versions PUT API
               "type": "static"
           }
           """
-        And I GET "/datasets/edition-change-dataset"
-        Then I should receive the following JSON response with status "200":
-             """
-            {
-              "id": "edition-change-dataset",
-              "current": {
-                "id": "edition-change-dataset",
-                "last_updated": "0001-01-01T00:00:00Z",
-                "state": "associated",
-                "title": "Change edition in version link test",
-                "topics": [
-                  "businessindustryandtrade-topic-id"
-                ],
-                "type": "static"
-              },
-              "next": {
-                "id": "edition-change-dataset",
-                "last_updated": "0001-01-01T00:00:00Z",
-                "links": {
-                  "latest_version": {
-                    "href": "/datasets/edition-change-dataset/editions/2026-update/versions/1",
-                    "id": "1"
-                  }
-                },
-                "state": "associated",
-                "title": "Change edition in version link test",
-                "topics": [
-                  "businessindustryandtrade-topic-id"
-                ],
-                "type": "static"
-              }
-            }
-            """
+        And the dataset "edition-change-dataset" should have latest_version href "/datasets/edition-change-dataset/editions/2026-update/versions/1"
 
     Scenario: PUT updates static dataset version edition and saves previous edition ID
         Given I have a static dataset with version:

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -406,6 +406,9 @@ func createDatasetUpdateQuery(ctx context.Context, id string, dataset *models.Da
 			if dataset.Links.LatestVersion.HRef != "" {
 				updates["next.links.latest_version.href"] = dataset.Links.LatestVersion.HRef
 			}
+			if dataset.Links.LatestVersion.ID != "" {
+				updates["next.links.latest_version.id"] = dataset.Links.LatestVersion.ID
+			}
 		}
 	}
 

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -401,6 +401,12 @@ func createDatasetUpdateQuery(ctx context.Context, id string, dataset *models.Da
 				updates["next.links.taxonomy.href"] = dataset.Links.Taxonomy.HRef
 			}
 		}
+
+		if dataset.Links.LatestVersion != nil {
+			if dataset.Links.LatestVersion.HRef != "" {
+				updates["next.links.latest_version.href"] = dataset.Links.LatestVersion.HRef
+			}
+		}
 	}
 
 	if dataset.Methodologies != nil {


### PR DESCRIPTION
### What
[Jira Link](https://officefornationalstatistics.atlassian.net/browse/DIS-4981?atlOrigin=eyJpIjoiMDBhYTg1MWU0YjdlNDU0MjhmMmRlOGQ2NzZjYzMxOWMiLCJwIjoiaiJ9)
When an edition ID is updated via a PUT to `/datasets/<dataset>/editions/<edition>/version/<version>` the latest version link in the dataset entry is not updated, so when a GET is done to `/datasets/dataset` the information is out of date.
### How to review
Bring up the dataset catalogue stack and insert data for a dataset/edition/version.
Do a PUT to `/datasets/<your-dataset>/editions/<your-edition>/version/<version>` updating the edition ID.
Do a GET to `/datasets/<your-dataset` and check that the latest version link still contains the old edition ID.

Refresh the dataset-api in your stack with this branch.
Do another PUT to `/datasets/<your-dataset>/editions/<your-edition>/version/<version>` updating the edition ID.
Do another GET to `/datasets/<your-dataset` and check that the latest version link has been updated to show the new edition ID.
### Who can review

Anyone.
