### PR TITLE
feat: add related content for versions

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -223,17 +223,14 @@ func (smDS *StateMachineDatasetAPI) PopulateVersionInfo(ctx context.Context, ver
 }
 
 //nolint:gocyclo // cyclomatic complexity 21 of func `populateNewVersionDoc` is high (> 20)
-func populateNewVersionDoc(currentVersion, originalVersion *models.Version) (*models.Version, error) {
+func populateNewVersionDoc(currentVersion, versionUpdate *models.Version) (*models.Version, error) {
 	var version models.Version
-	err := copier.Copy(&version, originalVersion) // create local copy that escapes to the HEAP at the end of this function
+	err := copier.Copy(&version, versionUpdate) // create local copy that escapes to the HEAP at the end of this function
 	if err != nil {
 		return nil, err
 	}
 
 	var related_content []models.GeneralDetails
-	if currentVersion.RelatedContent != nil {
-		related_content = append(related_content, *currentVersion.RelatedContent...)
-	}
 	if version.RelatedContent != nil {
 		related_content = append(related_content, *version.RelatedContent...)
 	}

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -3091,40 +3091,38 @@ func TestPopulateNewVersionDocWithRelatedContent(t *testing.T) {
 			Version:     1,
 			ID:          "789",
 		}
-
-		originalVersion := &models.Version{
+		versionUpdate := &models.Version{
 			Type: models.Static.String(),
 		}
-
 		Convey("When only the current version includes related content", func() {
 			currentVersion.RelatedContent = &[]models.GeneralDetails{
 				{Title: "Related content title", HRef: "https://www.ons.gov.uk/my-related-page", Description: "Related content description"},
 			}
-			version, err := populateNewVersionDoc(currentVersion, originalVersion)
+			version, err := populateNewVersionDoc(currentVersion, versionUpdate)
 			So(err, ShouldBeNil)
 			So(version, ShouldNotBeNil)
-			So(*version.RelatedContent, ShouldEqual, *currentVersion.RelatedContent)
+			So(version.RelatedContent, ShouldBeNil)
 		})
 		Convey("When only the original version includes related content", func() {
-			originalVersion.RelatedContent = &[]models.GeneralDetails{
+			versionUpdate.RelatedContent = &[]models.GeneralDetails{
 				{Title: "Related content title", HRef: "https://www.ons.gov.uk/my-related-page", Description: "Related content description"},
 			}
-			version, err := populateNewVersionDoc(currentVersion, originalVersion)
+			version, err := populateNewVersionDoc(currentVersion, versionUpdate)
 			So(err, ShouldBeNil)
 			So(version, ShouldNotBeNil)
-			So(*version.RelatedContent, ShouldEqual, *originalVersion.RelatedContent)
+			So(*version.RelatedContent, ShouldEqual, *versionUpdate.RelatedContent)
 		})
 		Convey("When both the current version and the original version include related content", func() {
-			originalVersion.RelatedContent = &[]models.GeneralDetails{
+			versionUpdate.RelatedContent = &[]models.GeneralDetails{
 				{Title: "Related content title", HRef: "https://www.ons.gov.uk/my-related-page", Description: "Related content description"},
 			}
 			currentVersion.RelatedContent = &[]models.GeneralDetails{
 				{Title: "More Related content title", HRef: "https://www.ons.gov.uk/my-other-related-page", Description: "Additional Related content description"},
 			}
-			version, err := populateNewVersionDoc(currentVersion, originalVersion)
+			version, err := populateNewVersionDoc(currentVersion, versionUpdate)
 			So(err, ShouldBeNil)
 			So(version, ShouldNotBeNil)
-			So(len(*version.RelatedContent), ShouldEqual, len(*currentVersion.RelatedContent)+len(*originalVersion.RelatedContent))
+			So(*version.RelatedContent, ShouldEqual, *versionUpdate.RelatedContent)
 		})
 	})
 }


### PR DESCRIPTION
### What

Amended `populateNewVersionDoc` to overwrite `related_content` with whatever is specified in the `PUT` request.

### How to review

Run locally and check that any existing `related_content` stored in the database is correctly overwritten with the content of the `PUT` request.

### Who can review

Anyone