### PR TITLE
fix: related content now deleted from database

### DIFF
--- a/mongo/dataset_store.go
+++ b/mongo/dataset_store.go
@@ -626,6 +626,8 @@ func createVersionUpdateQuery(version *models.Version, newETag string) bson.M {
 
 	if version.RelatedContent != nil {
 		setUpdates["related_content"] = version.RelatedContent
+	} else {
+		setUpdates["related_content"] = nil
 	}
 
 	if newETag != "" {


### PR DESCRIPTION
### What

Fixed the issue where `related_content` was persisting in the database when it should have been deleted.

### How to review

Verify that when a `PUT` request is sent for a version that currently has `related_content` associated with it, and the body of the request does not contain a `related_content` object, that the database reflects this deletion.

### Who can review

Anyone
