### PR TITLE
wait for async Kafka message and Cloudflare purge in unit tests

### DIFF
--- a/api/dataset_test.go
+++ b/api/dataset_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/ONSdigital/dp-dataset-api/url"
 	filesAPISDK "github.com/ONSdigital/dp-files-api/sdk"
 	filesAPISDKMocks "github.com/ONSdigital/dp-files-api/sdk/mocks"
-	kafka "github.com/ONSdigital/dp-kafka/v4"
 	dprequest "github.com/ONSdigital/dp-net/v3/request"
 	"github.com/gorilla/mux"
 
@@ -78,16 +77,6 @@ var (
 	enableURLRewriting = false
 	mu                 sync.Mutex
 )
-
-func getSearchContentUpdatedMock() *mocks.KafkaProducerMock {
-	producerMock := &mocks.KafkaProducerMock{
-		OutputFunc: func() chan kafka.BytesMessage {
-			return make(chan kafka.BytesMessage, 1)
-		},
-	}
-
-	return producerMock
-}
 
 // GetAPIWithCMDMocks also used in other tests, so exported
 func GetAPIWithCMDMocks(mockedDataStore store.Storer, mockedGeneratedDownloads DownloadsGenerator, authorisationMock *authMock.MiddlewareMock, searchContentUpdated application.SearchContentUpdatedProducer, cloudflareMock *cloudflareMocks.ClienterMock, auditServiceMock *applicationMocks.AuditServiceMock, staticDatasetServiceMock *applicationMocks.StaticDatasetServiceMock, topicAPISDKMock *topicAPISDKMocks.ClienterMock, filesAPISDKMock *filesAPISDKMocks.ClienterMock) *DatasetAPI {

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -29,6 +29,7 @@ import (
 	filesAPISDK "github.com/ONSdigital/dp-files-api/sdk"
 	filesAPISDKMocks "github.com/ONSdigital/dp-files-api/sdk/mocks"
 	filesAPIErrors "github.com/ONSdigital/dp-files-api/store"
+	kafka "github.com/ONSdigital/dp-kafka/v4"
 	permissionsAPISDK "github.com/ONSdigital/dp-permissions-api/sdk"
 	topicAPISDKMocks "github.com/ONSdigital/dp-topic-api/sdk/mocks"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -4970,11 +4971,19 @@ func TestPutStateReturnsOk(t *testing.T) {
 			},
 		}
 
-		scuProducerMock := getSearchContentUpdatedMock()
+		outputCalled := make(chan bool, 1)
+		scuProducerMock := &mocks.KafkaProducerMock{
+			OutputFunc: func() chan kafka.BytesMessage {
+				outputCalled <- true
+				return make(chan kafka.BytesMessage, 1)
+			},
+		}
 		searchContentUpdated := application.SearchContentUpdatedProducer{Producer: scuProducerMock}
 
+		purgeByPrefixesCalled := make(chan bool, 1)
 		cloudflareMock := &cloudflareMocks.ClienterMock{
 			PurgeByPrefixesFunc: func(ctx context.Context, prefixes []string) error {
+				purgeByPrefixesCalled <- true
 				return nil
 			},
 			GetTimeoutFunc: func() time.Duration {
@@ -4990,6 +4999,17 @@ func TestPutStateReturnsOk(t *testing.T) {
 
 		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, searchContentUpdated, cloudflareMock, auditServiceMock, &applicationMocks.StaticDatasetServiceMock{}, &topicAPISDKMocks.ClienterMock{}, &mockFilesAPIClient)
 		api.Router.ServeHTTP(w, r)
+
+		select {
+		case <-outputCalled:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for kafka message to be sent")
+		}
+		select {
+		case <-purgeByPrefixesCalled:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for Cloudflare purge")
+		}
 
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(mockedDataStore.GetVersionStaticCalls(), ShouldHaveLength, 2)


### PR DESCRIPTION
### What

- Bug fix for occasional unit test failures
- Cloudflare and Kafka function calls are made asynchronously within the `PUT .../state` endpoint meaning that the request can return a 200 response before the function calls have completed. This then causes assertions like `So(len(scuProducerMock.OutputCalls()), ShouldEqual, 1)` and `So(cloudflareMock.GetTimeoutCalls(), ShouldHaveLength, 1)` to fail.
- This has been fixed by adding a maximum 5 second wait for these calls to complete else the test will fail. The same approach has been used previously [here](https://github.com/ONSdigital/dp-dataset-api/blob/a3c6c81887bb14d5bc2f22ec866d38714246a019/api/versions_test.go#L1783-L1857).

### How to review

- Check unit tests can pass
- To confirm this works you can add a 6 second `time.Sleep()` before the lines [here](https://github.com/ONSdigital/dp-dataset-api/blob/a3c6c81887bb14d5bc2f22ec866d38714246a019/application/application.go#L764) and [here](https://github.com/ONSdigital/dp-dataset-api/blob/a3c6c81887bb14d5bc2f22ec866d38714246a019/application/application.go#L778) to simulate the function calls being made late (longer than the 5 second timeout I set in the tests). Then run the `TestPutStateReturnsOk` unit test and it will return a `timed out waiting for...` failure. (Remove the sleeps one by one to see the error message change depending on which call was timing out)

### Who can review

- Anyone