### PR TITLE
avoid data race on config in parallel tests

### DIFF
--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -2339,9 +2339,11 @@ func TestPutVersionGenerateDownloadsError(t *testing.T) {
 			r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(versionAssociatedPayload))
 
 			w := httptest.NewRecorder()
+			mu.Lock()
 			cfg, err := config.Get()
 			So(err, ShouldBeNil)
 			cfg.EnablePrivateEndpoints = true
+			mu.Unlock()
 
 			authorisationMock := &authMock.MiddlewareMock{
 				RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {

--- a/api/webendpoints_test.go
+++ b/api/webendpoints_test.go
@@ -384,6 +384,8 @@ func GetWebAPIWithMocks(ctx context.Context, mockedDataStore store.Storer, mocke
 		DownloadGenerators: mockedMapSMGeneratedDownloads,
 	}
 
+	mu.Lock()
+	defer mu.Unlock()
 	cfg, err := config.Get()
 	So(err, ShouldBeNil)
 	cfg.ServiceAuthToken = authToken


### PR DESCRIPTION
### What

- Fix data race on `Config` within parallel unit tests
- `config.Get()` returns a returns a package level pointer which then gets shared when running tests in parallel. This memory address is then called concurrently which can cause data race conditions. To fix this,  `mu.Lock()` and `defer mu.Unlock()` calls have been added to areas which had this issue such as in `GetWebAPIWithMocks()`.
- This pattern already exists in unit test helpers like `GetAPIWithCMDMocks()`, but was missing in some areas

### How to review

- Check changes are ok and unit tests pass

### Who can review

- Anyone
