### PR TITLE
Feature/add is migration field to metadata endpoint

### DIFF
--- a/api/metadata.go
+++ b/api/metadata.go
@@ -133,8 +133,15 @@ func (api *DatasetAPI) getMetadata(w http.ResponseWriter, r *http.Request) {
 		if api.enableURLRewriting {
 			datasetLinksBuilder := links.FromHeadersOrDefault(&r.Header, api.urlBuilder.GetDatasetAPIURL())
 			codeListLinksBuilder := links.FromHeadersOrDefault(&r.Header, api.urlBuilder.GetCodeListAPIURL())
+			websiteLinksBuilder := &links.Builder{}
 
-			err = utils.RewriteMetadataLinks(ctx, metaDataDoc.Links, datasetLinksBuilder)
+			if authorised {
+				websiteLinksBuilder.URL = api.urlBuilder.GetPrivateWebsiteURL()
+			} else {
+				websiteLinksBuilder.URL = api.urlBuilder.GetPublicWebsiteURL()
+			}
+
+			err = utils.RewriteMetadataLinks(ctx, metaDataDoc.Links, datasetLinksBuilder, websiteLinksBuilder)
 			if err != nil {
 				log.Error(ctx, "getMetadata endpoint: failed to rewrite metadata links", err, logData)
 				return nil, err
@@ -163,12 +170,6 @@ func (api *DatasetAPI) getMetadata(w http.ResponseWriter, r *http.Request) {
 				log.Error(ctx, "getMetadata endpoint: failed to rewrite distributions DownloadURL", err, logData)
 				return nil, err
 			}
-		}
-
-		b, err := json.Marshal(metaDataDoc)
-		if err != nil {
-			log.Error(ctx, "getMetadata endpoint: failed to marshal metadata resource into bytes", err, logData)
-			return nil, err
 		}
 
 		if authorised {
@@ -200,6 +201,14 @@ func (api *DatasetAPI) getMetadata(w http.ResponseWriter, r *http.Request) {
 				"endpoint": "/datasets/" + datasetID + "/editions/" + edition + "/versions/" + version + "/metadata",
 				"outcome":  "success",
 			})
+		} else {
+			metaDataDoc.IsMigration = nil
+		}
+
+		b, err := json.Marshal(metaDataDoc)
+		if err != nil {
+			log.Error(ctx, "getMetadata endpoint: failed to marshal metadata resource into bytes", err, logData)
+			return nil, err
 		}
 
 		return b, err

--- a/api/metadata_test.go
+++ b/api/metadata_test.go
@@ -697,6 +697,109 @@ func TestGetMetadataReturnsOk(t *testing.T) {
 		So(metaData.UnitOfMeasure, ShouldEqual, "Pounds Sterling")
 		So(metaData.State, ShouldEqual, versionDoc.State)
 	})
+
+	Convey("Authenticated user sees is_migration in metadata response for a static dataset", t, func() {
+		datasetDoc := createDatasetDoc()
+		datasetDoc.Current.Type = staticType
+		if datasetDoc.Next != nil {
+			datasetDoc.Next.Type = staticType
+		}
+
+		versionDoc := createPublishedVersionDoc()
+		versionDoc.IsMigration = boolPtr(true)
+
+		r := createRequestWithAuth("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/metadata", nil)
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return datasetDoc, nil
+			},
+			CheckEditionExistsStaticFunc: func(context.Context, string, string, string) error {
+				return nil
+			},
+			GetVersionStaticFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
+				return versionDoc, nil
+			},
+			GetVersionsStaticByEditionNoLimitFunc: func(ctx context.Context, datasetID string, edition string, state string) ([]*models.Version, int, error) {
+				return nil, 0, nil
+			},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return &permissionsAPISDK.EntityData{UserID: "test-user-id"}, nil
+			},
+		}
+
+		auditServiceMock := &applicationMocks.AuditServiceMock{
+			RecordMetadataAuditEventFunc: func(ctx context.Context, requestedBy models.RequestedBy, action models.Action, resource string, metadata *models.Metadata) error {
+				return nil
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, application.SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, auditServiceMock, &applicationMocks.StaticDatasetServiceMock{}, nil, &filesAPISDKMocks.ClienterMock{})
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusOK)
+
+		var metaData models.Metadata
+		err := json.Unmarshal(w.Body.Bytes(), &metaData)
+		So(err, ShouldBeNil)
+		So(metaData.IsMigration, ShouldNotBeNil)
+		So(*metaData.IsMigration, ShouldBeTrue)
+	})
+
+	Convey("Unauthenticated user does not see is_migration in metadata response for a static dataset", t, func() {
+		datasetDoc := createDatasetDoc()
+		datasetDoc.Current.Type = staticType
+		if datasetDoc.Next != nil {
+			datasetDoc.Next.Type = staticType
+		}
+
+		versionDoc := createPublishedVersionDoc()
+		versionDoc.IsMigration = boolPtr(true)
+
+		r := httptest.NewRequest("GET", "http://localhost:22000/datasets/123/editions/2017/versions/1/metadata", http.NoBody)
+		w := httptest.NewRecorder()
+
+		mockedDataStore := &storetest.StorerMock{
+			GetDatasetFunc: func(context.Context, string) (*models.DatasetUpdate, error) {
+				return datasetDoc, nil
+			},
+			CheckEditionExistsStaticFunc: func(context.Context, string, string, string) error {
+				return nil
+			},
+			GetVersionStaticFunc: func(context.Context, string, string, int, string) (*models.Version, error) {
+				return versionDoc, nil
+			},
+			GetVersionsStaticByEditionNoLimitFunc: func(ctx context.Context, datasetID string, edition string, state string) ([]*models.Version, int, error) {
+				return nil, 0, nil
+			},
+		}
+
+		authorisationMock := &authMock.MiddlewareMock{
+			RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+				return handlerFunc
+			},
+			ParseFunc: func(token string) (*permissionsAPISDK.EntityData, error) {
+				return nil, permissionsAPISDK.ErrFailedToParsePermissionsResponse
+			},
+		}
+
+		api := GetAPIWithCMDMocks(mockedDataStore, &mocks.DownloadsGeneratorMock{}, authorisationMock, application.SearchContentUpdatedProducer{}, &cloudflareMocks.ClienterMock{}, &applicationMocks.AuditServiceMock{}, &applicationMocks.StaticDatasetServiceMock{}, nil, &filesAPISDKMocks.ClienterMock{})
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusOK)
+
+		var metaData models.Metadata
+		err := json.Unmarshal(w.Body.Bytes(), &metaData)
+		So(err, ShouldBeNil)
+		So(metaData.IsMigration, ShouldBeNil)
+	})
 }
 
 func TestGetMetadataReturnsError(t *testing.T) {

--- a/application/application.go
+++ b/application/application.go
@@ -747,7 +747,7 @@ func PublishVersionInfo(ctx context.Context, smDS *StateMachineDatasetAPI,
 
 				searchContentUpdatedEvent := map[string]interface{}{
 					"dataset_id":   versionDetails.datasetID,
-					"uri":          fmt.Sprintf("/datasets/%s", versionDetails.datasetID),
+					"uri":          updatedV.Links.WebPage.HRef,
 					"title":        updatedV.EditionTitle,
 					"edition":      updatedV.Edition,
 					"content_type": "dataset_landing_page",

--- a/application/application.go
+++ b/application/application.go
@@ -747,7 +747,7 @@ func PublishVersionInfo(ctx context.Context, smDS *StateMachineDatasetAPI,
 
 				searchContentUpdatedEvent := map[string]interface{}{
 					"dataset_id":   versionDetails.datasetID,
-					"uri":          updatedV.Links.WebPage.HRef,
+					"uri":          fmt.Sprintf("/%s", strings.TrimLeft(updatedV.Links.WebPage.HRef, "/")),
 					"title":        updatedV.EditionTitle,
 					"edition":      updatedV.Edition,
 					"content_type": "dataset_landing_page",

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -2289,9 +2289,6 @@ func TestPublishVersionDatasetDownloadsOK(t *testing.T) {
 					HRef: "http://localhost:22000/datasets/123",
 					ID:   "123",
 				},
-				Dimensions: &models.LinkObject{
-					HRef: "http://localhost:22000/datasets/123/editions/2017/versions/1/dimensions",
-				},
 				Edition: &models.LinkObject{
 					HRef: "http://localhost:22000/datasets/123/editions/2017",
 					ID:   "2017",
@@ -2302,6 +2299,9 @@ func TestPublishVersionDatasetDownloadsOK(t *testing.T) {
 				Version: &models.LinkObject{
 					HRef: "http://localhost:22000/datasets/123/editions/2017/versions/1",
 					ID:   "1",
+				},
+				WebPage: &models.LinkObject{
+					HRef: "http://localhost:22000/economy/datasets/123/editions/2017/versions/1",
 				},
 			},
 		}
@@ -2320,9 +2320,6 @@ func TestPublishVersionDatasetDownloadsOK(t *testing.T) {
 					HRef: "http://localhost:22000/datasets/123",
 					ID:   "123",
 				},
-				Dimensions: &models.LinkObject{
-					HRef: "http://localhost:22000/datasets/123/editions/2017/versions/1/dimensions",
-				},
 				Edition: &models.LinkObject{
 					HRef: "http://localhost:22000/datasets/123/editions/2017",
 					ID:   "2017",
@@ -2333,6 +2330,9 @@ func TestPublishVersionDatasetDownloadsOK(t *testing.T) {
 				Version: &models.LinkObject{
 					HRef: "http://localhost:22000/datasets/123/editions/2017/versions/1",
 					ID:   "1",
+				},
+				WebPage: &models.LinkObject{
+					HRef: "http://localhost:22000/economy/datasets/123/editions/2017/versions/1",
 				},
 			},
 		}

--- a/features/get_metadata_with_permissions.feature
+++ b/features/get_metadata_with_permissions.feature
@@ -8,7 +8,7 @@ Feature: Dataset API - Metadata Permissions
                     "id": "static-test-dataset",
                     "title": "static dataset title",
                     "description": "Public Description",
-                    "state": "published",
+                    "state": "created",
                     "type": "static",
                     "license": "Open Government License v3.0"
                 },
@@ -21,20 +21,115 @@ Feature: Dataset API - Metadata Permissions
                     "release_date": "2023-05-20",
                     "links": {
                         "dataset": {
+                            "href": "/datasets/static-test-dataset",
                             "id": "static-test-dataset"
                         },
                         "edition": {
+                            "href": "/datasets/static-test-dataset/editions/time-series",
                             "id": "time-series"
                         },
                         "self": {
                             "href": "/datasets/static-test-dataset/editions/time-series/versions/1"
+                        },
+                        "web_page": {
+                            "href": "economy/datasets/static-test-dataset/editions/time-series/versions/1"
                         }
                     },
                     "distributions": [
                         {
                             "title": "Dataset CSV",
                             "format": "csv",
-                            "download_url": "/files/data.csv"
+                            "download_url": "uuid/data.csv"
+                        }
+                    ]
+                }
+            }
+            """
+        And I have a static dataset with version:
+            """
+            {
+                "dataset": {
+                    "id": "static-migrated-dataset-unpublished",
+                    "title": "static migration title",
+                    "description": "Migration Description",
+                    "state": "created",
+                    "type": "static",
+                    "license": "Open Government License v3.0"
+                },
+                "version": {
+                    "id": "v1-migration-approved",
+                    "version": 1,
+                    "edition": "time-series",
+                    "state": "approved",
+                    "type": "static",
+                    "release_date": "2023-05-20",
+                    "is_migration": true,
+                    "links": {
+                        "dataset": {
+                            "href": "/datasets/static-migrated-dataset-unpublished",
+                            "id": "static-migrated-dataset-unpublished"
+                        },
+                        "edition": {
+                            "href": "/datasets/static-migrated-dataset-unpublished/editions/time-series",
+                            "id": "time-series"
+                        },
+                        "self": {
+                            "href": "/datasets/static-migrated-dataset-unpublished/editions/time-series/versions/1"
+                        },
+                        "web_page": {
+                            "href": "economy/datasets/static-migrated-dataset-unpublished/editions/time-series/versions/1"
+                        }
+                    },
+                    "distributions": [
+                        {
+                            "title": "Dataset CSV",
+                            "format": "csv",
+                            "download_url": "uuid/data.csv"
+                        }
+                    ]
+                }
+            }
+            """
+        And I have a static dataset with version:
+            """
+            {
+                "dataset": {
+                    "id": "static-migrated-dataset-published",
+                    "title": "static migration published title",
+                    "description": "Migration Published Description",
+                    "state": "published",
+                    "type": "static",
+                    "license": "Open Government License v3.0"
+                },
+                "version": {
+                    "id": "v1-migration-published",
+                    "version": 1,
+                    "edition": "time-series",
+                    "state": "published",
+                    "type": "static",
+                    "release_date": "2023-05-20",
+                    "is_migration": true,
+                    "links": {
+                        "dataset": {
+                            "href": "/datasets/static-migrated-dataset-published",
+                            "id": "static-migrated-dataset-published"
+                        },
+                        "edition": {
+                            "href": "/datasets/static-migrated-dataset-published/editions/time-series",
+                            "id": "time-series"
+                        },
+                        "self": {
+                            "href": "/datasets/static-migrated-dataset-published/editions/time-series/versions/1"
+                        },
+                        "web_page": {
+                            "href": "economy/datasets/static-migrated-dataset-published/editions/time-series/versions/1"
+                        }
+                    },
+                    "distributions": [
+                        {
+                            "title": "Dataset CSV",
+                            "format": "csv",
+                            "download_url": "uuid/data.csv"
                         }
                     ]
                 }
@@ -52,7 +147,7 @@ Feature: Dataset API - Metadata Permissions
                 "description": "Public Description",
                 "distributions": [
                     {
-                        "download_url": "/files/data.csv",
+                        "download_url": "uuid/data.csv",
                         "format": "csv",
                         "title": "Dataset CSV"
                     }
@@ -70,7 +165,7 @@ Feature: Dataset API - Metadata Permissions
                         "id": "1"
                     },
                     "website_version": {
-                        "href": "http://localhost:20000/datasets/static-test-dataset/editions/time-series/versions/1"
+                        "href": "economy/datasets/static-test-dataset/editions/time-series/versions/1"
                     }
                 },
                 "release_date": "2023-05-20",
@@ -81,6 +176,84 @@ Feature: Dataset API - Metadata Permissions
             }
             """
 
+    Scenario: GET /datasets/{id}/editions/{edition}/versions/1/metadata returns is_migration for an authorised viewer
+        Given private endpoints are enabled
+        And I am a JWT user with email "viewer1@ons.gov.uk" and group "role-viewer-allowed"
+        And I have viewer access to the dataset edition "static-migrated-dataset-unpublished/time-series"
+        When I GET "/datasets/static-migrated-dataset-unpublished/editions/time-series/versions/1/metadata"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "description": "Migration Description",
+                "distributions": [
+                    {
+                        "download_url": "uuid/data.csv",
+                        "format": "csv",
+                        "title": "Dataset CSV"
+                    }
+                ],
+                "edition": "time-series",
+                "id": "static-migrated-dataset-unpublished",
+                "is_migration": true,
+                "last_updated": "0001-01-01T00:00:00Z",
+                "license": "Open Government License v3.0",
+                "links": {
+                    "self": {
+                        "href": "/datasets/static-migrated-dataset-unpublished/editions/time-series/versions/1/metadata"
+                    },
+                    "version": {
+                        "href": "/datasets/static-migrated-dataset-unpublished/editions/time-series/versions/1",
+                        "id": "1"
+                    },
+                    "website_version": {
+                        "href": "economy/datasets/static-migrated-dataset-unpublished/editions/time-series/versions/1"
+                    }
+                },
+                "release_date": "2023-05-20",
+                "state": "approved",
+                "title": "static migration title",
+                "type": "static",
+                "version": 1
+            }
+            """
+
+    Scenario: GET /datasets/{id}/editions/{edition}/versions/1/metadata does not return is_migration for an unauthenticated user
+        When I GET "/datasets/static-migrated-dataset-published/editions/time-series/versions/1/metadata"
+        Then I should receive the following JSON response with status "200":
+            """
+            {
+                "description": "Migration Published Description",
+                "distributions": [
+                    {
+                        "download_url": "uuid/data.csv",
+                        "format": "csv",
+                        "title": "Dataset CSV"
+                    }
+                ],
+                "edition": "time-series",
+                "id": "static-migrated-dataset-published",
+                "last_updated": "0001-01-01T00:00:00Z",
+                "license": "Open Government License v3.0",
+                "links": {
+                    "self": {
+                        "href": "/datasets/static-migrated-dataset-published/editions/time-series/versions/1/metadata"
+                    },
+                    "version": {
+                        "href": "/datasets/static-migrated-dataset-published/editions/time-series/versions/1",
+                        "id": "1"
+                    },
+                    "website_version": {
+                        "href": "economy/datasets/static-migrated-dataset-published/editions/time-series/versions/1"
+                    }
+                },
+                "release_date": "2023-05-20",
+                "state": "published",
+                "title": "static migration published title",
+                "type": "static",
+                "version": 1
+            }
+            """
+    
     Scenario: GET /datasets/{id}/editions/{edition}/versions/1 returns 403 for an unauthorised viewer
         Given private endpoints are enabled
         And I am a JWT user with email "viewer1@ons.gov.uk" and group "role-viewer-allowed"

--- a/features/metadata.feature
+++ b/features/metadata.feature
@@ -1007,9 +1007,11 @@ Scenario: GET metadata for a static dataset
                 ],
                 "links": {
                     "dataset": {
+                        "href": "/datasets/static-dataset",
                         "id": "static-dataset"
                     },
                     "edition": {
+                        "href": "/datasets/static-dataset/editions/time-series",
                         "id": "time-series"
                     },
                     "self": {
@@ -1018,6 +1020,9 @@ Scenario: GET metadata for a static dataset
                     "version": {
                         "href": "/datasets/static-dataset/editions/time-series/versions/1",
                         "id": "1"
+                    },
+                    "web_page": {
+                        "href": "economy/datasets/static-dataset/editions/time-series/versions/1"
                     }
                 },
                 "edition": "time-series",
@@ -1061,7 +1066,7 @@ Scenario: GET metadata for a static dataset
                     "id": "1"
                 },
                 "website_version": {
-                    "href": "http://localhost:20000/datasets/static-dataset/editions/time-series/versions/1"
+                    "href": "economy/datasets/static-dataset/editions/time-series/versions/1"
                 }
             },
             "edition": "time-series",
@@ -1125,9 +1130,11 @@ Scenario: GET metadata for a static dataset with URL rewriting enabled
                 ],
                 "links": {
                     "dataset": {
+                        "href": "/datasets/static-dataset",
                         "id": "static-dataset"
                     },
                     "edition": {
+                        "href": "/datasets/static-dataset/editions/time-series",
                         "id": "time-series"
                     },
                     "self": {
@@ -1136,6 +1143,9 @@ Scenario: GET metadata for a static dataset with URL rewriting enabled
                     "version": {
                         "href": "/datasets/static-dataset/editions/time-series/versions/1",
                         "id": "1"
+                    },
+                    "web_page": {
+                        "href": "economy/datasets/static-dataset/editions/time-series/versions/1"
                     }
                 },
                 "edition": "time-series",
@@ -1182,7 +1192,7 @@ Scenario: GET metadata for a static dataset with URL rewriting enabled
                     "id": "1"
                 },
                 "website_version": {
-                    "href": "http://localhost:20000/datasets/static-dataset/editions/time-series/versions/1"
+                    "href": "http://localhost:20000/economy/datasets/static-dataset/editions/time-series/versions/1"
                 }
             },
             "edition": "time-series",
@@ -1246,9 +1256,11 @@ Scenario: GET metadata for an unpublished static dataset
                 ],
                 "links": {
                     "dataset": {
+                        "href": "/datasets/static-dataset",
                         "id": "static-dataset"
                     },
                     "edition": {
+                        "href": "/datasets/static-dataset/editions/time-series",
                         "id": "time-series"
                     },
                     "self": {
@@ -1257,6 +1269,9 @@ Scenario: GET metadata for an unpublished static dataset
                     "version": {
                         "href": "/datasets/static-dataset/editions/time-series/versions/1",
                         "id": "1"
+                    },
+                    "web_page": {
+                        "href": "economy/datasets/static-dataset/editions/time-series/versions/1"
                     }
                 },
                 "edition": "time-series",
@@ -1300,7 +1315,7 @@ Scenario: GET metadata for an unpublished static dataset
                     "id": "1"
                 },
                 "website_version": {
-                    "href": "http://localhost:20000/datasets/static-dataset/editions/time-series/versions/1"
+                    "href": "economy/datasets/static-dataset/editions/time-series/versions/1"
                 }
             },
             "edition": "time-series",

--- a/features/metadata_web.feature
+++ b/features/metadata_web.feature
@@ -35,9 +35,11 @@ Scenario: GET metadata for a published static dataset
                 ],
                 "links": {
                     "dataset": {
+                        "href": "/datasets/static-dataset",
                         "id": "static-dataset"
                     },
                     "edition": {
+                        "href": "/datasets/static-dataset/editions/time-series",
                         "id": "time-series"
                     },
                     "self": {
@@ -46,6 +48,9 @@ Scenario: GET metadata for a published static dataset
                     "version": {
                         "href": "/datasets/static-dataset/editions/time-series/versions/1",
                         "id": "1"
+                    },
+                    "web_page": {
+                        "href": "economy/datasets/static-dataset/editions/time-series/versions/1"
                     }
                 },
                 "edition": "time-series",
@@ -89,7 +94,7 @@ Scenario: GET metadata for a published static dataset
                     "id": "1"
                 },
                 "website_version": {
-                    "href": "http://localhost:20000/datasets/static-dataset/editions/time-series/versions/1"
+                    "href": "economy/datasets/static-dataset/editions/time-series/versions/1"
                 }
             },
             "edition": "time-series",
@@ -151,9 +156,11 @@ Scenario: GET metadata for an unpublished static dataset
                 ],
                 "links": {
                     "dataset": {
+                        "href": "/datasets/static-dataset",
                         "id": "static-dataset"
                     },
                     "edition": {
+                        "href": "/datasets/static-dataset/editions/time-series",
                         "id": "time-series"
                     },
                     "self": {
@@ -162,6 +169,9 @@ Scenario: GET metadata for an unpublished static dataset
                     "version": {
                         "href": "/datasets/static-dataset/editions/time-series/versions/1",
                         "id": "1"
+                    },
+                    "web_page": {
+                        "href": "economy/datasets/static-dataset/editions/time-series/versions/1"
                     }
                 },
                 "edition": "time-series",

--- a/models/metadata.go
+++ b/models/metadata.go
@@ -43,6 +43,7 @@ type EditableMetadata struct {
 	Description        string             `json:"description,omitempty"`
 	Dimensions         []Dimension        `json:"dimensions,omitempty"`
 	Distributions      *[]Distribution    `json:"distributions,omitempty"`
+	IsMigration        *bool              `json:"is_migration,omitempty"`
 	Keywords           []string           `json:"keywords,omitempty"`
 	LastUpdated        time.Time          `json:"last_updated,omitempty"`
 	LatestChanges      *[]LatestChange    `json:"latest_changes,omitempty"`
@@ -89,6 +90,7 @@ func CreateMetaDataDoc(datasetDoc *Dataset, versionDoc *Version, urlBuilder *url
 			Description:        datasetDoc.Description,
 			Dimensions:         versionDoc.Dimensions,
 			Distributions:      versionDoc.Distributions,
+			IsMigration:        versionDoc.IsMigration,
 			Keywords:           datasetDoc.Keywords,
 			LatestChanges:      versionDoc.LatestChanges,
 			License:            datasetDoc.License,
@@ -138,12 +140,17 @@ func CreateMetaDataDoc(datasetDoc *Dataset, versionDoc *Version, urlBuilder *url
 		metaDataDoc.Links.Spatial = versionDoc.Links.Spatial
 		metaDataDoc.Links.Version = versionDoc.Links.Version
 
-		websiteVersionURL := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d",
-			urlBuilder.GetPublicWebsiteURL(),
-			datasetDoc.ID,
-			versionDoc.Links.Edition.ID,
-			versionDoc.Version,
-		)
+		var websiteVersionURL string
+		if metaDataDoc.Type == Static.String() {
+			websiteVersionURL = versionDoc.Links.WebPage.HRef
+		} else {
+			websiteVersionURL = fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d",
+				urlBuilder.GetPublicWebsiteURL(),
+				datasetDoc.ID,
+				versionDoc.Links.Edition.ID,
+				versionDoc.Version,
+			)
+		}
 
 		metaDataDoc.Links.WebsiteVersion = &LinkObject{
 			HRef: websiteVersionURL,

--- a/models/metadata_test.go
+++ b/models/metadata_test.go
@@ -211,6 +211,16 @@ func TestCreateMetadata(t *testing.T) {
 			Convey("And the state is set from the version", func() {
 				So(metaDataDoc.State, ShouldEqual, version.State)
 			})
+
+			Convey("And the website version URL is built using the urlBuilder and IDs", func() {
+				expectedURL := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d",
+					publicWebsiteURL.String(),
+					dataset.ID,
+					version.Links.Edition.ID,
+					version.Version,
+				)
+				So(metaDataDoc.Links.WebsiteVersion.HRef, ShouldEqual, expectedURL)
+			})
 		})
 
 		Convey("When we call CreateMetaDataDoc with a static dataset", func() {
@@ -218,6 +228,11 @@ func TestCreateMetadata(t *testing.T) {
 			staticDataset := dataset
 			staticDataset.Type = "static"
 			staticDataset.Topics = []string{"topic1", "topic2", "topic3"}
+
+			staticVersion := version
+			staticVersion.Links.WebPage = &LinkObject{
+				HRef: "economy/datasets/123/editions/2017/versions/1",
+			}
 
 			codeListAPIURL := &neturl.URL{Scheme: "http", Host: "localhost:22400"}
 			datasetAPIURL := &neturl.URL{Scheme: "http", Host: "localhost:22000"}
@@ -235,6 +250,10 @@ func TestCreateMetadata(t *testing.T) {
 
 			Convey("And the state is set from the version", func() {
 				So(metaDataDoc.State, ShouldEqual, version.State)
+			})
+
+			Convey("And the website version URL is set to the web page link from the version", func() {
+				So(metaDataDoc.Links.WebsiteVersion.HRef, ShouldEqual, staticVersion.Links.WebPage.HRef)
 			})
 		})
 	})

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2283,6 +2283,9 @@ definitions:
           - cantabular_table
           - ltla
           - ethnic_group_tb_8a
+      is_migration:
+        description: "Indicates whether this version was created as part of a dataset migration"
+        type: boolean
       keywords:
         description: "A list of keywords for a dataset"
         type: array

--- a/utils/rewriting.go
+++ b/utils/rewriting.go
@@ -455,7 +455,7 @@ func RewriteEditionLinks(ctx context.Context, oldLinks *models.EditionUpdateLink
 	return nil
 }
 
-func RewriteMetadataLinks(ctx context.Context, oldLinks *models.MetadataLinks, datasetLinksBuilder *links.Builder) error {
+func RewriteMetadataLinks(ctx context.Context, oldLinks *models.MetadataLinks, datasetLinksBuilder, websiteLinksBuilder *links.Builder) error {
 	if oldLinks == nil {
 		return nil
 	}
@@ -474,6 +474,14 @@ func RewriteMetadataLinks(ctx context.Context, oldLinks *models.MetadataLinks, d
 		oldLinks.Version.HRef, err = datasetLinksBuilder.BuildLink(oldLinks.Version.HRef)
 		if err != nil {
 			log.Error(ctx, "failed to rewrite version link", err, log.Data{"link": oldLinks.Version.HRef})
+			return err
+		}
+	}
+
+	if oldLinks.WebsiteVersion != nil && oldLinks.WebsiteVersion.HRef != "" {
+		oldLinks.WebsiteVersion.HRef, err = websiteLinksBuilder.BuildLink(oldLinks.WebsiteVersion.HRef)
+		if err != nil {
+			log.Error(ctx, "failed to rewrite website version link", err, log.Data{"link": oldLinks.WebsiteVersion.HRef})
 			return err
 		}
 	}

--- a/utils/rewriting_test.go
+++ b/utils/rewriting_test.go
@@ -3782,6 +3782,7 @@ func TestRewriteMetadataLinks_Success(t *testing.T) {
 	ctx := context.Background()
 	Convey("Given a set of metadata links", t, func() {
 		datasetLinksBuilder := links.FromHeadersOrDefault(&http.Header{}, datasetAPIURL)
+		websiteLinksBuilder := links.FromHeadersOrDefault(&http.Header{}, publicWebsiteURL)
 		Convey("When the metadata links need rewriting", func() {
 			metadataLinks := &models.MetadataLinks{
 				AccessRights: &models.LinkObject{
@@ -3799,7 +3800,7 @@ func TestRewriteMetadataLinks_Success(t *testing.T) {
 				},
 			}
 
-			err := RewriteMetadataLinks(ctx, metadataLinks, datasetLinksBuilder)
+			err := RewriteMetadataLinks(ctx, metadataLinks, datasetLinksBuilder, websiteLinksBuilder)
 
 			Convey("Then the links should be rewritten correctly", func() {
 				So(err, ShouldBeNil)
@@ -3807,7 +3808,7 @@ func TestRewriteMetadataLinks_Success(t *testing.T) {
 				So(metadataLinks.Self.HRef, ShouldEqual, "http://localhost:22000/datasets/cpih01/editions/time-series/versions/1/metadata")
 				So(metadataLinks.Version.HRef, ShouldEqual, "http://localhost:22000/datasets/cpih01/editions/time-series/versions/1")
 				So(metadataLinks.Version.ID, ShouldEqual, "1")
-				So(metadataLinks.WebsiteVersion.HRef, ShouldEqual, "https://oldhost:1000/datasets/cpih01/editions/time-series/versions/1")
+				So(metadataLinks.WebsiteVersion.HRef, ShouldEqual, "http://localhost:20000/datasets/cpih01/editions/time-series/versions/1")
 			})
 		})
 
@@ -3828,7 +3829,7 @@ func TestRewriteMetadataLinks_Success(t *testing.T) {
 				},
 			}
 
-			err := RewriteMetadataLinks(ctx, metadataLinks, datasetLinksBuilder)
+			err := RewriteMetadataLinks(ctx, metadataLinks, datasetLinksBuilder, websiteLinksBuilder)
 
 			Convey("Then the links should remain the same", func() {
 				So(err, ShouldBeNil)
@@ -3843,7 +3844,7 @@ func TestRewriteMetadataLinks_Success(t *testing.T) {
 		Convey("When the metadata links are empty", func() {
 			metadataLinks := &models.MetadataLinks{}
 
-			err := RewriteMetadataLinks(ctx, metadataLinks, datasetLinksBuilder)
+			err := RewriteMetadataLinks(ctx, metadataLinks, datasetLinksBuilder, websiteLinksBuilder)
 
 			Convey("Then the links should remain empty", func() {
 				So(err, ShouldBeNil)
@@ -3852,7 +3853,7 @@ func TestRewriteMetadataLinks_Success(t *testing.T) {
 		})
 
 		Convey("When the metadata links are nil", func() {
-			err := RewriteMetadataLinks(ctx, nil, datasetLinksBuilder)
+			err := RewriteMetadataLinks(ctx, nil, datasetLinksBuilder, websiteLinksBuilder)
 
 			Convey("Then the links should remain nil", func() {
 				So(err, ShouldBeNil)
@@ -3860,7 +3861,7 @@ func TestRewriteMetadataLinks_Success(t *testing.T) {
 		})
 
 		Convey("When the metadata links are missing", func() {
-			err := RewriteMetadataLinks(ctx, &models.MetadataLinks{}, datasetLinksBuilder)
+			err := RewriteMetadataLinks(ctx, &models.MetadataLinks{}, datasetLinksBuilder, websiteLinksBuilder)
 
 			Convey("Then the links should remain empty", func() {
 				So(err, ShouldBeNil)
@@ -3873,6 +3874,7 @@ func TestRewriteMetadataLinks_Error(t *testing.T) {
 	ctx := context.Background()
 	Convey("Given a set of metadata links", t, func() {
 		datasetLinksBuilder := links.FromHeadersOrDefault(&http.Header{}, datasetAPIURL)
+		websiteLinksBuilder := links.FromHeadersOrDefault(&http.Header{}, publicWebsiteURL)
 		Convey("When the Self link is unable to be parsed", func() {
 			metadataLinks := &models.MetadataLinks{
 				Self: &models.LinkObject{
@@ -3887,7 +3889,7 @@ func TestRewriteMetadataLinks_Error(t *testing.T) {
 				},
 			}
 
-			err := RewriteMetadataLinks(ctx, metadataLinks, datasetLinksBuilder)
+			err := RewriteMetadataLinks(ctx, metadataLinks, datasetLinksBuilder, websiteLinksBuilder)
 
 			Convey("Then a parsing error should be returned", func() {
 				So(err, ShouldNotBeNil)
@@ -3909,7 +3911,29 @@ func TestRewriteMetadataLinks_Error(t *testing.T) {
 				},
 			}
 
-			err := RewriteMetadataLinks(ctx, metadataLinks, datasetLinksBuilder)
+			err := RewriteMetadataLinks(ctx, metadataLinks, datasetLinksBuilder, websiteLinksBuilder)
+
+			Convey("Then a parsing error should be returned", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "unable to parse link to URL")
+			})
+		})
+
+		Convey("When the WebsiteVersion link is unable to be parsed", func() {
+			metadataLinks := &models.MetadataLinks{
+				Self: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/cpih01/editions/time-series/versions/1/metadata",
+				},
+				Version: &models.LinkObject{
+					HRef: "http://localhost:22000/datasets/cpih01/editions/time-series/versions/1",
+					ID:   "1",
+				},
+				WebsiteVersion: &models.LinkObject{
+					HRef: "://oldhost:1000/datasets/cpih01/editions/time-series/versions/1",
+				},
+			}
+
+			err := RewriteMetadataLinks(ctx, metadataLinks, datasetLinksBuilder, websiteLinksBuilder)
 
 			Convey("Then a parsing error should be returned", func() {
 				So(err, ShouldNotBeNil)


### PR DESCRIPTION
### What

- Add `is_migration` field to `GET /metadata` endpoint ([ticket here](https://officefornationalstatistics.atlassian.net/browse/DIS-5229))
- Bugfix to return the correct `website_version` link for `GET /metadata` endpoint ([ticket here](https://officefornationalstatistics.atlassian.net/browse/DIS-5230))
- Bugfix to set the correct `URI` for the search content updated Kafka event ([ticket here](https://officefornationalstatistics.atlassian.net/browse/DIS-5083))

### How to review

For tickets 1 and 2:
- Create a publish a dataset version with `is_migration` set to `true` at both series and version level
- Call `GET /metadata` in publishing mode to see `is_migration` returned and call in web mode to see it not returned
- Check that the `website_version` link returned is correct (contains the topic slug). If the dataset is not static then it return it without the topic slug.

For ticket 3:
- Create and publish a dataset version
- After calling `PUT /state` to transition to published, check the dataset-api logs and within the `search_content_updated` logData you should see the `URI` set including the topic slug.

Note:
Technically legacy behaviour has been changed for `GET /metadata` within publishing mode as URL rewriting has been enabled for the `website_version` link. The change being that the host on the `website_version` link when called within publishing mode will be the publishing host (previously this would have been the public host). This is not expected to cause any issues and does affect web mode.

### Who can review

- Anyone
