### PR TITLE
Feature/lock ids for migrated datasets

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -44,10 +44,11 @@ var (
 
 	// errors that should return a 409 status
 	datasetsConflict = map[error]bool{
-		errs.ErrCannotChangeIDForPublishedDataset: true,
-		errs.ErrAddDatasetAlreadyExists:           true,
-		errs.ErrAddDatasetTitleAlreadyExists:      true,
-		errs.ErrPublishedDatasetTopicChange:       true,
+		errs.ErrCannotChangeIDForPublishedDataset:       true,
+		errs.ErrCannotChangeDatasetIDForMigratedDataset: true,
+		errs.ErrAddDatasetAlreadyExists:                 true,
+		errs.ErrAddDatasetTitleAlreadyExists:            true,
+		errs.ErrPublishedDatasetTopicChange:             true,
 	}
 )
 
@@ -612,6 +613,11 @@ func (api *DatasetAPI) putDataset(w http.ResponseWriter, r *http.Request) {
 			if isPublished && isIDChanged {
 				log.Error(ctx, "putDataset endpoint: unable to update ID of a published dataset", errs.ErrCannotChangeIDForPublishedDataset, data)
 				return nil, errs.ErrCannotChangeIDForPublishedDataset
+			}
+
+			if isIDChanged && currentDataset.Next.IsMigration != nil && *currentDataset.Next.IsMigration {
+				log.Error(ctx, "putDataset endpoint: cannot change dataset ID for migrated dataset", errs.ErrCannotChangeDatasetIDForMigratedDataset, data)
+				return nil, errs.ErrCannotChangeDatasetIDForMigratedDataset
 			}
 
 			if !isPublished && isIDChanged {

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -2135,7 +2135,7 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		w := httptest.NewRecorder()
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
-				return &models.DatasetUpdate{ID: "123", Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"topic-0", "topic-1"}, PreviousSeriesId: []string{"789"}, IsMigration: boolPtr(true)}}, nil
+				return &models.DatasetUpdate{ID: "123", Next: &models.Dataset{Type: models.Static.String(), Title: "CensusEthnicity", State: models.CreatedState, Topics: []string{"topic-0", "topic-1"}, PreviousSeriesId: []string{"789"}}}, nil
 			},
 			CheckDatasetExistsFunc: func(ctx context.Context, id, state string) error {
 				return errs.ErrDatasetNotFound
@@ -2176,8 +2176,6 @@ func TestPutDatasetReturnsSuccessfully(t *testing.T) {
 		So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 1)
 		So(mockedDataStore.UpsertDatasetCalls()[0].ID, ShouldEqual, "456")
 		So(mockedDataStore.UpsertDatasetCalls()[0].DatasetDoc.Next.PreviousSeriesId, ShouldResemble, []string{"789", "123"})
-		So(mockedDataStore.UpsertDatasetCalls()[0].DatasetDoc.Next.IsMigration, ShouldNotBeNil)
-		So(*mockedDataStore.UpsertDatasetCalls()[0].DatasetDoc.Next.IsMigration, ShouldBeTrue)
 		So(mockedDataStore.DeleteDatasetCalls(), ShouldHaveLength, 1)
 		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 0)
 	})
@@ -3270,6 +3268,41 @@ func TestPutDatasetReturnsError(t *testing.T) {
 		So(mockedDataStore.UpdateDatasetCalls(), ShouldHaveLength, 0)
 		So(mockedDataStore.UpsertDatasetCalls(), ShouldHaveLength, 0)
 		So(mockedDataStore.DeleteDatasetCalls(), ShouldHaveLength, 0)
+	})
+
+	Convey("When a request is made to change the dataset id of a migrated dataset", t, func() {
+		b := `{"id":"456","contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"static-published","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"StaticPublished","theme":"population","state":"published","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","href":"https://www.ons.gov.uk/"},"type":"static","keywords":["keyword","keyword 2"],"topics":["topic-0","topic-1"],"license":"Open Government Licence v3.0"}`
+		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return &models.DatasetUpdate{
+					ID:      "123",
+					Current: &models.Dataset{Type: models.Static.String(), State: models.PublishedState, Topics: []string{"topic-0", "topic-1"}, IsMigration: new(true)},
+					Next:    &models.Dataset{Type: models.Static.String(), Title: "StaticPublished", Topics: []string{"topic-0", "topic-1"}, IsMigration: new(true)},
+				}, nil
+			},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return testEntityData, nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, application.SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{}, &applicationMocks.StaticDatasetServiceMock{}, nil, &filesAPISDKMocks.ClienterMock{})
+		api.Router.ServeHTTP(w, r)
+
+		Convey("Then it should return a 409 conflict response", func() {
+			So(w.Code, ShouldEqual, http.StatusConflict)
+			So(w.Body.String(), ShouldContainSubstring, errs.ErrCannotChangeDatasetIDForMigratedDataset.Error())
+
+			So(mockedDataStore.GetDatasetCalls(), ShouldHaveLength, 1)
+		})
 	})
 
 	Convey("When PUT static unpublished dataset calls trying to change id to an existing one returns 409 response", t, func() {

--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -3271,16 +3271,15 @@ func TestPutDatasetReturnsError(t *testing.T) {
 	})
 
 	Convey("When a request is made to change the dataset id of a migrated dataset", t, func() {
-		b := `{"id":"456","contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"static-published","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"StaticPublished","theme":"population","state":"published","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","href":"https://www.ons.gov.uk/"},"type":"static","keywords":["keyword","keyword 2"],"topics":["topic-0","topic-1"],"license":"Open Government Licence v3.0"}`
+		b := `{"id":"456","contacts":[{"email":"testing@hotmail.com","name":"John Cox","telephone":"01623 456789"}],"description":"migrated-dataset","links":{"access_rights":{"href":"http://ons.gov.uk/accessrights"}},"title":"Migrated Dataset","theme":"population","state":"created","next_release":"2016-04-04","publisher":{"name":"The office of national statistics","type":"government department","href":"https://www.ons.gov.uk/"},"type":"static","keywords":["keyword","keyword 2"],"topics":["topic-0","topic-1"],"license":"Open Government Licence v3.0"}`
 		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123", bytes.NewBufferString(b))
 		w := httptest.NewRecorder()
 
 		mockedDataStore := &storetest.StorerMock{
 			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
 				return &models.DatasetUpdate{
-					ID:      "123",
-					Current: &models.Dataset{Type: models.Static.String(), State: models.PublishedState, Topics: []string{"topic-0", "topic-1"}, IsMigration: new(true)},
-					Next:    &models.Dataset{Type: models.Static.String(), Title: "StaticPublished", Topics: []string{"topic-0", "topic-1"}, IsMigration: new(true)},
+					ID:   "123",
+					Next: &models.Dataset{Type: models.Static.String(), Title: "Migrated Dataset", Topics: []string{"topic-0", "topic-1"}, IsMigration: new(true)},
 				}, nil
 			},
 		}

--- a/api/versions.go
+++ b/api/versions.go
@@ -428,7 +428,7 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 
 		if version.DatasetID != "" {
 			if err := utils.ValidateIDNoSpaces(version.DatasetID); err != nil {
-				log.Error(ctx, "putVersion endpoint: edition ID in request body contains spaces", err, data)
+				log.Error(ctx, "putVersion endpoint: dataset ID in request body contains spaces", err, data)
 				handleVersionAPIErr(ctx, err, w, data)
 				return
 			}
@@ -457,6 +457,12 @@ func (api *DatasetAPI) putVersion(w http.ResponseWriter, r *http.Request) {
 
 			// Only validate uniqueness IF edition or title is changing
 			if editionChanged {
+				if existingVersion.IsMigration != nil && *existingVersion.IsMigration {
+					log.Error(ctx, "cannot change edition ID for migrated edition", errs.ErrCannotChangeEditionIDForMigratedEdition, data)
+					handleVersionAPIErr(ctx, errs.ErrCannotChangeEditionIDForMigratedEdition, w, data)
+					return
+				}
+
 				checkErr := api.dataStore.Backend.CheckEditionExistsStatic(ctx, version.DatasetID, version.Edition, "")
 				if checkErr == nil {
 					log.Error(ctx, "edition ID already exists for this dataset", errs.ErrEditionAlreadyExists, data)

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -5303,7 +5303,7 @@ func TestPutVersionIsMigration(t *testing.T) {
 	Convey("When is_migration is included in a PUT version request body", t, func() {
 		trueVal := true
 
-		b := `{"edition_title":"Updated Edition Title","release_date":"2017-04-04","is_migration":true,"type":"static"}`
+		b := `{"edition":"2017","edition_title":"Original Title","release_date":"2017-04-04","is_migration":true,"type":"static"}`
 		r := createRequestWithAuth("PUT", "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
 		w := httptest.NewRecorder()
 
@@ -5373,6 +5373,47 @@ func TestPutVersionIsMigration(t *testing.T) {
 			So(capturedVersionUpdate, ShouldNotBeNil)
 			So(capturedVersionUpdate.IsMigration, ShouldNotBeNil)
 			So(*capturedVersionUpdate.IsMigration, ShouldBeTrue)
+		})
+	})
+}
+
+func TestPutVersion_EditionIDCannotBeChangedForMigratedEdition(t *testing.T) {
+	t.Parallel()
+
+	Convey("When a request is made to the change the edition ID of a migrated edition", t, func() {
+		b := `{"edition":"changed-id","edition_title":"Original Title","release_date":"2017-04-04","type":"static"}`
+		r := createRequestWithAuth(http.MethodPut, "http://localhost:22000/datasets/123/editions/2017/versions/1", bytes.NewBufferString(b))
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			GetVersionFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
+				return nil, errs.ErrVersionNotFound
+			},
+			GetVersionStaticFunc: func(ctx context.Context, datasetID, editionID string, version int, state string) (*models.Version, error) {
+				return &models.Version{
+					Edition:     "2017",
+					IsMigration: new(true),
+				}, nil
+			},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return testEntityData, nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, application.SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{}, &applicationMocks.StaticDatasetServiceMock{}, nil, &filesAPISDKMocks.ClienterMock{})
+		api.Router.ServeHTTP(w, r)
+
+		Convey("Then it returns a 409 Conflict", func() {
+			So(w.Code, ShouldEqual, http.StatusConflict)
+			So(w.Body.String(), ShouldContainSubstring, errs.ErrCannotChangeEditionIDForMigratedEdition.Error())
+
+			So(len(mockedDataStore.GetVersionStaticCalls()), ShouldEqual, 1)
 		})
 	})
 }

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -15,55 +15,57 @@ func (e ErrInvalidPatch) Error() string {
 
 // A list of error messages for Dataset API
 var (
-	ErrAddDatasetAlreadyExists            = errors.New("dataset already exists")
-	ErrAddDatasetTitleAlreadyExists       = errors.New("dataset title already exists")
-	ErrDatasetTypeInvalid                 = errors.New("invalid dataset type")
-	ErrTypeMismatch                       = errors.New("type mismatch")
-	ErrAddUpdateDatasetBadRequest         = errors.New("failed to parse json body")
-	ErrConflictUpdatingInstance           = errors.New("conflict updating instance resource")
-	ErrDatasetNotFound                    = errors.New("dataset not found")
-	ErrDeletePublishedDatasetForbidden    = errors.New("a published dataset cannot be deleted")
-	ErrDeletePublishedVersionForbidden    = errors.New("a published version cannot be deleted")
-	ErrDimensionNodeNotFound              = errors.New("dimension node not found")
-	ErrDimensionNotFound                  = errors.New("dimension not found")
-	ErrDimensionOptionNotFound            = errors.New("dimension option not found")
-	ErrDimensionsNotFound                 = errors.New("dimensions not found")
-	ErrEditionNotFound                    = errors.New("edition not found")
-	ErrEditionsNotFound                   = errors.New("no editions were found")
-	ErrIncorrectStateToDetach             = errors.New("only versions with a state of edition-confirmed or associated can be detached")
-	ErrInstanceNotFound                   = errors.New("instance not found")
-	ErrInstanceConflict                   = errors.New("instance does not match the expected eTag")
-	ErrInternalServer                     = errors.New("internal error")
-	ErrInsertedObservationsInvalidSyntax  = errors.New("inserted observation request parameter not an integer")
-	ErrInvalidQueryParameter              = errors.New("invalid query parameter")
-	ErrInvalidBody                        = errors.New("invalid request body")
-	ErrTooManyQueryParameters             = errors.New("too many query parameters have been provided")
-	ErrMetadataVersionNotFound            = errors.New("version not found")
-	ErrMissingJobProperties               = errors.New("missing job properties")
-	ErrMissingParameters                  = errors.New("missing properties in JSON")
-	ErrResourcePublished                  = errors.New("unable to update resource as it has been published")
-	ErrResourceState                      = errors.New("incorrect resource state")
-	ErrUnableToParseJSON                  = errors.New("failed to parse json body")
-	ErrUnableToReadMessage                = errors.New("failed to read message body")
-	ErrUnauthorised                       = errors.New("unauthorised access to API")
-	ErrVersionMissingState                = errors.New("missing state from version")
-	ErrVersionNotFound                    = errors.New("version not found")
-	ErrVersionsNotFound                   = errors.New("no versions were found")
-	ErrInvalidVersion                     = errors.New("invalid version requested")
-	ErrVersionAlreadyExists               = errors.New("an unpublished version of this dataset already exists")
-	ErrNotFound                           = errors.New("not found")
-	ErrMissingDatasetID                   = errors.New("invalid fields: missing dataset id in request body")
-	ErrEditionAlreadyExists               = errors.New("the edition already exists")
-	ErrEditionTitleAlreadyExists          = errors.New("the edition-title already exists")
-	ErrInvalidDatasetTypeForEditionUpdate = errors.New("unable to update edition-id, invalid dataset type")
-	ErrSpacesNotAllowedInID               = errors.New("spaces are not allowed in the ID field")
-	ErrCannotChangeIDForPublishedDataset  = errors.New("cannot change the dataset ID for a published dataset")
-	ErrFileMetadataNotFound               = errors.New("file metadata not found")
-	ErrFileNotInCorrectState              = errors.New("file not in correct state")
-	ErrInvalidParamCombination            = errors.New("cannot request state and published parameters at the same time")
-	ErrMethodNotAllowed                   = errors.New("method not allowed")
-	ErrPublishedDatasetTopicChange        = errors.New("canonical topic can't be changed once a series is published")
-	ErrStateNotFound                      = errors.New("incorrect state, can be one of the following: edition-confirmed, associated, approved or published")
+	ErrAddDatasetAlreadyExists                 = errors.New("dataset already exists")
+	ErrAddDatasetTitleAlreadyExists            = errors.New("dataset title already exists")
+	ErrDatasetTypeInvalid                      = errors.New("invalid dataset type")
+	ErrTypeMismatch                            = errors.New("type mismatch")
+	ErrAddUpdateDatasetBadRequest              = errors.New("failed to parse json body")
+	ErrConflictUpdatingInstance                = errors.New("conflict updating instance resource")
+	ErrDatasetNotFound                         = errors.New("dataset not found")
+	ErrDeletePublishedDatasetForbidden         = errors.New("a published dataset cannot be deleted")
+	ErrDeletePublishedVersionForbidden         = errors.New("a published version cannot be deleted")
+	ErrDimensionNodeNotFound                   = errors.New("dimension node not found")
+	ErrDimensionNotFound                       = errors.New("dimension not found")
+	ErrDimensionOptionNotFound                 = errors.New("dimension option not found")
+	ErrDimensionsNotFound                      = errors.New("dimensions not found")
+	ErrEditionNotFound                         = errors.New("edition not found")
+	ErrEditionsNotFound                        = errors.New("no editions were found")
+	ErrIncorrectStateToDetach                  = errors.New("only versions with a state of edition-confirmed or associated can be detached")
+	ErrInstanceNotFound                        = errors.New("instance not found")
+	ErrInstanceConflict                        = errors.New("instance does not match the expected eTag")
+	ErrInternalServer                          = errors.New("internal error")
+	ErrInsertedObservationsInvalidSyntax       = errors.New("inserted observation request parameter not an integer")
+	ErrInvalidQueryParameter                   = errors.New("invalid query parameter")
+	ErrInvalidBody                             = errors.New("invalid request body")
+	ErrTooManyQueryParameters                  = errors.New("too many query parameters have been provided")
+	ErrMetadataVersionNotFound                 = errors.New("version not found")
+	ErrMissingJobProperties                    = errors.New("missing job properties")
+	ErrMissingParameters                       = errors.New("missing properties in JSON")
+	ErrResourcePublished                       = errors.New("unable to update resource as it has been published")
+	ErrResourceState                           = errors.New("incorrect resource state")
+	ErrUnableToParseJSON                       = errors.New("failed to parse json body")
+	ErrUnableToReadMessage                     = errors.New("failed to read message body")
+	ErrUnauthorised                            = errors.New("unauthorised access to API")
+	ErrVersionMissingState                     = errors.New("missing state from version")
+	ErrVersionNotFound                         = errors.New("version not found")
+	ErrVersionsNotFound                        = errors.New("no versions were found")
+	ErrInvalidVersion                          = errors.New("invalid version requested")
+	ErrVersionAlreadyExists                    = errors.New("an unpublished version of this dataset already exists")
+	ErrNotFound                                = errors.New("not found")
+	ErrMissingDatasetID                        = errors.New("invalid fields: missing dataset id in request body")
+	ErrEditionAlreadyExists                    = errors.New("the edition already exists")
+	ErrEditionTitleAlreadyExists               = errors.New("the edition-title already exists")
+	ErrInvalidDatasetTypeForEditionUpdate      = errors.New("unable to update edition-id, invalid dataset type")
+	ErrSpacesNotAllowedInID                    = errors.New("spaces are not allowed in the ID field")
+	ErrCannotChangeIDForPublishedDataset       = errors.New("cannot change the dataset ID for a published dataset")
+	ErrCannotChangeDatasetIDForMigratedDataset = errors.New("cannot change the dataset ID for a migrated dataset")
+	ErrCannotChangeEditionIDForMigratedEdition = errors.New("cannot change the edition ID for a migrated edition")
+	ErrFileMetadataNotFound                    = errors.New("file metadata not found")
+	ErrFileNotInCorrectState                   = errors.New("file not in correct state")
+	ErrInvalidParamCombination                 = errors.New("cannot request state and published parameters at the same time")
+	ErrMethodNotAllowed                        = errors.New("method not allowed")
+	ErrPublishedDatasetTopicChange             = errors.New("canonical topic can't be changed once a series is published")
+	ErrStateNotFound                           = errors.New("incorrect state, can be one of the following: edition-confirmed, associated, approved or published")
 
 	ErrExpectedResourceStateOfCreated          = errors.New("unable to update resource, expected resource to have a state of created")
 	ErrExpectedResourceStateOfSubmitted        = errors.New("unable to update resource, expected resource to have a state of submitted")
@@ -101,13 +103,15 @@ var (
 	}
 
 	ConflictRequestMap = map[error]bool{
-		ErrAddDatasetAlreadyExists:           true,
-		ErrCannotChangeIDForPublishedDataset: true,
-		ErrConflictUpdatingInstance:          true,
-		ErrInstanceConflict:                  true,
-		ErrEditionAlreadyExists:              true,
-		ErrEditionTitleAlreadyExists:         true,
-		ErrFileNotInCorrectState:             true,
+		ErrAddDatasetAlreadyExists:                 true,
+		ErrCannotChangeIDForPublishedDataset:       true,
+		ErrCannotChangeDatasetIDForMigratedDataset: true,
+		ErrCannotChangeEditionIDForMigratedEdition: true,
+		ErrConflictUpdatingInstance:                true,
+		ErrInstanceConflict:                        true,
+		ErrEditionAlreadyExists:                    true,
+		ErrEditionTitleAlreadyExists:               true,
+		ErrFileNotInCorrectState:                   true,
 	}
 
 	ForbiddenMap = map[error]bool{

--- a/features/static_dataset_put.feature
+++ b/features/static_dataset_put.feature
@@ -13,7 +13,6 @@ Feature: PUT /datasets/{id} for static datasets
                         "title": "Original Title",
                         "description": "A static dataset",
                         "state": "created",
-                        "is_migration": true,
                         "topics": [
                             "old-topic",
                             "topic-1"
@@ -65,6 +64,19 @@ Feature: PUT /datasets/{id} for static datasets
                             "old-topic",
                             "topic-1"
                         ]
+                    }
+                },
+                {
+                    "next": {
+                        "id": "migrated-dataset-id",
+                        "state": "created",
+                        "type": "static",
+                        "title": "Migrated Dataset",
+                        "topics": [
+                            "old-topic",
+                            "topic-1"
+                        ],
+                        "is_migration": true
                     }
                 }
             ]
@@ -146,7 +158,6 @@ Feature: PUT /datasets/{id} for static datasets
                     "prices"
                 ],
                 "type": "static",
-                "is_migration": true,
                 "topics": [
                     "economy-topic-id",
                     "topic-1"
@@ -263,6 +274,38 @@ Feature: PUT /datasets/{id} for static datasets
         And I should receive the following response:
             """
             cannot change the dataset ID for a published dataset
+            """
+
+    Scenario: Cannot change id of a migrated dataset
+        When I PUT "/datasets/migrated-dataset-id"
+            """
+            {
+                "id": "new-dataset-id",
+                "type": "static",
+                "title": "Migrated Dataset",
+                "description": "Migrated static dataset",
+                "next_release": "2026-01-01T00:00:00Z",
+                "contacts": [
+                    {
+                        "name": "John Doe",
+                        "email": "john@example.com"
+                    }
+                ],
+                "license": "Open Government Licence v3.0",
+                "keywords": [
+                    "economy",
+                    "prices"
+                ],
+                "topics": [
+                    "old-topic",
+                    "topic-1"
+                ]
+            }
+            """
+        Then the HTTP status code should be "409"
+        And I should receive the following response:
+            """
+            cannot change the dataset ID for a migrated dataset
             """
 
     Scenario: Cannot change canonical topic of published static dataset

--- a/features/static_versions_put.feature
+++ b/features/static_versions_put.feature
@@ -1100,6 +1100,65 @@ Feature: Static Dataset Versions PUT API
             }
             """
 
+    Scenario: PUT fails when attempting to change edition ID for a migrated version
+        Given I have a static dataset with version:
+            """
+            {
+                "dataset": {
+                    "id": "migrated-dataset",
+                    "title": "Migrated Dataset",
+                    "state": "associated",
+                    "type": "static"
+                },
+                "version": {
+                    "id": "migrated-version",
+                    "edition": "original-edition",
+                    "edition_title": "Original Edition",
+                    "links": {
+                        "dataset": {
+                            "id": "migrated-dataset"
+                        },
+                        "edition": {
+                            "href": "/datasets/migrated-dataset/editions/original-edition",
+                            "id": "original-edition"
+                        },
+                        "self": {
+                            "href": "/datasets/migrated-dataset/editions/original-edition/versions/1"
+                        }
+                    },
+                    "version": 1,
+                    "release_date": "2025-01-01T09:00:00.000Z",
+                    "state": "associated",
+                    "type": "static",
+                    "is_migration": true,
+                    "distributions": [
+                        {
+                            "title": "csv",
+                            "format": "csv",
+                            "media_type": "text/csv",
+                            "download_url": "/uuid/filename.csv",
+                            "byte_size": 125000
+                        }
+                    ]
+                }
+            }
+            """
+        And private endpoints are enabled
+        And I am an admin user
+        When I PUT "/datasets/migrated-dataset/editions/original-edition/versions/1"
+            """
+            {
+                "edition": "changed-edition",
+                "edition_title": "Changed Edition",
+                "type": "static"
+            }
+            """
+        Then the HTTP status code should be "409"
+        And I should receive the following response:
+            """
+            cannot change the edition ID for a migrated edition
+            """
+
     Scenario: PUT successfully updates edition ID and all associated links
       Given I have a static dataset with version:
           """


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-5144

- Do not allow datasetID or editionID to be changed on migrated datasets

### How to review

- Check changes are ok
- Create a dataset and edition with both having `is_migration` set to `true` when creating them
- Try to change the id on the dataset or edition IDs and a 409 error should be returned

### Who can review

- Anyone
