### PR TITLE
use existing latest version link and rewrite if it exists

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -668,10 +668,10 @@ func (api *DatasetAPI) putDataset(w http.ResponseWriter, r *http.Request) {
 					},
 				}
 
-				if dataset.Links != nil && dataset.Links.LatestVersion != nil {
+				if currentDataset.Next.Links != nil && currentDataset.Next.Links.LatestVersion != nil {
 					updatedLinks.LatestVersion = &models.LinkObject{
-						ID:   dataset.Links.LatestVersion.ID,
-						HRef: strings.ReplaceAll(dataset.Links.LatestVersion.HRef, fmt.Sprintf("/datasets/%s/", datasetID), fmt.Sprintf("/datasets/%s/", dataset.ID)),
+						ID:   currentDataset.Next.Links.LatestVersion.ID,
+						HRef: strings.ReplaceAll(currentDataset.Next.Links.LatestVersion.HRef, fmt.Sprintf("/datasets/%s/", datasetID), fmt.Sprintf("/datasets/%s/", dataset.ID)),
 					}
 				}
 

--- a/features/static_dataset_put.feature
+++ b/features/static_dataset_put.feature
@@ -16,7 +16,19 @@ Feature: PUT /datasets/{id} for static datasets
                         "topics": [
                             "old-topic",
                             "topic-1"
-                        ]
+                        ],
+                        "links": {
+                            "self": {
+                                "href": "/datasets/old-dataset-id"
+                            },
+                            "editions": {
+                                "href": "/datasets/old-dataset-id/editions"
+                            },
+                            "latest_version": {
+                                "href": "/datasets/old-dataset-id/editions/2025/versions/1",
+                                "id": "1"
+                            }
+                        }
                     }
                 },
                 {
@@ -143,6 +155,10 @@ Feature: PUT /datasets/{id} for static datasets
                     },
                     "editions": {
                         "href": "/datasets/new-dataset-id/editions"
+                    },
+                    "latest_version": {
+                        "href": "/datasets/new-dataset-id/editions/2025/versions/1",
+                        "id": "1"
                     }
                 }
             }


### PR DESCRIPTION
### What

- Bug fix to avoid removing latest version link when dataset ID is changed using `PUT /datasets/{id}`. Previously it used the link sent in the request body but this should be auto-generated and is not sent in request bodies. Instead, if the link existed previously then it will be rewritten using the new ID.

### How to review

- Create a dataset with a version and then call `PUT /datasets/{id}` to change the ID. The dataset record should then keep the `latest_version` link and rewrite it correctly

### Who can review

- Anyone
