### PR TITLE
Store previous series IDs for datasets

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -914,6 +914,7 @@ func mapResults(results []*models.DatasetUpdate) []*models.Dataset {
 			continue
 		}
 		item.Current.ID = item.ID
+		item.Current.PreviousSeriesId = nil
 		items = append(items, item.Current)
 	}
 	return items

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -246,6 +246,8 @@ func (api *DatasetAPI) getDataset(w http.ResponseWriter, r *http.Request) {
 					dataset.Current.Topics = nil
 				}
 
+				dataset.Current.PreviousSeriesId = nil
+
 				datasetResponse = dataset.Current
 			} else {
 				// User has valid authentication to get raw dataset document
@@ -685,6 +687,8 @@ func (api *DatasetAPI) putDataset(w http.ResponseWriter, r *http.Request) {
 				return nil, err
 			}
 		} else if dataset.Type == models.Static.String() && dataset.ID != currentDataset.ID {
+			dataset.PreviousSeriesId = append([]string{}, currentDataset.Next.PreviousSeriesId...)
+			dataset.PreviousSeriesId = append(dataset.PreviousSeriesId, currentDataset.ID)
 			renamedDatasetUpdate := &models.DatasetUpdate{
 				ID:   dataset.ID,
 				Next: dataset,

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -224,6 +224,7 @@ func (api *DatasetAPI) getDataset(w http.ResponseWriter, r *http.Request) {
 				}
 				log.Info(ctx, "getDataset endpoint: get dataset with auth", logData)
 			} else {
+				dataset.Current.PreviousSeriesId = nil
 				datasetResponse, err = utils.RewriteDatasetWithoutAuth(ctx, dataset, datasetLinksBuilder)
 				if err != nil {
 					log.Error(ctx, "getDataset endpoint: failed to rewrite dataset without authorisation", err, logData)

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -376,6 +376,90 @@ func TestGetDatasetsReturnsOK(t *testing.T) {
 		So(mockedDataStore.GetDatasetsCalls()[0].Offset, ShouldEqual, 12)
 	})
 
+	Convey("A successful web-mode request to get datasets does not expose previous_series_id", t, func() {
+		r := &http.Request{}
+		w := httptest.NewRecorder()
+		address, err := neturl.Parse("localhost:20000/datasets")
+		So(err, ShouldBeNil)
+		r.URL = address
+
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetsFunc: func(context.Context, int, int, bool) ([]*models.DatasetUpdate, int, error) {
+				return []*models.DatasetUpdate{{
+					ID: "123-456",
+					Current: &models.Dataset{
+						ID:               "123-456",
+						Type:             models.Static.String(),
+						PreviousSeriesId: []string{"old-series-id"},
+					},
+				}}, 1, nil
+			},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return nil, permissionsAPISDK.ErrFailedToParsePermissionsResponse
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, application.SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{}, &applicationMocks.StaticDatasetServiceMock{}, nil, &filesAPISDKMocks.ClienterMock{})
+		api.enableURLRewriting = true
+
+		actualResponse, actualTotalCount, err := api.getDatasets(w, r, 11, 12)
+		So(err, ShouldBeNil)
+		So(actualTotalCount, ShouldEqual, 1)
+
+		datasets, ok := actualResponse.([]*models.Dataset)
+		So(ok, ShouldBeTrue)
+		So(datasets, ShouldHaveLength, 1)
+		So(datasets[0].PreviousSeriesId, ShouldBeNil)
+	})
+
+	Convey("A successful web-mode request to get datasets does not expose previous_series_id when URL rewriting is disabled", t, func() {
+		r := &http.Request{}
+		w := httptest.NewRecorder()
+		address, err := neturl.Parse("localhost:20000/datasets")
+		So(err, ShouldBeNil)
+		r.URL = address
+
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetsFunc: func(context.Context, int, int, bool) ([]*models.DatasetUpdate, int, error) {
+				return []*models.DatasetUpdate{{
+					ID: "123-456",
+					Current: &models.Dataset{
+						ID:               "123-456",
+						Type:             models.Static.String(),
+						PreviousSeriesId: []string{"old-series-id"},
+					},
+				}}, 1, nil
+			},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return nil, permissionsAPISDK.ErrFailedToParsePermissionsResponse
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, application.SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{}, &applicationMocks.StaticDatasetServiceMock{}, nil, &filesAPISDKMocks.ClienterMock{})
+		api.enableURLRewriting = false
+
+		actualResponse, actualTotalCount, err := api.getDatasets(w, r, 11, 12)
+		So(err, ShouldBeNil)
+		So(actualTotalCount, ShouldEqual, 1)
+
+		datasets, ok := actualResponse.([]*models.Dataset)
+		So(ok, ShouldBeTrue)
+		So(datasets, ShouldHaveLength, 1)
+		So(datasets[0].PreviousSeriesId, ShouldBeNil)
+	})
+
 	Convey("A successful request to get datasetwith type query parameter returns 200 OK response, and limit and offset are delegated to the datastore", t, func() {
 		r := &http.Request{}
 		w := httptest.NewRecorder()

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -1957,13 +1957,13 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 	})
 
 	Convey("A successful request to rename an unpublished static dataset returns 200 OK response", t, func() {
-		b := `{"id":"456","contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"census","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"CensusEthnicity","theme":"population","state":"completed","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","href":"https://www.ons.gov.uk/"},"type":"static","keywords":["keyword","keyword 2"],"topics":["topic-0","topic-1"],"license":"Open Government Licence v3.0"}`
+		b := `{"id":"456","contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"census","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"CensusEthnicity","theme":"population","state":"completed","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","href":"https://www.ons.gov.uk/"},"type":"static","keywords":["keyword","keyword 2"],"topics":["topic-0","topic-1"],"license":"Open Government Licence v3.0","previous_series_id":["789"]}`
 		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
-				return &models.DatasetUpdate{ID: "123", Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"topic-0", "topic-1"}}}, nil
+				return &models.DatasetUpdate{ID: "123", Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"topic-0", "topic-1"}, PreviousSeriesId: []string{"789"}}}, nil
 			},
 			CheckDatasetExistsFunc: func(ctx context.Context, id, state string) error {
 				return errs.ErrDatasetNotFound
@@ -2002,6 +2002,8 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		So(mockedDataStore.CheckDatasetExistsCalls(), ShouldHaveLength, 1)
 		So(mockedDataStore.GetVersionsStaticNoLimitCalls(), ShouldHaveLength, 1)
 		So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 1)
+		So(mockedDataStore.UpsertDatasetCalls()[0].ID, ShouldEqual, "456")
+		So(mockedDataStore.UpsertDatasetCalls()[0].DatasetDoc.Next.PreviousSeriesId, ShouldResemble, []string{"789", "123"})
 		So(mockedDataStore.DeleteDatasetCalls(), ShouldHaveLength, 1)
 		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 0)
 	})

--- a/features/datasets_id_web.feature
+++ b/features/datasets_id_web.feature
@@ -8,6 +8,12 @@ Feature: GET /datasets/{id} in web mode
                     "id": "published-dataset",
                     "state": "published",
                     "title": "Published Dataset"
+                },
+                {
+                    "id": "published-dataset-with-previous-series",
+                    "state": "published",
+                    "title": "Published Dataset with previous series ID",
+                    "previous_series_id": ["old-dataset-id"]
                 }
             ]
             """
@@ -21,6 +27,18 @@ Feature: GET /datasets/{id} in web mode
                 "last_updated": "{{DYNAMIC_TIMESTAMP}}",
                 "state": "published",
                 "title": "Published Dataset"
+            }
+            """
+
+    Scenario: Retrieving a published dataset with previous series returns 200 with the fields redacted
+        When I GET "/datasets/published-dataset-with-previous-series"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "id": "published-dataset-with-previous-series",
+                "last_updated": "{{DYNAMIC_TIMESTAMP}}",
+                "state": "published",
+                "title": "Published Dataset with previous series ID"
             }
             """
     

--- a/features/public_datasets.feature
+++ b/features/public_datasets.feature
@@ -86,4 +86,30 @@ Feature: Dataset API
             }
             """
         Then the HTTP status code should be "405"
-        
+
+    Scenario: Get /datasets does not return redacted fields
+        Given I have these datasets:
+            """
+            [
+                {
+                    "id": "population-estimates",
+                    "previous_series_id": ["old-dataset-id"]
+                }
+            ]
+            """
+        When I GET "/datasets"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "count":1,
+                "items": [
+                    {
+                        "id": "population-estimates",
+                        "last_updated":"0001-01-01T00:00:00Z"
+                    }
+                ],
+                "limit":20,
+                "offset":0,
+                "total_count":1
+            }
+            """

--- a/features/static_dataset_put.feature
+++ b/features/static_dataset_put.feature
@@ -160,7 +160,10 @@ Feature: PUT /datasets/{id} for static datasets
                         "href": "/datasets/new-dataset-id/editions/2025/versions/1",
                         "id": "1"
                     }
-                }
+                },
+                "previous_series_id": [
+                    "old-dataset-id"
+                ]
             }
             """
         And the static version in the database for id "version-1" should be:

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -120,6 +120,7 @@ type Dataset struct {
 	Survey            string           `bson:"survey,omitempty"                 json:"survey,omitempty"`
 	RelatedContent    []GeneralDetails `bson:"related_content,omitempty"        json:"related_content,omitempty"`
 	Topics            []string         `bson:"topics,omitempty"                 json:"topics,omitempty"`
+	PreviousSeriesId  []string         `bson:"previous_series_id,omitempty"     json:"previous_series_id,omitempty"`
 }
 
 // DatasetLinks represents a list of specific links related to the dataset resource

--- a/utils/rewriting.go
+++ b/utils/rewriting.go
@@ -44,16 +44,18 @@ func RewriteDatasetsWithoutAuth(ctx context.Context, results []*models.DatasetUp
 
 	items := []*models.Dataset{}
 	for _, item := range results {
-		if item.Current != nil {
-			err := RewriteDatasetLinks(ctx, item.Current.Links, datasetLinksBuilder)
-			if err != nil {
-				log.Error(ctx, "failed to rewrite 'current' links", err)
-				return nil, err
-			}
-			item.Current.ID = item.ID
-			item.Current.PreviousSeriesId = nil
-			items = append(items, item.Current)
+		if item.Current == nil {
+			continue
 		}
+
+		err := RewriteDatasetLinks(ctx, item.Current.Links, datasetLinksBuilder)
+		if err != nil {
+			log.Error(ctx, "failed to rewrite 'current' links", err)
+			return nil, err
+		}
+		item.Current.ID = item.ID
+		item.Current.PreviousSeriesId = nil
+		items = append(items, item.Current)
 	}
 	return items, nil
 }

--- a/utils/rewriting.go
+++ b/utils/rewriting.go
@@ -51,6 +51,7 @@ func RewriteDatasetsWithoutAuth(ctx context.Context, results []*models.DatasetUp
 				return nil, err
 			}
 			item.Current.ID = item.ID
+			item.Current.PreviousSeriesId = nil
 			items = append(items, item.Current)
 		}
 	}


### PR DESCRIPTION
### What

[Jira Link](https://officefornationalstatistics.atlassian.net/browse/DIS-4963)

If a dataset has it's ID changed prior to publication, this can cause issues if it has been added to a bundle as the bundle will reference the old dataset ID. This adds a new field to store any previous used previous dataset ID.

### How to review

Build this branch and run it in your dataset catalogue stack
Create a dataset
Submit a PUT to the dataset that changes the dataset ID
Do a GET or check your mongo DB to see if the old dataset ID is stored in a field called `previous_series_id`
Do a couple of times to check that it can store multiple IDs

Run your dataset-api in web mode and do a GET on your dataset and check that `previous_series_id` is not returned

### Who can review

Anyone