### PR TITLE
Feature/allow dataset id changes

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -44,9 +44,10 @@ var (
 
 	// errors that should return a 409 status
 	datasetsConflict = map[error]bool{
-		errs.ErrAddDatasetAlreadyExists:      true,
-		errs.ErrAddDatasetTitleAlreadyExists: true,
-		errs.ErrPublishedDatasetTopicChange:  true,
+		errs.ErrCannotChangeIDForPublishedDataset: true,
+		errs.ErrAddDatasetAlreadyExists:           true,
+		errs.ErrAddDatasetTitleAlreadyExists:      true,
+		errs.ErrPublishedDatasetTopicChange:       true,
 	}
 )
 
@@ -563,90 +564,139 @@ func (api *DatasetAPI) putDataset(w http.ResponseWriter, r *http.Request) {
 
 		dataset.Type = currentDataset.Next.Type
 
-		if dataset.Type == models.Static.String() && dataset.ID != "" {
-			if err := utils.ValidateIDNoSpaces(dataset.ID); err != nil {
-				log.Error(ctx, "putDataset endpoint: dataset ID in request body contains spaces", err, data)
-				return nil, err
-			}
-		}
 		models.CleanDataset(dataset)
-
 		if err = models.ValidateDataset(dataset); err != nil {
 			log.Error(ctx, "putDataset endpoint: failed validation check to update dataset", err, data)
 			return nil, err
 		}
 
 		if dataset.Type == models.Static.String() {
-			datasetTitleExists, err := api.dataStore.Backend.CheckDatasetTitleExist(ctx, dataset.Title)
-			if err != nil {
-				log.Error(ctx, "putDataset endpoint: error checking if dataset title exists", err, data)
+			if err := utils.ValidateIDNoSpaces(dataset.ID); err != nil {
+				log.Error(ctx, "putDataset endpoint: dataset ID in request body contains spaces", err, data)
 				return nil, err
 			}
 
-			if datasetTitleExists && dataset.Title != currentDataset.Next.Title {
-				log.Error(ctx, "putDataset endpoint: unable to update a dataset with title that already exists", errs.ErrAddDatasetTitleAlreadyExists, data)
-				return nil, errs.ErrAddDatasetTitleAlreadyExists
+			if dataset.Title != currentDataset.Next.Title {
+				datasetTitleExists, err := api.dataStore.Backend.CheckDatasetTitleExist(ctx, dataset.Title)
+				if err != nil {
+					log.Error(ctx, "putDataset endpoint: error checking if dataset title exists", err, data)
+					return nil, err
+				}
+
+				if datasetTitleExists {
+					log.Error(ctx, "putDataset endpoint: dataset title already exists in another dataset", errs.ErrAddDatasetTitleAlreadyExists, data)
+					return nil, errs.ErrAddDatasetTitleAlreadyExists
+				}
 			}
 
-			if currentDataset.Current != nil && currentDataset.Current.State == models.PublishedState &&
-				len(currentDataset.Current.Topics) > 0 && len(dataset.Topics) > 0 &&
-				currentDataset.Current.Topics[0] != dataset.Topics[0] {
+			isPublished := currentDataset.Current != nil && currentDataset.Current.State == models.PublishedState
+
+			canonicalTopic := currentDataset.Next.Topics[0]
+			if isPublished {
+				canonicalTopic = currentDataset.Current.Topics[0]
+			}
+
+			isCanonicalTopicChanged := dataset.Topics[0] != canonicalTopic
+			isIDChanged := dataset.ID != currentDataset.ID
+
+			if isPublished && isCanonicalTopicChanged {
 				log.Error(ctx, "putDataset endpoint: unable to update canonical topic of a published dataset", errs.ErrPublishedDatasetTopicChange, data)
 				return nil, errs.ErrPublishedDatasetTopicChange
 			}
 
-			if currentDataset.Next != nil && currentDataset.Current == nil && currentDataset.Next.State != models.PublishedState {
-				if len(currentDataset.Next.Topics) > 0 && len(dataset.Topics) > 0 && currentDataset.Next.Topics[0] != dataset.Topics[0] {
-					state := ""
-					versions, _, err := api.dataStore.Backend.GetAllStaticVersions(ctx, datasetID, state, 0, 100)
-					if err != nil {
-						log.Error(ctx, "putDataset endpoint: error getting versions for dataset", err, data)
-						return nil, err
-					}
+			if isPublished && isIDChanged {
+				log.Error(ctx, "putDataset endpoint: unable to update ID of a published dataset", errs.ErrCannotChangeIDForPublishedDataset, data)
+				return nil, errs.ErrCannotChangeIDForPublishedDataset
+			}
 
-					if len(versions) != 0 {
+			if !isPublished && isIDChanged {
+				err := api.dataStore.Backend.CheckDatasetExists(ctx, dataset.ID, "")
+				if err == nil {
+					log.Error(ctx, "putDataset endpoint: dataset with this ID already exists", errs.ErrAddDatasetAlreadyExists, data)
+					return nil, errs.ErrAddDatasetAlreadyExists
+				}
+				if err != errs.ErrDatasetNotFound {
+					log.Error(ctx, "putDataset endpoint: error checking if dataset with this ID already exists", err, data)
+					return nil, err
+				}
+			}
+
+			if !isPublished && (isCanonicalTopicChanged || isIDChanged) {
+				versions, _, err := api.dataStore.Backend.GetVersionsStaticNoLimit(ctx, datasetID, "")
+				if err != nil && err != errs.ErrVersionsNotFound {
+					log.Error(ctx, "putDataset endpoint: error getting versions for dataset", err, data)
+					return nil, err
+				}
+
+				if len(versions) > 0 {
+					topicSlug := ""
+					if isCanonicalTopicChanged {
 						topicSDKHeaders := topicAPISDK.Headers{
 							ServiceAuthToken: fetchAccessTokenFromHeader(r),
 						}
 						topic, err := api.topicAPIClient.GetTopicPrivate(ctx, topicSDKHeaders, dataset.Topics[0])
 						if err != nil {
-							log.Error(ctx, "putVersion endpoint: failed to get topic from Topic API", err, data)
+							log.Error(ctx, "putDataset endpoint: failed to get topic from Topic API", err, data)
 							return nil, err
 						}
-						for vCount := range versions {
-							currentVersion := versions[vCount]
-							updatedVersion := new(models.Version)
-							*updatedVersion = *versions[vCount]
+						topicSlug = topic.Current.Slug
+					} else {
+						topicSlug = strings.Split(strings.TrimPrefix(versions[0].Links.WebPage.HRef, "/"), "/")[0]
+					}
 
-							if updatedVersion.Links == nil {
-								updatedVersion.Links = &models.VersionLinks{}
-							}
-							if updatedVersion.Links.WebPage == nil {
-								updatedVersion.Links.WebPage = &models.LinkObject{}
-							}
+					for i := range versions {
+						currentVersion := versions[i]
+						updatedVersion := *currentVersion
+						updatedVersion.Links = models.GenerateVersionLinksStatic(topicSlug, dataset.ID, updatedVersion.Edition, updatedVersion.Version)
 
-							updatedVersion.Links.WebPage.HRef = fmt.Sprintf(
-								"%s/datasets/%s/editions/%s/versions/%d",
-								topic.Current.Slug,
-								datasetID,
-								currentVersion.Edition,
-								currentVersion.Version,
-							)
-
-							_, err := api.dataStore.Backend.UpdateVersionStatic(ctx, currentVersion, updatedVersion, currentVersion.ETag)
-							if err != nil {
-								log.Error(ctx, "putDataset endpoint: failed to update version", err, data)
-								return nil, err
-							}
+						_, err := api.dataStore.Backend.UpdateVersionStatic(ctx, currentVersion, &updatedVersion, currentVersion.ETag)
+						if err != nil {
+							log.Error(ctx, "putDataset endpoint: failed to update version", err, data)
+							return nil, err
 						}
 					}
 				}
+			}
+
+			if isIDChanged {
+				updatedLinks := &models.DatasetLinks{
+					Editions: &models.LinkObject{
+						HRef: fmt.Sprintf("/datasets/%s/editions", dataset.ID),
+					},
+					Self: &models.LinkObject{
+						HRef: fmt.Sprintf("/datasets/%s", dataset.ID),
+					},
+				}
+
+				if dataset.Links != nil && dataset.Links.LatestVersion != nil {
+					updatedLinks.LatestVersion = &models.LinkObject{
+						ID:   dataset.Links.LatestVersion.ID,
+						HRef: strings.ReplaceAll(dataset.Links.LatestVersion.HRef, fmt.Sprintf("/datasets/%s/", datasetID), fmt.Sprintf("/datasets/%s/", dataset.ID)),
+					}
+				}
+
+				dataset.Links = updatedLinks
 			}
 		}
 
 		if dataset.State == models.PublishedState {
 			if err := api.publishDataset(ctx, currentDataset, nil); err != nil {
 				log.Error(ctx, "putDataset endpoint: failed to update dataset document to published", err, data)
+				return nil, err
+			}
+		} else if dataset.Type == models.Static.String() && dataset.ID != currentDataset.ID {
+			renamedDatasetUpdate := &models.DatasetUpdate{
+				ID:   dataset.ID,
+				Next: dataset,
+			}
+
+			if err := api.dataStore.Backend.UpsertDataset(ctx, dataset.ID, renamedDatasetUpdate); err != nil {
+				log.Error(ctx, "putDataset endpoint: failed to upsert renamed dataset", err, data)
+				return nil, err
+			}
+
+			if err := api.dataStore.Backend.DeleteDataset(ctx, datasetID); err != nil {
+				log.Error(ctx, "putDataset endpoint: failed to delete old dataset document after renaming", err, data)
 				return nil, err
 			}
 		} else {

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -1729,7 +1729,12 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
-				return &models.DatasetUpdate{Next: &models.Dataset{Type: "static"}}, nil
+				return &models.DatasetUpdate{
+					ID: "123",
+					Next: &models.Dataset{
+						Type:   models.Static.String(),
+						Topics: []string{"topic-0"},
+					}}, nil
 			},
 			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
 				return false, nil
@@ -1786,7 +1791,12 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
-				return &models.DatasetUpdate{Next: &models.Dataset{Type: "static"}}, nil
+				return &models.DatasetUpdate{
+					ID: "123",
+					Next: &models.Dataset{
+						Type:   models.Static.String(),
+						Topics: []string{"topic-0"},
+					}}, nil
 			},
 			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
 				return false, nil
@@ -1895,7 +1905,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
-				return &models.DatasetUpdate{Next: &models.Dataset{Type: "static", Topics: []string{"topic-0", "topic-1"}}}, nil
+				return &models.DatasetUpdate{ID: "123", Next: &models.Dataset{Type: "static", Topics: []string{"topic-0", "topic-1"}}}, nil
 			},
 			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
 				return false, nil
@@ -1946,6 +1956,56 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		})
 	})
 
+	Convey("A successful request to rename an unpublished static dataset returns 200 OK response", t, func() {
+		b := `{"id":"456","contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"census","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"CensusEthnicity","theme":"population","state":"completed","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","href":"https://www.ons.gov.uk/"},"type":"static","keywords":["keyword","keyword 2"],"topics":["topic-0","topic-1"],"license":"Open Government Licence v3.0"}`
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{ID: "123", Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"topic-0", "topic-1"}}}, nil
+			},
+			CheckDatasetExistsFunc: func(ctx context.Context, id, state string) error {
+				return errs.ErrDatasetNotFound
+			},
+			GetVersionsStaticNoLimitFunc: func(ctx context.Context, datasetID, state string) ([]*models.Version, int, error) {
+				return []*models.Version{}, 0, errs.ErrVersionsNotFound
+			},
+			UpsertDatasetFunc: func(context.Context, string, *models.DatasetUpdate) error {
+				return nil
+			},
+			DeleteDatasetFunc: func(context.Context, string) error {
+				return nil
+			},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return testEntityData, nil
+			},
+		}
+
+		auditServiceMock := &applicationMocks.AuditServiceMock{
+			RecordDatasetAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, dataset *models.Dataset) error {
+				return nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, application.SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock, &applicationMocks.StaticDatasetServiceMock{}, nil, &filesAPISDKMocks.ClienterMock{})
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusOK)
+		So(mockedDataStore.GetDatasetCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.CheckDatasetExistsCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.GetVersionsStaticNoLimitCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.DeleteDatasetCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 0)
+	})
+
 	Convey("A successful request to put static dataset with canonical topic change updates version web_page links", t, func() {
 		b := datasetPayloadWithTypeStatic
 		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
@@ -1955,12 +2015,12 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
-				return &models.DatasetUpdate{Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"old-topic", "topic-1"}}}, nil
+				return &models.DatasetUpdate{ID: "123", Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"old-topic", "topic-1"}}}, nil
 			},
 			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
 				return false, nil
 			},
-			GetAllStaticVersionsFunc: func(ctx context.Context, datasetID, state string, offset, limit int) ([]*models.Version, int, error) {
+			GetVersionsStaticNoLimitFunc: func(ctx context.Context, datasetID, state string) ([]*models.Version, int, error) {
 				return []*models.Version{{
 					Edition: "2025",
 					Version: 1,
@@ -2004,7 +2064,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(updatedWebPageHref, ShouldEqual, "businessindustryandtrade/datasets/123/editions/2025/versions/1")
-		So(mockedDataStore.GetAllStaticVersionsCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.GetVersionsStaticNoLimitCalls(), ShouldHaveLength, 1)
 		So(mockedDataStore.UpdateVersionStaticCalls(), ShouldHaveLength, 1)
 		So(topicAPIMock.GetTopicPrivateCalls(), ShouldHaveLength, 1)
 	})
@@ -2016,7 +2076,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
-				return &models.DatasetUpdate{Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"topic-0", "topic-1"}}}, nil
+				return &models.DatasetUpdate{ID: "123", Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"topic-0", "topic-1"}}}, nil
 			},
 			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
 				return false, nil
@@ -2058,6 +2118,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
 				// Current is non-nil so the unpublished topic-change branch is skipped
 				return &models.DatasetUpdate{
+					ID:      "123",
 					Current: &models.Dataset{Type: models.Static.String(), State: models.PublishedState, Topics: []string{"old-topic", "topic-1"}},
 					Next:    &models.Dataset{Type: models.Static.String(), State: models.PublishedState, Topics: []string{"old-topic", "topic-1"}},
 				}, nil
@@ -2101,13 +2162,13 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
-				return &models.DatasetUpdate{Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"old-topic", "topic-1"}}}, nil
+				return &models.DatasetUpdate{ID: "123", Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"old-topic", "topic-1"}}}, nil
 			},
 			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
 				return false, nil
 			},
-			GetAllStaticVersionsFunc: func(ctx context.Context, datasetID, state string, offset, limit int) ([]*models.Version, int, error) {
-				return []*models.Version{}, 0, nil
+			GetVersionsStaticNoLimitFunc: func(ctx context.Context, datasetID, state string) ([]*models.Version, int, error) {
+				return []*models.Version{}, 0, errs.ErrVersionsNotFound
 			},
 			UpdateDatasetFunc: func(context.Context, string, *models.Dataset, string) error {
 				return nil
@@ -2140,24 +2201,24 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusOK)
-		So(mockedDataStore.GetAllStaticVersionsCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.GetVersionsStaticNoLimitCalls(), ShouldHaveLength, 1)
 		So(mockedDataStore.UpdateVersionStaticCalls(), ShouldHaveLength, 0)
 		So(topicAPIMock.GetTopicPrivateCalls(), ShouldHaveLength, 0)
 	})
 
-	Convey("When put static dataset topic changes and GetAllStaticVersions returns error, 500 is returned", t, func() {
+	Convey("When put static dataset topic changes and GetVersionsStaticNoLimit returns error, 500 is returned", t, func() {
 		b := datasetPayloadWithTypeStatic // topics ["topic-0","topic-1"]
 		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 		w := httptest.NewRecorder()
 
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
-				return &models.DatasetUpdate{Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"old-topic", "topic-1"}}}, nil
+				return &models.DatasetUpdate{ID: "123", Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"old-topic", "topic-1"}}}, nil
 			},
 			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
 				return false, nil
 			},
-			GetAllStaticVersionsFunc: func(ctx context.Context, datasetID, state string, offset, limit int) ([]*models.Version, int, error) {
+			GetVersionsStaticNoLimitFunc: func(ctx context.Context, datasetID, state string) ([]*models.Version, int, error) {
 				return nil, 0, errors.New("versions store error")
 			},
 		}
@@ -2188,7 +2249,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		api.Router.ServeHTTP(w, r)
 
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		So(mockedDataStore.GetAllStaticVersionsCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.GetVersionsStaticNoLimitCalls(), ShouldHaveLength, 1)
 		So(mockedDataStore.UpdateVersionStaticCalls(), ShouldHaveLength, 0)
 	})
 
@@ -2199,12 +2260,12 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
-				return &models.DatasetUpdate{Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"old-topic", "topic-1"}}}, nil
+				return &models.DatasetUpdate{ID: "123", Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"old-topic", "topic-1"}}}, nil
 			},
 			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
 				return false, nil
 			},
-			GetAllStaticVersionsFunc: func(ctx context.Context, datasetID, state string, offset, limit int) ([]*models.Version, int, error) {
+			GetVersionsStaticNoLimitFunc: func(ctx context.Context, datasetID, state string) ([]*models.Version, int, error) {
 				return []*models.Version{{Edition: "2025", Version: 1, ETag: "e1", Links: &models.VersionLinks{WebPage: &models.LinkObject{HRef: "/old"}}}}, 1, nil
 			},
 		}
@@ -2246,12 +2307,12 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
-				return &models.DatasetUpdate{Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"old-topic", "topic-1"}}}, nil
+				return &models.DatasetUpdate{ID: "123", Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"old-topic", "topic-1"}}}, nil
 			},
 			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
 				return false, nil
 			},
-			GetAllStaticVersionsFunc: func(ctx context.Context, datasetID, state string, offset, limit int) ([]*models.Version, int, error) {
+			GetVersionsStaticNoLimitFunc: func(ctx context.Context, datasetID, state string) ([]*models.Version, int, error) {
 				return []*models.Version{{Edition: "2025", Version: 1, ETag: "e1", Links: &models.VersionLinks{WebPage: &models.LinkObject{HRef: "/old"}}}}, 1, nil
 			},
 			UpdateVersionStaticFunc: func(ctx context.Context, currentVersion *models.Version, versionUpdate *models.Version, eTagSelector string) (string, error) {
@@ -2962,7 +3023,7 @@ func TestPutDatasetReturnsError(t *testing.T) {
 				return &models.DatasetUpdate{
 					ID:      "123",
 					Current: &models.Dataset{Type: models.Static.String(), State: models.PublishedState, Topics: []string{"topic-change", "topic-1"}},
-					Next:    &models.Dataset{Type: models.Static.String(), Title: "StaticPublished"},
+					Next:    &models.Dataset{Type: models.Static.String(), Title: "StaticPublished", Topics: []string{"topic-0", "topic-1"}},
 				}, nil
 			},
 			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
@@ -2989,13 +3050,85 @@ func TestPutDatasetReturnsError(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusConflict)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.CheckDatasetTitleExistCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.UpdateDatasetCalls()), ShouldEqual, 0)
 
 		Convey("then the request body has been drained", func() {
 			_, err := r.Body.Read(make([]byte, 1))
 			So(err, ShouldEqual, io.EOF)
 		})
+	})
+
+	Convey("When PUT static published dataset calls trying to change id returns 409 response", t, func() {
+		b := `{"id":"456","contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"static-published","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"StaticPublished","theme":"population","state":"published","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","href":"https://www.ons.gov.uk/"},"type":"static","keywords":["keyword","keyword 2"],"topics":["topic-0","topic-1"],"license":"Open Government Licence v3.0"}`
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{
+					ID:      "123",
+					Current: &models.Dataset{Type: models.Static.String(), State: models.PublishedState, Topics: []string{"topic-0", "topic-1"}},
+					Next:    &models.Dataset{Type: models.Static.String(), Title: "StaticPublished", Topics: []string{"topic-0", "topic-1"}},
+				}, nil
+			},
+			CheckDatasetTitleExistFunc: func(ctx context.Context, title string) (bool, error) {
+				return false, nil
+			},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return testEntityData, nil
+			},
+		}
+
+		auditServiceMock := &applicationMocks.AuditServiceMock{}
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, application.SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock, &applicationMocks.StaticDatasetServiceMock{}, nil, &filesAPISDKMocks.ClienterMock{})
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusConflict)
+		So(mockedDataStore.GetDatasetCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 0)
+		So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 0)
+		So(mockedDataStore.DeleteDatasetCalls(), ShouldHaveLength, 0)
+	})
+
+	Convey("When PUT static unpublished dataset calls trying to change id to an existing one returns 409 response", t, func() {
+		b := `{"id":"456","contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"census","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"CensusEthnicity","theme":"population","state":"completed","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","href":"https://www.ons.gov.uk/"},"type":"static","keywords":["keyword","keyword 2"],"topics":["topic-0","topic-1"],"license":"Open Government Licence v3.0"}`
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
+
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{ID: "123", Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"topic-0", "topic-1"}}}, nil
+			},
+			CheckDatasetExistsFunc: func(ctx context.Context, id, state string) error {
+				return nil
+			},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return testEntityData, nil
+			},
+		}
+
+		auditServiceMock := &applicationMocks.AuditServiceMock{}
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, application.SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock, &applicationMocks.StaticDatasetServiceMock{}, nil, &filesAPISDKMocks.ClienterMock{})
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusConflict)
+		So(mockedDataStore.GetDatasetCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.CheckDatasetExistsCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 0)
+		So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 0)
+		So(mockedDataStore.DeleteDatasetCalls(), ShouldHaveLength, 0)
 	})
 }
 

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -57,6 +57,7 @@ var (
 	ErrEditionTitleAlreadyExists          = errors.New("the edition-title already exists")
 	ErrInvalidDatasetTypeForEditionUpdate = errors.New("unable to update edition-id, invalid dataset type")
 	ErrSpacesNotAllowedInID               = errors.New("spaces are not allowed in the ID field")
+	ErrCannotChangeIDForPublishedDataset  = errors.New("cannot change the dataset ID for a published dataset")
 	ErrFileMetadataNotFound               = errors.New("file metadata not found")
 	ErrFileNotInCorrectState              = errors.New("file not in correct state")
 	ErrInvalidParamCombination            = errors.New("cannot request state and published parameters at the same time")
@@ -100,11 +101,13 @@ var (
 	}
 
 	ConflictRequestMap = map[error]bool{
-		ErrConflictUpdatingInstance:  true,
-		ErrInstanceConflict:          true,
-		ErrEditionAlreadyExists:      true,
-		ErrEditionTitleAlreadyExists: true,
-		ErrFileNotInCorrectState:     true,
+		ErrAddDatasetAlreadyExists:           true,
+		ErrCannotChangeIDForPublishedDataset: true,
+		ErrConflictUpdatingInstance:          true,
+		ErrInstanceConflict:                  true,
+		ErrEditionAlreadyExists:              true,
+		ErrEditionTitleAlreadyExists:         true,
+		ErrFileNotInCorrectState:             true,
 	}
 
 	ForbiddenMap = map[error]bool{

--- a/features/private_datasets.feature
+++ b/features/private_datasets.feature
@@ -805,7 +805,13 @@ Feature: Private Dataset API
             """
             {
                 "id": "test dataset id with spaces",
-                "type": "static"
+                "title": "Valid Dataset",
+                "description": "Dataset description",
+                "license": "Open Government Licence v3.0",
+                "next_release": "2026-01-01",
+                "keywords": ["keyword"],
+                "topics": ["topic-0"],
+                "contacts": [{"name": "Test", "email": "test@test.com"}]
             }
             """
         Then the HTTP status code should be "400"

--- a/features/static_dataset_put.feature
+++ b/features/static_dataset_put.feature
@@ -1,0 +1,277 @@
+Feature: PUT /datasets/{id} for static datasets
+
+    Background:
+        Given private endpoints are enabled
+        And I am an admin user
+        And I have realistic datasets:
+            """
+            [
+                {
+                    "next": {
+                        "id": "old-dataset-id",
+                        "type": "static",
+                        "title": "Original Title",
+                        "description": "A static dataset",
+                        "state": "created",
+                        "topics": [
+                            "old-topic",
+                            "topic-1"
+                        ]
+                    }
+                },
+                {
+                    "next": {
+                        "id": "existing-dataset-id",
+                        "type": "static",
+                        "title": "Existing Dataset",
+                        "description": "An existing dataset",
+                        "state": "created",
+                        "topics": [
+                            "topic-2",
+                            "topic-3"
+                        ]
+                    }
+                },
+                {
+                    "current": {
+                        "id": "published-dataset-id",
+                        "state": "published",
+                        "type": "static",
+                        "title": "Published Dataset",
+                        "topics": [
+                            "old-topic",
+                            "topic-1"
+                        ]
+                    },
+                    "next": {
+                        "id": "published-dataset-id",
+                        "state": "published",
+                        "type": "static",
+                        "title": "Published Dataset",
+                        "topics": [
+                            "old-topic",
+                            "topic-1"
+                        ]
+                    }
+                }
+            ]
+            """
+        And I have these static versions:
+            """
+            [
+                {
+                    "id": "version-1",
+                    "edition": "2025",
+                    "edition_title": "2025 Edition",
+                    "version": 1,
+                    "release_date": "2025-01-01T00:00:00Z",
+                    "state": "associated",
+                    "type": "static",
+                    "links": {
+                        "dataset": {
+                            "id": "old-dataset-id"
+                        },
+                        "edition": {
+                            "href": "/datasets/old-dataset-id/editions/2025",
+                            "id": "2025"
+                        },
+                        "version": {
+                            "href": "/datasets/old-dataset-id/editions/2025/versions/1"
+                        },
+                        "web_page": {
+                            "href": "/old-topic/datasets/old-dataset-id/editions/2025/versions/1"
+                        }
+                    }
+                }
+            ]
+            """
+
+    Scenario: Successfully rename unpublished static dataset and update its canonical topic
+        When I PUT "/datasets/old-dataset-id"
+            """
+            {
+                "id": "new-dataset-id",
+                "contacts": [
+                    {
+                        "name": "John Doe",
+                        "email": "john@example.com"
+                    }
+                ],
+                "type": "static",
+                "title": "Original Title",
+                "description": "A static dataset",
+                "next_release": "2026-01-01T00:00:00Z",
+                "license": "Open Government Licence v3.0",
+                "keywords": [
+                    "economy",
+                    "prices"
+                ],
+                "topics": [
+                    "economy-topic-id",
+                    "topic-1"
+                ]
+            }
+            """
+        Then the HTTP status code should be "200"
+        And the dataset "old-dataset-id" should not exist
+        And the document in the database for id "new-dataset-id" should be:
+            """
+            {
+                "id": "new-dataset-id",
+                "contacts": [
+                    {
+                        "name": "John Doe",
+                        "email": "john@example.com"
+                    }
+                ],
+                "title": "Original Title",
+                "description": "A static dataset",
+                "license": "Open Government Licence v3.0",
+                "next_release": "2026-01-01T00:00:00Z",
+                "keywords": [
+                    "economy",
+                    "prices"
+                ],
+                "type": "static",
+                "topics": [
+                    "economy-topic-id",
+                    "topic-1"
+                ],
+                "links": {
+                    "self": {
+                        "href": "/datasets/new-dataset-id"
+                    },
+                    "editions": {
+                        "href": "/datasets/new-dataset-id/editions"
+                    }
+                }
+            }
+            """
+        And the static version in the database for id "version-1" should be:
+            """
+            {
+                "id": "version-1",
+                "edition": "2025",
+                "edition_title": "2025 Edition",
+                "version": 1,
+                "release_date": "2025-01-01T00:00:00Z",
+                "state": "associated",
+                "type": "static",
+                "links": {
+                    "dataset": {
+                        "id": "new-dataset-id",
+                        "href": "/datasets/new-dataset-id"
+                    },
+                    "edition": {
+                        "href": "/datasets/new-dataset-id/editions/2025",
+                        "id": "2025"
+                    },
+                    "self": {
+                        "href": "/datasets/new-dataset-id/editions/2025/versions/1"
+                    },
+                    "version": {
+                        "href": "/datasets/new-dataset-id/editions/2025/versions/1",
+                        "id": "1"
+                    },
+                    "web_page": {
+                        "href": "economy/datasets/new-dataset-id/editions/2025/versions/1"
+                    }
+                }
+            }
+            """
+
+    Scenario: Cannot rename unpublished static dataset when new id already exists
+        When I PUT "/datasets/old-dataset-id"
+            """
+            {
+                "id": "existing-dataset-id",
+                "contacts": [
+                    {
+                        "name": "John Doe",
+                        "email": "john@example.com"
+                    }
+                ],
+                "type": "static",
+                "title": "Dataset To Rename",
+                "description": "A static dataset",
+                "next_release": "2026-01-01T00:00:00Z",
+                "license": "Open Government Licence v3.0",
+                "keywords": [
+                    "economy",
+                    "prices"
+                ],
+                "topics": [
+                    "old-topic",
+                    "topic-1"
+                ]
+            }
+            """
+        Then the HTTP status code should be "409"
+        And I should receive the following response:
+            """
+            dataset already exists
+            """
+
+    Scenario: Cannot change id of published static dataset
+        When I PUT "/datasets/published-dataset-id"
+            """
+            {
+                "id": "new-dataset-id",
+                "type": "static",
+                "title": "Published Dataset",
+                "description": "Published static dataset",
+                "next_release": "2026-01-01T00:00:00Z",
+                "contacts": [
+                    {
+                        "name": "John Doe",
+                        "email": "john@example.com"
+                    }
+                ],
+                "license": "Open Government Licence v3.0",
+                "keywords": [
+                    "economy",
+                    "prices"
+                ],
+                "topics": [
+                    "old-topic",
+                    "topic-1"
+                ]
+            }
+            """
+        Then the HTTP status code should be "409"
+        And I should receive the following response:
+            """
+            cannot change the dataset ID for a published dataset
+            """
+
+    Scenario: Cannot change canonical topic of published static dataset
+        When I PUT "/datasets/published-dataset-id"
+            """
+            {
+                "id": "published-dataset-id",
+                "type": "static",
+                "title": "Published Dataset",
+                "description": "Published static dataset",
+                "next_release": "2026-01-01T00:00:00Z",
+                "contacts": [
+                    {
+                        "name": "John Doe",
+                        "email": "john@example.com"
+                    }
+                ],
+                "license": "Open Government Licence v3.0",
+                "keywords": [
+                    "economy",
+                    "prices"
+                ],
+                "topics": [
+                    "new-topic",
+                    "topic-1"
+                ]
+            }
+            """
+        Then the HTTP status code should be "409"
+        And I should receive the following response:
+            """
+            canonical topic can't be changed once a series is published
+            """

--- a/features/steps/dataset_component.go
+++ b/features/steps/dataset_component.go
@@ -324,12 +324,18 @@ func (c *DatasetComponent) DoGetTopicAPIClientOk(ctx context.Context, cfg *confi
 			switch id {
 			case "economy-topic-id":
 				return &topicAPIModels.TopicResponse{
+					Current: &topicAPIModels.Topic{
+						Slug: "economy",
+					},
 					Next: &topicAPIModels.Topic{
 						Slug: "economy",
 					},
 				}, nil
 			case "businessindustryandtrade-topic-id":
 				return &topicAPIModels.TopicResponse{
+					Current: &topicAPIModels.Topic{
+						Slug: "businessindustryandtrade",
+					},
 					Next: &topicAPIModels.Topic{
 						Slug: "businessindustryandtrade",
 					},

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -38,6 +38,7 @@ func (c *DatasetComponent) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the document in the database for id "([^"]*)" should be:$`, c.theDocumentInTheDatabaseForIDShouldBe)
 	ctx.Step(`^the instance in the database for id "([^"]*)" should be:$`, c.theInstanceInTheDatabaseForIDShouldBe)
 	ctx.Step(`^the version in the database for id "([^"]*)" should be:$`, c.theVersionInTheDatabaseForIDShouldBe)
+	ctx.Step(`^the static version in the database for id "([^"]*)" should be:$`, c.theStaticVersionInTheDatabaseForIDShouldBe)
 	ctx.Step(`^there are no datasets$`, c.thereAreNoDatasets)
 	ctx.Step(`^I have these datasets:$`, c.iHaveTheseDatasets)
 	ctx.Step(`^I have these "([^"]*)" datasets:$`, c.iHaveTheseConditionalDatasets)
@@ -184,6 +185,37 @@ func (c *DatasetComponent) theVersionInTheDatabaseForIDShouldBe(id string, body 
 		// Ignore generated etag if we are not concerned about it
 		expected.ETag = got.ETag
 	}
+
+	assert.Equal(&c.ErrorFeature, expected, got)
+
+	return c.ErrorFeature.StepError()
+}
+
+func (c *DatasetComponent) theStaticVersionInTheDatabaseForIDShouldBe(id string, body *godog.DocString) error {
+	var expected models.Version
+
+	if err := json.Unmarshal([]byte(body.Content), &expected); err != nil {
+		return fmt.Errorf("failed to unmarshal body: %w", err)
+	}
+
+	collectionName := c.MongoClient.ActualCollectionName(config.VersionsCollection)
+
+	var got models.Version
+
+	if err := c.MongoClient.Connection.Collection(collectionName).FindOne(context.Background(), bson.M{"_id": id}, &got); err != nil {
+		return fmt.Errorf("failed to get static version from collection: %w", err)
+	}
+
+	// LastUpdated is set to "now" so cannot be known in advance.
+	got.LastUpdated = time.Time{}
+
+	// VersionLinks.Version is ommitted in the JSON.
+	if got.Links != nil {
+		got.Links.Version = nil
+	}
+
+	// ETag is generated and ommitted in the JSON so cannot be known in advance.
+	got.ETag = ""
 
 	assert.Equal(&c.ErrorFeature, expected, got)
 

--- a/models/version.go
+++ b/models/version.go
@@ -547,6 +547,31 @@ func ValidateVersion(version *Version) error {
 	return nil
 }
 
+// GenerateVersionLinksStatic generates the version links for a static dataset.
+// This will populate the fields, Dataset, Edition, Self, Version and WebPage.
+func GenerateVersionLinksStatic(topicSlug, datasetID, editionID string, versionNumber int) *VersionLinks {
+	return &VersionLinks{
+		Dataset: &LinkObject{
+			ID:   datasetID,
+			HRef: fmt.Sprintf("/datasets/%s", datasetID),
+		},
+		Edition: &LinkObject{
+			ID:   editionID,
+			HRef: fmt.Sprintf("/datasets/%s/editions/%s", datasetID, editionID),
+		},
+		Self: &LinkObject{
+			HRef: fmt.Sprintf("/datasets/%s/editions/%s/versions/%d", datasetID, editionID, versionNumber),
+		},
+		Version: &LinkObject{
+			ID:   strconv.Itoa(versionNumber),
+			HRef: fmt.Sprintf("/datasets/%s/editions/%s/versions/%d", datasetID, editionID, versionNumber),
+		},
+		WebPage: &LinkObject{
+			HRef: fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d", topicSlug, datasetID, editionID, versionNumber),
+		},
+	}
+}
+
 // ParseAndValidateVersionNumber checks the version is a positive integer above 0
 func ParseAndValidateVersionNumber(ctx context.Context, version string) (int, error) {
 	versionNumber, err := strconv.Atoi(version)

--- a/models/version_test.go
+++ b/models/version_test.go
@@ -338,6 +338,43 @@ func TestCreateDownloadList(t *testing.T) {
 	})
 }
 
+func TestGenerateVersionLinksStatic(t *testing.T) {
+	Convey("Given valid inputs for GenerateVersionLinksStatic", t, func() {
+		topicSlug := "topicSlug"
+		datasetID := "datasetID"
+		editionID := "editionID"
+		versionNumber := 1
+
+		Convey("When GenerateVersionLinksStatic is called", func() {
+			links := GenerateVersionLinksStatic(topicSlug, datasetID, editionID, versionNumber)
+
+			Convey("Then the returned VersionLinks should be correctly populated", func() {
+				expectedLinks := &VersionLinks{
+					Dataset: &LinkObject{
+						ID:   datasetID,
+						HRef: fmt.Sprintf("/datasets/%s", datasetID),
+					},
+					Edition: &LinkObject{
+						ID:   editionID,
+						HRef: fmt.Sprintf("/datasets/%s/editions/%s", datasetID, editionID),
+					},
+					Self: &LinkObject{
+						HRef: fmt.Sprintf("/datasets/%s/editions/%s/versions/%d", datasetID, editionID, versionNumber),
+					},
+					Version: &LinkObject{
+						ID:   strconv.Itoa(versionNumber),
+						HRef: fmt.Sprintf("/datasets/%s/editions/%s/versions/%d", datasetID, editionID, versionNumber),
+					},
+					WebPage: &LinkObject{
+						HRef: fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d", topicSlug, datasetID, editionID, versionNumber),
+					},
+				}
+				So(links, ShouldResemble, expectedLinks)
+			})
+		})
+	})
+}
+
 func TestValidateVersionNumberSuccess(t *testing.T) {
 	Convey("Given valid version number above 0 in string format", t, func() {
 		versionStr := "5"

--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -625,16 +625,31 @@ func updateLinksFields(version *models.Version, setUpdates bson.M) {
 		return
 	}
 
+	if version.Links.Dataset != nil {
+		if version.Links.Dataset.HRef != "" {
+			setUpdates["links.dataset.href"] = version.Links.Dataset.HRef
+		}
+		if version.Links.Dataset.ID != "" {
+			setUpdates["links.dataset.id"] = version.Links.Dataset.ID
+		}
+	}
+
 	if version.Links.Spatial != nil && version.Links.Spatial.HRef != "" {
 		setUpdates["links.spatial.href"] = version.Links.Spatial.HRef
 	}
 
 	if version.Links.Edition != nil && version.Links.Edition.HRef != "" {
 		setUpdates["links.edition.href"] = version.Links.Edition.HRef
+		if version.Links.Edition.ID != "" {
+			setUpdates["links.edition.id"] = version.Links.Edition.ID
+		}
 	}
 
 	if version.Links.Version != nil && version.Links.Version.HRef != "" {
 		setUpdates["links.version.href"] = version.Links.Version.HRef
+		if version.Links.Version.ID != "" {
+			setUpdates["links.version.id"] = version.Links.Version.ID
+		}
 	}
 
 	if version.Links.Self != nil && version.Links.Self.HRef != "" {
@@ -643,6 +658,9 @@ func updateLinksFields(version *models.Version, setUpdates bson.M) {
 
 	if version.Links.WebPage != nil && version.Links.WebPage.HRef != "" {
 		setUpdates["links.web_page.href"] = version.Links.WebPage.HRef
+		if version.Links.WebPage.ID != "" {
+			setUpdates["links.web_page.id"] = version.Links.WebPage.ID
+		}
 	}
 }
 

--- a/mongo/version_store.go
+++ b/mongo/version_store.go
@@ -144,6 +144,27 @@ func (m *Mongo) GetVersionsStatic(ctx context.Context, datasetID, edition, state
 	return results, totalCount, nil
 }
 
+// GetVersionsStaticNoLimit retrieves all versions for a given dataset without pagination.
+func (m *Mongo) GetVersionsStaticNoLimit(ctx context.Context, datasetID, state string) ([]*models.Version, int, error) {
+	selector := bson.M{"links.dataset.id": datasetID}
+	if state != "" {
+		selector["state"] = state
+	}
+
+	results := []*models.Version{}
+	count, err := m.Connection.Collection(m.ActualCollectionName(config.VersionsCollection)).Find(ctx, selector, &results,
+		mongodriver.Sort(bson.M{"release_date": -1}))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if count < 1 {
+		return nil, 0, errs.ErrVersionsNotFound
+	}
+
+	return results, count, nil
+}
+
 // GetVersion retrieves a version document for a dataset edition
 func (m *Mongo) GetVersionStatic(ctx context.Context, id, editionID string, versionID int, state string) (*models.Version, error) {
 	selector := buildVersionQuery(id, editionID, state, versionID)

--- a/mongo/version_store_test.go
+++ b/mongo/version_store_test.go
@@ -106,6 +106,61 @@ func TestVersionsStatic(t *testing.T) {
 	})
 }
 
+func TestGetVersionsStaticNoLimit(t *testing.T) {
+	Convey("Given MongoDB is running and populated with static versions", t, func() {
+		ctx := context.Background()
+		mongoDB, err := getTestMongoDB(ctx, t)
+		So(err, ShouldBeNil)
+
+		_, err = setupVersionsTestData(ctx, mongoDB)
+		So(err, ShouldBeNil)
+
+		Convey("When GetVersionsStaticNoLimit is called with no state", func() {
+			retrievedVersions, count, err := mongoDB.GetVersionsStaticNoLimit(ctx, staticDatasetID, "")
+
+			Convey("Then all versions are returned", func() {
+				So(err, ShouldBeNil)
+				So(count, ShouldEqual, 3)
+				So(retrievedVersions, ShouldHaveLength, 3)
+			})
+		})
+
+		Convey("When GetVersionsStaticNoLimit is called with a state filter", func() {
+			retrievedVersions, count, err := mongoDB.GetVersionsStaticNoLimit(ctx, staticDatasetID, models.PublishedState)
+
+			Convey("Then only versions matching the state are returned", func() {
+				So(err, ShouldBeNil)
+				So(count, ShouldEqual, 1)
+				So(retrievedVersions, ShouldHaveLength, 1)
+				So(retrievedVersions[0].State, ShouldEqual, models.PublishedState)
+			})
+		})
+
+		Convey("When GetVersionsStaticNoLimit and there no matching versions", func() {
+			retrievedVersions, count, err := mongoDB.GetVersionsStaticNoLimit(ctx, nonExistentDatasetID, "")
+
+			Convey("Then ErrVersionsNotFound is returned", func() {
+				So(err, ShouldEqual, errs.ErrVersionsNotFound)
+				So(count, ShouldEqual, 0)
+				So(retrievedVersions, ShouldBeNil)
+			})
+		})
+
+		Convey("When GetVersionsStaticNoLimit is called and the mongo connection fails", func() {
+			err = mongoDB.Connection.Close(ctx)
+			So(err, ShouldBeNil)
+
+			retrievedVersions, count, err := mongoDB.GetVersionsStaticNoLimit(ctx, staticDatasetID, "")
+
+			Convey("Then an error is returned", func() {
+				So(err, ShouldNotBeNil)
+				So(count, ShouldEqual, 0)
+				So(retrievedVersions, ShouldBeNil)
+			})
+		})
+	})
+}
+
 func TestGetVersionStaticByPreviousEditionID(t *testing.T) {
 	Convey("Given MongoDB is running with a version that has a previous edition ID", t, func() {
 		ctx := context.Background()

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -52,6 +52,7 @@ type dataMongoDB interface {
 	GetUniqueDimensionAndOptions(ctx context.Context, ID, dimension string) ([]*string, int, error)
 	GetVersions(ctx context.Context, datasetID, editionID, state string, offset, limit int) ([]models.Version, int, error)
 	GetVersionsStatic(ctx context.Context, datasetID, edition, state string, offset, limit int) ([]models.Version, int, error)
+	GetVersionsStaticNoLimit(ctx context.Context, datasetID, state string) ([]*models.Version, int, error)
 	UpdateDataset(ctx context.Context, ID string, dataset *models.Dataset, currentState string) error
 	UpdateDatasetWithAssociation(ctx context.Context, ID, state string, version *models.Version) error
 	UpdateDimensionsNodeIDAndOrder(ctx context.Context, updates []*models.DimensionOption) error

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -138,6 +138,9 @@ var _ store.Storer = &StorerMock{}
 //			GetVersionsStaticFunc: func(ctx context.Context, datasetID string, edition string, state string, offset int, limit int) ([]models.Version, int, error) {
 //				panic("mock out the GetVersionsStatic method")
 //			},
+//			GetVersionsStaticNoLimitFunc: func(ctx context.Context, datasetID string, state string) ([]*models.Version, int, error) {
+//				panic("mock out the GetVersionsStaticNoLimit method")
+//			},
 //			IsStaticDatasetFunc: func(ctx context.Context, datasetID string) (bool, error) {
 //				panic("mock out the IsStaticDataset method")
 //			},
@@ -330,6 +333,9 @@ type StorerMock struct {
 
 	// GetVersionsStaticFunc mocks the GetVersionsStatic method.
 	GetVersionsStaticFunc func(ctx context.Context, datasetID string, edition string, state string, offset int, limit int) ([]models.Version, int, error)
+
+	// GetVersionsStaticNoLimitFunc mocks the GetVersionsStaticNoLimit method.
+	GetVersionsStaticNoLimitFunc func(ctx context.Context, datasetID string, state string) ([]*models.Version, int, error)
 
 	// IsStaticDatasetFunc mocks the IsStaticDataset method.
 	IsStaticDatasetFunc func(ctx context.Context, datasetID string) (bool, error)
@@ -815,6 +821,15 @@ type StorerMock struct {
 			// Limit is the limit argument value.
 			Limit int
 		}
+		// GetVersionsStaticNoLimit holds details about calls to the GetVersionsStaticNoLimit method.
+		GetVersionsStaticNoLimit []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// DatasetID is the datasetID argument value.
+			DatasetID string
+			// State is the state argument value.
+			State string
+		}
 		// IsStaticDataset holds details about calls to the IsStaticDataset method.
 		IsStaticDataset []struct {
 			// Ctx is the ctx argument value.
@@ -1084,6 +1099,7 @@ type StorerMock struct {
 	lockGetVersionStaticByPreviousEditionID sync.RWMutex
 	lockGetVersions                         sync.RWMutex
 	lockGetVersionsStatic                   sync.RWMutex
+	lockGetVersionsStaticNoLimit            sync.RWMutex
 	lockIsStaticDataset                     sync.RWMutex
 	lockRemoveDatasetVersionAndEditionLinks sync.RWMutex
 	lockSetInstanceIsPublished              sync.RWMutex
@@ -2790,6 +2806,46 @@ func (mock *StorerMock) GetVersionsStaticCalls() []struct {
 	mock.lockGetVersionsStatic.RLock()
 	calls = mock.calls.GetVersionsStatic
 	mock.lockGetVersionsStatic.RUnlock()
+	return calls
+}
+
+// GetVersionsStaticNoLimit calls GetVersionsStaticNoLimitFunc.
+func (mock *StorerMock) GetVersionsStaticNoLimit(ctx context.Context, datasetID string, state string) ([]*models.Version, int, error) {
+	if mock.GetVersionsStaticNoLimitFunc == nil {
+		panic("StorerMock.GetVersionsStaticNoLimitFunc: method is nil but Storer.GetVersionsStaticNoLimit was just called")
+	}
+	callInfo := struct {
+		Ctx       context.Context
+		DatasetID string
+		State     string
+	}{
+		Ctx:       ctx,
+		DatasetID: datasetID,
+		State:     state,
+	}
+	mock.lockGetVersionsStaticNoLimit.Lock()
+	mock.calls.GetVersionsStaticNoLimit = append(mock.calls.GetVersionsStaticNoLimit, callInfo)
+	mock.lockGetVersionsStaticNoLimit.Unlock()
+	return mock.GetVersionsStaticNoLimitFunc(ctx, datasetID, state)
+}
+
+// GetVersionsStaticNoLimitCalls gets all the calls that were made to GetVersionsStaticNoLimit.
+// Check the length with:
+//
+//	len(mockedStorer.GetVersionsStaticNoLimitCalls())
+func (mock *StorerMock) GetVersionsStaticNoLimitCalls() []struct {
+	Ctx       context.Context
+	DatasetID string
+	State     string
+} {
+	var calls []struct {
+		Ctx       context.Context
+		DatasetID string
+		State     string
+	}
+	mock.lockGetVersionsStaticNoLimit.RLock()
+	calls = mock.calls.GetVersionsStaticNoLimit
+	mock.lockGetVersionsStaticNoLimit.RUnlock()
 	return calls
 }
 

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -142,6 +142,9 @@ var _ store.MongoDB = &MongoDBMock{}
 //			GetVersionsStaticFunc: func(ctx context.Context, datasetID string, edition string, state string, offset int, limit int) ([]models.Version, int, error) {
 //				panic("mock out the GetVersionsStatic method")
 //			},
+//			GetVersionsStaticNoLimitFunc: func(ctx context.Context, datasetID string, state string) ([]*models.Version, int, error) {
+//				panic("mock out the GetVersionsStaticNoLimit method")
+//			},
 //			IsStaticDatasetFunc: func(ctx context.Context, datasetID string) (bool, error) {
 //				panic("mock out the IsStaticDataset method")
 //			},
@@ -334,6 +337,9 @@ type MongoDBMock struct {
 
 	// GetVersionsStaticFunc mocks the GetVersionsStatic method.
 	GetVersionsStaticFunc func(ctx context.Context, datasetID string, edition string, state string, offset int, limit int) ([]models.Version, int, error)
+
+	// GetVersionsStaticNoLimitFunc mocks the GetVersionsStaticNoLimit method.
+	GetVersionsStaticNoLimitFunc func(ctx context.Context, datasetID string, state string) ([]*models.Version, int, error)
 
 	// IsStaticDatasetFunc mocks the IsStaticDataset method.
 	IsStaticDatasetFunc func(ctx context.Context, datasetID string) (bool, error)
@@ -815,6 +821,15 @@ type MongoDBMock struct {
 			// Limit is the limit argument value.
 			Limit int
 		}
+		// GetVersionsStaticNoLimit holds details about calls to the GetVersionsStaticNoLimit method.
+		GetVersionsStaticNoLimit []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// DatasetID is the datasetID argument value.
+			DatasetID string
+			// State is the state argument value.
+			State string
+		}
 		// IsStaticDataset holds details about calls to the IsStaticDataset method.
 		IsStaticDataset []struct {
 			// Ctx is the ctx argument value.
@@ -1078,6 +1093,7 @@ type MongoDBMock struct {
 	lockGetVersionStaticByPreviousEditionID sync.RWMutex
 	lockGetVersions                         sync.RWMutex
 	lockGetVersionsStatic                   sync.RWMutex
+	lockGetVersionsStaticNoLimit            sync.RWMutex
 	lockIsStaticDataset                     sync.RWMutex
 	lockRemoveDatasetVersionAndEditionLinks sync.RWMutex
 	lockUnlockInstance                      sync.RWMutex
@@ -2803,6 +2819,46 @@ func (mock *MongoDBMock) GetVersionsStaticCalls() []struct {
 	mock.lockGetVersionsStatic.RLock()
 	calls = mock.calls.GetVersionsStatic
 	mock.lockGetVersionsStatic.RUnlock()
+	return calls
+}
+
+// GetVersionsStaticNoLimit calls GetVersionsStaticNoLimitFunc.
+func (mock *MongoDBMock) GetVersionsStaticNoLimit(ctx context.Context, datasetID string, state string) ([]*models.Version, int, error) {
+	if mock.GetVersionsStaticNoLimitFunc == nil {
+		panic("MongoDBMock.GetVersionsStaticNoLimitFunc: method is nil but MongoDB.GetVersionsStaticNoLimit was just called")
+	}
+	callInfo := struct {
+		Ctx       context.Context
+		DatasetID string
+		State     string
+	}{
+		Ctx:       ctx,
+		DatasetID: datasetID,
+		State:     state,
+	}
+	mock.lockGetVersionsStaticNoLimit.Lock()
+	mock.calls.GetVersionsStaticNoLimit = append(mock.calls.GetVersionsStaticNoLimit, callInfo)
+	mock.lockGetVersionsStaticNoLimit.Unlock()
+	return mock.GetVersionsStaticNoLimitFunc(ctx, datasetID, state)
+}
+
+// GetVersionsStaticNoLimitCalls gets all the calls that were made to GetVersionsStaticNoLimit.
+// Check the length with:
+//
+//	len(mockedMongoDB.GetVersionsStaticNoLimitCalls())
+func (mock *MongoDBMock) GetVersionsStaticNoLimitCalls() []struct {
+	Ctx       context.Context
+	DatasetID string
+	State     string
+} {
+	var calls []struct {
+		Ctx       context.Context
+		DatasetID string
+		State     string
+	}
+	mock.lockGetVersionsStaticNoLimit.RLock()
+	calls = mock.calls.GetVersionsStaticNoLimit
+	mock.lockGetVersionsStaticNoLimit.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-5028
Bug Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-5046

- Allow dataset ID to be changed using `PUT /datasets/{id}` for static datasets
- Fixed bug where changing main topic for a dataset with no editions would return an error

Notes:
- The `_id` field in mongo is immutable and this is the field used to store the dataset ID. Due to this restriction, a simple "update" cannot be done to change a dataset ID. Instead the original record is deleted a new record is created with the new ID.

### How to review

- Change the main topic for a dataset with no editions and no error should be returned
- Change the dataset ID for an unpublished dataset and all related links (dataset and version) should be updated
- Changing the dataset ID for a published dataset should return a 409
- Changing the dataset ID to one that already exists should return a 409

(To make local testing easier, see component tests for scenarios to test and request bodies to use)

### Who can review

- Anyone
