### PR TITLE
Fix/delete dataset deletes all associated version

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -80,7 +80,6 @@ type DatasetAPI struct {
 	instancePublishedChecker  *instance.PublishCheck
 	versionPublishedChecker   *PublishCheck
 	MaxRequestOptions         int
-	defaultLimit              int
 	smDatasetAPI              *application.StateMachineDatasetAPI
 	auditService              application.AuditService
 	staticDatasetService      application.StaticDatasetService
@@ -108,7 +107,6 @@ func Setup(ctx context.Context, cfg *config.Configuration, router *mux.Router, d
 		versionPublishedChecker:   nil,
 		instancePublishedChecker:  nil,
 		MaxRequestOptions:         cfg.MaxRequestOptions,
-		defaultLimit:              cfg.DefaultLimit,
 		smDatasetAPI:              smDatasetAPI,
 		permissionsChecker:        permissionsChecker,
 		auditService:              auditService,

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -820,10 +820,7 @@ func (api *DatasetAPI) deleteDataset(w http.ResponseWriter, r *http.Request) {
 
 		// Find any editions/versions associated with the dataset based on the type
 		if currentDataset.Next.Type == models.Static.String() {
-			// Limit is set to DEFAULT_LIMIT (20) to prevent unbounded queries.
-			// If a dataset has more than DEFAULT_LIMIT unpublished editions/versions, only the first DEFAULT_LIMIT will be deleted.
-			// Refactoring is required if more than DEFAULT_LIMIT editions/versions per dataset is a possibility.
-			versionDocs, _, err := api.dataStore.Backend.GetAllStaticVersions(ctx, currentDataset.ID, "", 0, api.defaultLimit)
+			versions, _, err := api.dataStore.Backend.GetVersionsStaticNoLimit(ctx, currentDataset.ID, "")
 			if err != nil {
 				if err == errs.ErrVersionsNotFound {
 					log.Info(ctx, "deleteDataset endpoint: dataset didn't contain any versions, continuing to delete dataset", logData)
@@ -833,9 +830,9 @@ func (api *DatasetAPI) deleteDataset(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			for i := range versionDocs {
-				if versionDocs[i].Distributions != nil {
-					for _, distribution := range *versionDocs[i].Distributions {
+			for i := range versions {
+				if versions[i].Distributions != nil {
+					for _, distribution := range *versions[i].Distributions {
 						logData["distribution_title"] = distribution.Title
 						logData["distribution_download_url"] = distribution.DownloadURL
 
@@ -848,7 +845,7 @@ func (api *DatasetAPI) deleteDataset(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 
-				err := api.dataStore.Backend.DeleteStaticDatasetVersion(ctx, currentDataset.ID, versionDocs[i].Edition, versionDocs[i].Version)
+				err := api.dataStore.Backend.DeleteStaticDatasetVersion(ctx, currentDataset.ID, versions[i].Edition, versions[i].Version)
 				if err != nil {
 					log.Error(ctx, "deleteDataset endpoint: failed to delete version", err, logData)
 					return err

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -3322,7 +3322,7 @@ func TestDeleteDatasetReturnsSuccessfully(t *testing.T) {
 					},
 				}, nil
 			},
-			GetAllStaticVersionsFunc: func(context.Context, string, string, int, int) ([]*models.Version, int, error) {
+			GetVersionsStaticNoLimitFunc: func(context.Context, string, string) ([]*models.Version, int, error) {
 				versions := []*models.Version{
 					{
 						ID: "V1",
@@ -3388,7 +3388,7 @@ func TestDeleteDatasetReturnsSuccessfully(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusNoContent)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
-		So(len(mockedDataStore.GetAllStaticVersionsCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetVersionsStaticNoLimitCalls()), ShouldEqual, 1)
 		So(len(mockFilesAPIClient.DeleteFileCalls()), ShouldEqual, 2)
 		So(len(mockedDataStore.DeleteStaticDatasetVersionCalls()), ShouldEqual, 2)
 		So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 1)
@@ -3411,7 +3411,7 @@ func TestDeleteDatasetReturnsSuccessfully(t *testing.T) {
 					},
 				}, nil
 			},
-			GetAllStaticVersionsFunc: func(context.Context, string, string, int, int) ([]*models.Version, int, error) {
+			GetVersionsStaticNoLimitFunc: func(context.Context, string, string) ([]*models.Version, int, error) {
 				version := []*models.Version{}
 				return version, 0, errs.ErrVersionsNotFound
 			},
@@ -3440,6 +3440,7 @@ func TestDeleteDatasetReturnsSuccessfully(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusNoContent)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetVersionsStaticNoLimitCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.DeleteDatasetCalls()), ShouldEqual, 1)
 		So(auditServiceMock.RecordDatasetAuditEventCalls(), ShouldHaveLength, 1)
 		So(auditServiceMock.RecordDatasetAuditEventCalls()[0].Action, ShouldEqual, models.ActionDelete)
@@ -3695,7 +3696,7 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 					},
 				}, nil
 			},
-			GetAllStaticVersionsFunc: func(context.Context, string, string, int, int) ([]*models.Version, int, error) {
+			GetVersionsStaticNoLimitFunc: func(context.Context, string, string) ([]*models.Version, int, error) {
 				versions := []*models.Version{
 					{
 						ID: "V1",
@@ -3714,7 +3715,7 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 						},
 					},
 				}
-				return versions, 1, nil
+				return versions, len(versions), nil
 			},
 			DeleteStaticDatasetVersionFunc: func(ctx context.Context, datasetID, editionID string, version int) error {
 				return errs.ErrInternalServer
@@ -3735,6 +3736,7 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 
 		assertInternalServerErr(w)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetVersionsStaticNoLimitCalls()), ShouldEqual, 1)
 		So(len(mockedDataStore.DeleteStaticDatasetVersionCalls()), ShouldEqual, 1)
 	})
 
@@ -3752,7 +3754,7 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 					},
 				}, nil
 			},
-			GetAllStaticVersionsFunc: func(context.Context, string, string, int, int) ([]*models.Version, int, error) {
+			GetVersionsStaticNoLimitFunc: func(context.Context, string, string) ([]*models.Version, int, error) {
 				versions := []*models.Version{
 					{
 						ID: "1",
@@ -3769,7 +3771,7 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 						},
 					},
 				}
-				return versions, 1, nil
+				return versions, len(versions), nil
 			},
 		}
 
@@ -3794,6 +3796,7 @@ func TestDeleteDatasetReturnsError(t *testing.T) {
 
 		assertInternalServerErr(w)
 		So(len(mockedDataStore.GetDatasetCalls()), ShouldEqual, 1)
+		So(len(mockedDataStore.GetVersionsStaticNoLimitCalls()), ShouldEqual, 1)
 		So(len(mockFilesAPIClient.DeleteFileCalls()), ShouldEqual, 1)
 	})
 }


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-5223

- `DELETE /datasets/{id}` was limited to deleting only the `DEFAULT_LIMIT` for associated versions for a dataset. This meant that if a dataset had more than `DEFAULT_LIMIT` versions then the remaining version records would still exist. This has been fixed so all associated versions are deleted.

### How to review

- Create a dataset with more than `DEFAULT_LIMIT` (20 by default) editions/versions
- Call `DELETE /datasets/{id}` on and check that all the editions/versions have been deleted

(To make this easier to test locally you could have a script to make editions/versions or reduce the `DEFAULT_LIMIT` so you do not need to make so many editions/versions)

### Who can review

- Anyone
